### PR TITLE
chore: add custom domain for docs pages

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+jirac.keton.id


### PR DESCRIPTION
## Summary\n- add \ for the docs site\n- set the GitHub Pages custom domain to \\n\n## Context\nThis project's docs are intended to live under the Keton subdomain \. This change only adds the repository-side CNAME declaration for GitHub Pages.\n\n## Notes\n- DNS and GitHub Pages settings are handled separately\n- no content or routing changes are included in this PR\n- this is intentionally a minimal change