### PR TITLE
fix(ci): sync jira-core dep version on release-please bumps

### DIFF
--- a/crates/jira/Cargo.toml
+++ b/crates/jira/Cargo.toml
@@ -15,7 +15,7 @@ name = "jira"
 path = "src/main.rs"
 
 [dependencies]
-jira-core = { path = "../jira-core", version = "0.4.1" }
+jira-core = { path = "../jira-core", version = "0.4.1" } # x-release-please-version
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.29"
 crossterm = "0.28"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,8 @@
           "path": "/plugin/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
         },
-        "/crates/jira-core/Cargo.toml"
+        "/crates/jira-core/Cargo.toml",
+        "/crates/jira/Cargo.toml"
       ]
     }
   }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? Link related issues with "Fixes #123" if applicable. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [ ] No new dependency added without justification in PR description
- [ ] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [ ] No secrets, tokens, or credentials added to source code
- [ ] No new `unsafe` blocks without explanation
- [ ] No outbound network calls added outside of `jira-core/src/client.rs`
- [ ] No changes to `.github/workflows/` without explaining why in this PR
- [ ] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Notes for reviewer

<!-- Anything the reviewer should pay special attention to? -->
