### PR TITLE
docs: improve docs readability and add custom domain

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,8 +36,8 @@
             }
           },
           fontFamily: {
-            sans: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif'],
-            mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'monospace']
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif'],
+            mono: ['JetBrains Mono', 'SFMono-Regular', 'Menlo', 'Monaco', 'Cascadia Code', 'Consolas', 'Liberation Mono', 'monospace']
           },
           boxShadow: {
             soft: '0 8px 30px rgba(15, 23, 42, 0.08)'
@@ -57,18 +57,112 @@
         linear-gradient(to bottom, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
     }
     .command-row {
-      border: 1px solid rgba(148, 163, 184, 0.22);
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.98) 0%, rgba(2, 6, 23, 0.98) 100%);
       transition: border-color .2s ease, transform .2s ease, box-shadow .2s ease;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 8px 24px rgba(2, 6, 23, 0.18);
     }
     .command-row:hover {
-      border-color: rgba(59, 130, 246, 0.55);
+      border-color: rgba(96, 165, 250, 0.7);
       transform: translateY(-1px);
-      box-shadow: 0 10px 24px rgba(2, 6, 23, 0.25);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 14px 30px rgba(2, 6, 23, 0.28);
+    }
+    .command-row code,
+    pre code,
+    .command-code {
+      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
+      font-size: 0.95em;
+      line-height: 1.7;
+      font-weight: 500;
+      -webkit-font-smoothing: auto;
+      text-rendering: optimizeLegibility;
+    }
+    p code,
+    li code,
+    td code,
+    .inline-code {
+      display: inline-block;
+      padding: 0.14rem 0.42rem;
+      border-radius: 0.5rem;
+      border: 1px solid rgba(148, 163, 184, 0.32);
+      background: rgba(241, 245, 249, 0.95);
+      color: rgb(15, 23, 42);
+      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
+      font-size: 0.9em;
+      font-weight: 600;
+      line-height: 1.35;
+      vertical-align: baseline;
+      word-break: break-word;
+    }
+    .keycap {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2rem;
+      padding: 0.2rem 0.5rem;
+      border-radius: 0.6rem;
+      border: 1px solid rgba(148, 163, 184, 0.38);
+      background: linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(241,245,249,0.98) 100%);
+      box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.22), 0 1px 2px rgba(15, 23, 42, 0.08);
+      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
+      font-size: 0.85em;
+      font-weight: 700;
+      color: rgb(15, 23, 42);
+    }
+    .mini-command {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 0.8rem;
+      padding: 0.7rem 0.9rem;
+      border-radius: 0.75rem;
+      border: 1px solid rgba(51, 65, 85, 0.12);
+      background: rgba(15, 23, 42, 0.96);
+      color: rgb(248, 250, 252);
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+    }
+    .mini-command-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgb(147, 197, 253);
+    }
+    .command-cell code {
+      display: inline-block;
+      max-width: 100%;
+      padding: 0.28rem 0.56rem;
+      border-radius: 0.6rem;
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      background: rgba(248, 250, 252, 0.96);
+      color: rgb(15, 23, 42);
+      font-size: 0.88em;
+      font-weight: 600;
     }
     .dark .doc-card {
       background: linear-gradient(180deg, rgba(15, 23, 42, 0.9) 0%, rgba(2, 6, 23, 0.92) 100%);
       border-color: rgba(71, 85, 105, 0.65);
       box-shadow: 0 14px 40px rgba(2, 6, 23, 0.45);
+    }
+    .dark p code,
+    .dark li code,
+    .dark td code,
+    .dark .inline-code,
+    .dark .command-cell code {
+      border-color: rgba(71, 85, 105, 0.75);
+      background: rgba(15, 23, 42, 0.92);
+      color: rgb(241, 245, 249);
+    }
+    .dark .keycap {
+      border-color: rgba(100, 116, 139, 0.72);
+      background: linear-gradient(180deg, rgba(30,41,59,0.98) 0%, rgba(15,23,42,0.98) 100%);
+      box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.18), 0 1px 2px rgba(2, 6, 23, 0.35);
+      color: rgb(241, 245, 249);
+    }
+    .dark .mini-command {
+      border-color: rgba(71, 85, 105, 0.72);
+      background: linear-gradient(180deg, rgba(15,23,42,0.96) 0%, rgba(2,6,23,0.98) 100%);
+      box-shadow: 0 14px 28px rgba(2, 6, 23, 0.4);
     }
     .dark .copy-btn {
       border-color: rgba(100, 116, 139, 0.7);
@@ -168,10 +262,10 @@ $ jirac issue transition CORE-183 --to Done
       <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
         <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Quick Guide for Non-Tech Users</h2>
         <ol class="mt-6 grid gap-4 md:grid-cols-2">
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">1. Install</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Ask your IT/dev teammate to install <code>jirac</code> once.</p></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">2. Login</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Run <code>jirac auth login</code> and input your Jira URL, email, API token.</p></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">3. View your tasks</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Run <code>jirac issue list</code> to see issues assigned to you.</p></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">4. Move issue status</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Run <code>jirac issue transition PROJ-123</code> and choose new status.</p></li>
+          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">1. Install</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Ask your IT/dev teammate to install <code>jirac</code> once so it is ready on your machine.</p><div class="mini-command"><span class="mini-command-label">Tool</span><code>jirac</code></div></li>
+          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">2. Login</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use your Jira URL, email, and API token to connect your account the first time.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac auth login</code></div></li>
+          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">3. View your tasks</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">See issues assigned to you in a simple terminal list.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac issue list</code></div></li>
+          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">4. Move issue status</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Select an issue and move it to the next status when work changes.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac issue transition PROJ-123</code></div></li>
         </ol>
       </div>
     </section>
@@ -209,15 +303,15 @@ $ jirac issue transition CORE-183 --to Done
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-              <tr><td class="px-4 py-3">List assigned issues</td><td class="px-4 py-3"><code>jirac issue list</code></td></tr>
-              <tr><td class="px-4 py-3">List by project</td><td class="px-4 py-3"><code>jirac issue list --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">View issue detail</td><td class="px-4 py-3"><code>jirac issue view MYPROJ-123</code></td></tr>
-              <tr><td class="px-4 py-3">Create issue</td><td class="px-4 py-3"><code>jirac issue create --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">Transition issue</td><td class="px-4 py-3"><code>jirac issue transition MYPROJ-123 --to Done</code></td></tr>
-              <tr><td class="px-4 py-3">Add worklog</td><td class="px-4 py-3"><code>jirac issue worklog add MYPROJ-123 --time 2h --comment "Worked on API"</code></td></tr>
-              <tr><td class="px-4 py-3">Upload attachment</td><td class="px-4 py-3"><code>jirac issue attach MYPROJ-123 ./screenshot.png</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk transition</td><td class="px-4 py-3"><code>jirac issue bulk-transition -p MYPROJ -q 'status = "To Do"' -t "In Progress"</code></td></tr>
-              <tr><td class="px-4 py-3">Raw API call</td><td class="px-4 py-3"><code>jirac api get /rest/api/3/serverInfo</code></td></tr>
+              <tr><td class="px-4 py-3">List assigned issues</td><td class="px-4 py-3 command-cell"><code>jirac issue list</code></td></tr>
+              <tr><td class="px-4 py-3">List by project</td><td class="px-4 py-3 command-cell"><code>jirac issue list --project MYPROJ</code></td></tr>
+              <tr><td class="px-4 py-3">View issue detail</td><td class="px-4 py-3 command-cell"><code>jirac issue view MYPROJ-123</code></td></tr>
+              <tr><td class="px-4 py-3">Create issue</td><td class="px-4 py-3 command-cell"><code>jirac issue create --project MYPROJ</code></td></tr>
+              <tr><td class="px-4 py-3">Transition issue</td><td class="px-4 py-3 command-cell"><code>jirac issue transition MYPROJ-123 --to Done</code></td></tr>
+              <tr><td class="px-4 py-3">Add worklog</td><td class="px-4 py-3 command-cell"><code>jirac issue worklog add MYPROJ-123 --time 2h --comment "Worked on API"</code></td></tr>
+              <tr><td class="px-4 py-3">Upload attachment</td><td class="px-4 py-3 command-cell"><code>jirac issue attach MYPROJ-123 ./screenshot.png</code></td></tr>
+              <tr><td class="px-4 py-3">Bulk transition</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-transition -p MYPROJ -q 'status = "To Do"' -t "In Progress"</code></td></tr>
+              <tr><td class="px-4 py-3">Raw API call</td><td class="px-4 py-3 command-cell"><code>jirac api get /rest/api/3/serverInfo</code></td></tr>
             </tbody>
           </table>
         </div>
@@ -236,15 +330,15 @@ $ jirac issue transition CORE-183 --to Done
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-            <tr><td class="px-4 py-3"><code>↑ / k</code></td><td class="px-4 py-3">Move to the issue above.</td></tr>
-            <tr><td class="px-4 py-3"><code>↓ / j</code></td><td class="px-4 py-3">Move to the issue below.</td></tr>
-            <tr><td class="px-4 py-3"><code>Enter</code></td><td class="px-4 py-3">Open details for the selected issue.</td></tr>
-            <tr><td class="px-4 py-3"><code>c</code></td><td class="px-4 py-3">Create a new issue.</td></tr>
-            <tr><td class="px-4 py-3"><code>e</code></td><td class="px-4 py-3">Edit the selected issue.</td></tr>
-            <tr><td class="px-4 py-3"><code>t</code></td><td class="px-4 py-3">Change issue status (transition).</td></tr>
-            <tr><td class="px-4 py-3"><code>w</code></td><td class="px-4 py-3">Add worklog to the issue.</td></tr>
-            <tr><td class="px-4 py-3"><code>u</code></td><td class="px-4 py-3">Upload an attachment to the issue.</td></tr>
-            <tr><td class="px-4 py-3"><code>?</code></td><td class="px-4 py-3">Show shortcut help.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">↑ / k</span></td><td class="px-4 py-3">Move to the issue above.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">↓ / j</span></td><td class="px-4 py-3">Move to the issue below.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">Enter</span></td><td class="px-4 py-3">Open details for the selected issue.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">c</span></td><td class="px-4 py-3">Create a new issue.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">e</span></td><td class="px-4 py-3">Edit the selected issue.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">t</span></td><td class="px-4 py-3">Change issue status (transition).</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">w</span></td><td class="px-4 py-3">Add worklog to the issue.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">u</span></td><td class="px-4 py-3">Upload an attachment to the issue.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">?</span></td><td class="px-4 py-3">Show shortcut help.</td></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- What changed:
  - improve docs readability and command hierarchy in `/docs/index.html`
  - add `/docs/CNAME` with `jirac.keton.id` for GitHub Pages custom domain
- Why this change is needed:
  - command text and prose were too visually similar, especially for non-technical readers
  - command reference and quick-guide sections benefit from clearer visual hierarchy
  - the docs site is intended to live under the Keton subdomain `jirac.keton.id`

## Validation
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --all-targets --all-features -- -D warnings
- [ ] cargo test --all
- [ ] cargo build --all

## Scope & Risk
- [x] No breaking changes
- [ ] Breaking changes documented
- [x] Docs updated (if needed)
- [ ] Added/updated tests (if needed)

## Notes
- Jira issue / context:
  - docs readability polish + official docs custom domain setup
- Follow-up tasks (if any):
  - enable/update GitHub Pages settings for the repository
  - point DNS for `jirac.keton.id` to the correct GitHub Pages host
