### PR TITLE
feat: add plausible analytics snippet

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
+  <script defer data-domain="keton.id" src="https://plausible.keton.id/js/script.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Official web documentation for jirac (jira-commands): a Rust terminal tool for Jira, with MCP server and plugin support." />


### PR DESCRIPTION
## Summary
- add Plausible analytics script to the docs HTML head
- use the docs site domain `jirac.keton.id` as the Plausible data-domain
- keep the change limited to a single analytics snippet insertion

## Validation
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --all-targets --all-features -- -D warnings
- [ ] cargo test --all
- [ ] cargo build --all

## Scope & Risk
- [x] No breaking changes
- [x] Minimal docs-only change

## Notes
- analytics domain: `jirac.keton.id`
- script source: `https://plausible.keton.id/js/script.js`
