### PR TITLE
fix(jira-mcp): shorten keyword to fit crates.io 20-char limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/jira-mcp/Cargo.toml
+++ b/crates/jira-mcp/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/mulhamna/jira-commands"
 homepage = "https://github.com/mulhamna/jira-commands"
-keywords = ["jira", "mcp", "model-context-protocol", "atlassian"]
+keywords = ["jira", "mcp", "mcp-server", "atlassian"]
 categories = ["command-line-utilities"]
 
 [[bin]]


### PR DESCRIPTION
## Summary

Release workflow for tag `v0.8.0` failed at the "Publish to crates.io" job:

```
error: failed to publish jira-mcp v0.8.0 to registry at https://crates.io
Caused by:
  the remote server responded with an error (status 400 Bad Request):
  "model-context-protocol" is an invalid keyword
  (keywords must have less than 20 characters)
```

crates.io enforces a **20-character maximum per keyword**. The offending
`"model-context-protocol"` is 22 chars. This PR replaces it with
`"mcp-server"` (10 chars) — still distinctive for discoverability
alongside the existing `"mcp"` keyword.

Also syncs `Cargo.lock` to the 0.8.0 workspace versions that release-please
bumped in `Cargo.toml` during the 0.8.0 Release PR but never committed
back into the lockfile.

Failed pipeline: https://github.com/mulhamna/jira-commands/actions/runs/24625333749

## Release impact

The 0.8.0 release shipped partially before failing:

| Crate           | v0.8.0 on crates.io? |
| --------------- | :------------------: |
| `jira-core`     | ✅ published          |
| `jira-mcp`      | ❌ failed (this PR)   |
| `jira-commands` | ❌ not attempted      |

Because `jira-core 0.8.0` is immutable on crates.io, we can't re-run
the same tag cleanly. Merging this PR as a `fix:` commit lets
release-please produce **0.8.1**, which republishes all three crates
in sync and unblocks Homebrew + GitHub Release jobs.

## Test plan

- [x] `cargo publish --dry-run -p jira-mcp` passes locally
- [x] `cargo check --workspace` passes locally on Rust 1.95.0
- [ ] CI green on this PR
- [ ] release-please opens a 0.8.1 Release PR after merge
- [ ] Release workflow publishes jira-core 0.8.1 → jira-mcp 0.8.1 → jira-commands 0.8.1