### PR TITLE
fix(actions): restore workflow triggers

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -1,6 +1,6 @@
 name: Release Recover
 
-on:
+"on":
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -6,7 +6,7 @@ name: Release
 #   npx pin-github-action@latest .github/workflows/release.yml
 # ─────────────────────────────────────────────────────────────────────────────
 
-on:
+"on":
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary

- restore GitHub Actions trigger recognition for the release workflows
- prevent YAML parser ambiguity around the top-level `on` key

## Why

Both release workflows were being registered by GitHub but failing instantly with 0 jobs, and manual dispatch returned `Workflow does not have 'workflow_dispatch' trigger` even though the YAML appeared to define it. This strongly indicates the top-level `on` key was being parsed incorrectly before GitHub consumed the workflow.

## What changed

- quote the top-level `on` key in:
  - `.github/workflows/release-tag.yml`
  - `.github/workflows/release-recover.yml`

## Expected outcome

- tag-triggered release workflow should stop failing at 0 jobs
- manual dispatch for release recovery should become available again
- downstream Homebrew and manifest refresh can be validated properly after this lands
