### PR TITLE
Feat/worklog started

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ name = "jira-commands"
 version = "0.12.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "crossterm 0.28.1",
  "indicatif",

--- a/crates/jira/Cargo.toml
+++ b/crates/jira/Cargo.toml
@@ -28,3 +28,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 indicatif = "0.17"
 open = "5"
+chrono = { version = "0.4", default-features = true }

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::datetime::build_worklog_started;
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -587,6 +588,7 @@ pub enum WorklogCommand {
     /// Examples:
     ///   jirac issue worklog add PROJ-123 --time "2h 30m"
     ///   jirac issue worklog add PROJ-123 --time 1d --comment "Implemented login"
+    ///   jirac issue worklog add PROJ-123 --time 2h --date 2026-04-21 --start 09:30
     Add {
         /// Time spent in Jira duration format (e.g. "2h", "30m", "1d", "1h 30m")
         #[arg(short, long, value_name = "DURATION")]
@@ -594,6 +596,12 @@ pub enum WorklogCommand {
         /// Optional comment describing the work done
         #[arg(short, long, value_name = "TEXT")]
         comment: Option<String>,
+        /// Optional work date in local time (YYYY-MM-DD)
+        #[arg(long, value_name = "DATE")]
+        date: Option<String>,
+        /// Optional start time in local time (HH:MM or HH:MM:SS)
+        #[arg(long, value_name = "TIME")]
+        start: Option<String>,
     },
 
     /// Delete a worklog entry
@@ -1565,7 +1573,12 @@ async fn comment_add(
 async fn worklog(client: JiraClient, key: String, cmd: WorklogCommand) -> Result<()> {
     match cmd {
         WorklogCommand::List => worklog_list(client, key).await,
-        WorklogCommand::Add { time, comment } => worklog_add(client, key, time, comment).await,
+        WorklogCommand::Add {
+            time,
+            comment,
+            date,
+            start,
+        } => worklog_add(client, key, time, comment, date, start).await,
         WorklogCommand::Delete { id, force } => worklog_delete(client, key, id, force).await,
     }
 }
@@ -1605,10 +1618,14 @@ async fn worklog_add(
     key: String,
     time: String,
     comment: Option<String>,
+    date: Option<String>,
+    start: Option<String>,
 ) -> Result<()> {
+    let started = build_worklog_started(date.as_deref(), start.as_deref())?;
+
     let spinner = spinner_new(format!("Logging {time} on {key}..."));
     let log = client
-        .add_worklog(&key, &time, comment.as_deref(), None)
+        .add_worklog(&key, &time, comment.as_deref(), started.as_deref())
         .await
         .context("Failed to add worklog")?;
     spinner.finish_and_clear();

--- a/crates/jira/src/datetime.rs
+++ b/crates/jira/src/datetime.rs
@@ -1,0 +1,98 @@
+use anyhow::{anyhow, Result};
+use chrono::{Local, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
+
+/// Build a Jira worklog `started` timestamp.
+///
+/// Input forms:
+/// - no date + no start => None (let Jira default to now)
+/// - date only => use that date with the current local time
+/// - start only => use today's local date with that time
+/// - date + start => combine both
+///
+/// Output format: `YYYY-MM-DDTHH:MM:SS.000+ZZZZ`
+pub fn build_worklog_started(date: Option<&str>, start: Option<&str>) -> Result<Option<String>> {
+    if date.is_none() && start.is_none() {
+        return Ok(None);
+    }
+
+    let now = Local::now();
+
+    let date = match date {
+        Some(value) => Some(parse_date(value)?),
+        None => Some(now.date_naive()),
+    };
+
+    let time = match start {
+        Some(value) => Some(parse_time(value)?),
+        None => Some(now.time()),
+    };
+
+    let naive = NaiveDateTime::new(date.expect("date set"), time.expect("time set"));
+    let local = match Local.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(first, _) => first,
+        LocalResult::None => {
+            return Err(anyhow!(
+                "Could not resolve local time for started timestamp: {} {}",
+                naive.date(),
+                naive.time().format("%H:%M:%S")
+            ))
+        }
+    };
+
+    Ok(Some(local.format("%Y-%m-%dT%H:%M:%S.000%z").to_string()))
+}
+
+fn parse_date(value: &str) -> Result<NaiveDate> {
+    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").map_err(|_| {
+        anyhow!(
+            "Invalid date '{}'. Expected format: YYYY-MM-DD",
+            value.trim()
+        )
+    })
+}
+
+fn parse_time(value: &str) -> Result<NaiveTime> {
+    let value = value.trim();
+
+    NaiveTime::parse_from_str(value, "%H:%M")
+        .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S"))
+        .map_err(|_| {
+            anyhow!(
+                "Invalid start time '{}'. Expected format: HH:MM or HH:MM:SS",
+                value
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_none_when_no_inputs_are_provided() {
+        assert!(build_worklog_started(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn builds_timestamp_when_date_and_time_are_provided() {
+        let started = build_worklog_started(Some("2026-04-21"), Some("09:30"))
+            .unwrap()
+            .unwrap();
+
+        assert!(started.starts_with("2026-04-21T09:30:00.000"));
+        assert!(started.ends_with("+0000") || started.ends_with("-0000") || started.len() == 28);
+    }
+
+    #[test]
+    fn rejects_invalid_date() {
+        let err = build_worklog_started(Some("21-04-2026"), Some("09:30")).unwrap_err();
+        assert!(err.to_string().contains("Invalid date"));
+    }
+
+    #[test]
+    fn rejects_invalid_time() {
+        let err = build_worklog_started(Some("2026-04-21"), Some("9.30")).unwrap_err();
+        assert!(err.to_string().contains("Invalid start time"));
+    }
+}

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -4,6 +4,7 @@ use jira_core::{config::JiraConfig, JiraClient};
 use tracing_subscriber::{fmt, EnvFilter};
 
 mod cli;
+mod datetime;
 mod tui;
 
 #[derive(Debug, Parser)]

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, time::Duration};
 
+use crate::datetime::build_worklog_started;
 use anyhow::{Context, Result};
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
@@ -1182,15 +1183,44 @@ async fn tui_add_comment(client: &JiraClient, key: &str) -> Result<bool> {
 
 /// Add a worklog entry to an issue.
 async fn tui_add_worklog(client: &JiraClient, key: &str) -> Result<bool> {
+    use chrono::Local;
     use inquire::Text;
 
     println!("\n── Add Worklog to {key} ──────────────────────────────");
-    println!("  Time format examples: 2h, 30m, 1d, 1h 30m\n");
+    println!("  Time format examples: 2h, 30m, 1d, 1h 30m");
+    println!(
+        "  Date format: YYYY-MM-DD (blank = today {})",
+        Local::now().format("%Y-%m-%d")
+    );
+    println!(
+        "  Start time format: HH:MM or HH:MM:SS (blank = now {})\n",
+        Local::now().format("%H:%M")
+    );
 
     let time = match Text::new("Time spent (blank to cancel):").prompt_skippable()? {
         Some(s) if !s.trim().is_empty() => s.trim().to_string(),
         _ => return Ok(false),
     };
+
+    let date = Text::new("Date (blank = today):")
+        .prompt_skippable()?
+        .and_then(|s| {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s.trim().to_string())
+            }
+        });
+
+    let start = Text::new("Start time (blank = now):")
+        .prompt_skippable()?
+        .and_then(|s| {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s.trim().to_string())
+            }
+        });
 
     let comment = Text::new("Comment (blank to skip):")
         .prompt_skippable()?
@@ -1202,8 +1232,10 @@ async fn tui_add_worklog(client: &JiraClient, key: &str) -> Result<bool> {
             }
         });
 
+    let started = build_worklog_started(date.as_deref(), start.as_deref())?;
+
     client
-        .add_worklog(key, &time, comment.as_deref(), None)
+        .add_worklog(key, &time, comment.as_deref(), started.as_deref())
         .await?;
     println!("✓ Worklog added to {key}");
     Ok(true)


### PR DESCRIPTION
## Description

Add support for custom worklog started timestamps in both CLI and TUI.

Previously, worklog creation always relied on Jira's default "now" timestamp because the `started` field was not exposed through the CLI/TUI flow. This PR adds a shared helper to build Jira-compatible `started` timestamps from local date/time input and wires it into both interfaces.

### What changed
- add `--date` and `--start` flags to `jirac issue worklog add`
- add a shared `build_worklog_started` helper in `crates/jira/src/datetime.rs`
- support date and start time prompts in the TUI worklog flow
- preserve existing fallback behavior when date/time is omitted

### Why
This makes it possible to log work against the intended historical date/time instead of always using the current timestamp, while keeping CLI and TUI behavior consistent.

### Dependency note
This PR adds `chrono` in `crates/jira` to safely parse local date/time input and format Jira-compatible worklog timestamps. `chrono` uses permissive licensing (MIT / Apache-2.0).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] cargo fmt --all passes locally
- [x] cargo clippy --all-targets --all-features -- -D warnings passes
- [x] cargo test --all passes
- [ ] cargo audit passes (repository currently has existing allowed advisory warnings unrelated to this PR)
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new unsafe blocks without explanation
- [x] No outbound network calls added outside of jira-core/src/client.rs
- [x] No changes to .github/workflows/ without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no git = "..." deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add automerge label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- CLI and TUI now share the same started-timestamp construction logic.
- When no date/time is provided, behavior remains compatible with the existing default flow.