### PR TITLE
fix(release): clarify shipped binaries in release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Download from [GitHub Releases](https://github.com/mulhamna/jira-commands/releas
 
 For manual installs, prefer the packaged archives. They include the binary plus license files and README.
 
+Releases now publish the supported binaries `jirac` and `jirac-mcp`. The legacy `jira` binary is no longer shipped in release artifacts.
+
 | Platform              | Raw binary                 | Preferred archive            |
 | --------------------- | -------------------------- | ---------------------------- |
 | macOS (Apple Silicon) | `jirac-macos-aarch64`      | `jirac-macos-aarch64.tar.gz` |


### PR DESCRIPTION
## Summary
- clarify that release artifacts now ship only `jirac` and `jirac-mcp`
- document that the legacy `jira` binary is no longer included in release assets
- provide a releasable follow-up after the release workflow hotfix merged post-0.12.0
