### PR TITLE
fix: use the official release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,7 +49,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      - uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5 # v4
         id: release
         with:
           # Use PAT so that the pushed tag triggers release.yml.


### PR DESCRIPTION
## Description

Fix the repository release automation so `release-please` can correctly manage the Rust workspace and use the current official GitHub Action.

This PR addresses two release pipeline issues:
- workspace changes in `crates/jira-mcp` could be missed because `release-please` was only tracking `crates/jira`
- the workflow was still using the deprecated `google-github-actions/release-please-action` instead of the official `googleapis/release-please-action`

Changes included:
- switch `release-please` to track the workspace root (`.`)
- enable the `cargo-workspace` plugin for Rust workspace version management
- move the release manifest to the root workspace entry
- keep plugin version updates synchronized
- update the workflow to use the official `googleapis/release-please-action`
- align workflow comments with the workspace-based release model

Why this matters:
- MCP-only changes can now trigger a release PR and version bump
- release tags can be created from a workspace-aware configuration
- the release workflow remains able to publish `jira-core`, `jira-mcp`, and `jira-commands` after a tagged release

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Notes for reviewer

Please review the `release-please` config and workflow changes together. The intended behavior is one shared workspace version across `jira-core`, `jira-mcp`, `jira-commands`, and the Claude plugin, while ensuring MCP-only changes are still releasable.
