### PR TITLE
fix(actions): simplify release dispatch triggers

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -2,11 +2,6 @@ name: Release Recover
 
 on:
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Tag to release (for manual recovery runs, e.g. v0.15.0)'
-        required: true
-        type: string
 
 permissions: {}
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,11 +11,6 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Tag to release (for manual recovery runs, e.g. v0.15.0)'
-        required: false
-        type: string
 
 # No global permissions — each job declares only what it needs.
 permissions: {}


### PR DESCRIPTION
## Summary

- simplify release workflow trigger declarations to the minimum supported shape
- remove workflow_dispatch input declarations temporarily to isolate the 0-job trigger failure

## Why

The release workflows are still failing instantly with 0 jobs, and GitHub still reports that `workflow_dispatch` is unavailable. This PR strips the trigger blocks back to the simplest form so we can verify that Actions recognizes and runs the workflows again before adding richer dispatch inputs back.

## What changed

- keep tag push trigger on `release-tag.yml`
- keep bare `workflow_dispatch` on both workflows
- temporarily remove `workflow_dispatch.inputs` blocks from both release workflows

## Follow-up

Once the workflows are runnable again, the dispatch inputs can be reintroduced carefully in a smaller follow-up patch.
