### PR TITLE
fix(actions): restore release workflow dispatch inputs

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -2,6 +2,11 @@ name: Release Recover
 
 "on":
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to recover manually, for example v0.15.3.'
+        required: true
+        type: string
 
 permissions: {}
 

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -346,10 +346,10 @@ jobs:
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}
+          commit-message: "chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}"
           branch: chore/winget-manifests-v${{ steps.vars.outputs.version }}
           delete-branch: true
-          title: chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}
+          title: "chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}"
           body: |
             ## Summary
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -445,10 +445,10 @@ jobs:
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}
+          commit-message: "chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}"
           branch: chore/winget-manifests-v${{ steps.vars.outputs.version }}
           delete-branch: true
-          title: chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}
+          title: "chore(winget): refresh manifests for v${{ steps.vars.outputs.version }}"
           body: |
             ## Summary
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,11 @@ name: Release
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to release manually, for example v0.15.3. Leave empty on tag-push runs.'
+        required: false
+        type: string
 
 # No global permissions — each job declares only what it needs.
 permissions: {}


### PR DESCRIPTION
## Summary
- restore \ on release-tag workflow
- restore required \ on release-recover workflow
- align trigger declarations with the workflow body, which still references \

## Why
PR #69 simplified the workflow dispatch triggers, but both workflows still relied on \ in their job logic. That left the workflows registered yet still invalid or fragile for manual dispatch and recovery runs.

## Result
- release-tag can be triggered manually with an optional tag again
- release-recover can be triggered manually with the required recovery tag again
- workflow declarations now match the existing job logic
