### PR TITLE
fix(clawhub): add install metadata for jirac skill

### DIFF
--- a/clawhub/jirac/SKILL.md
+++ b/clawhub/jirac/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: jirac
 description: Jira issue management skill for OpenClaw using the jirac CLI. Requires the `jirac` binary to be installed and authenticated before use. Use when listing, viewing, creating, updating, transitioning, commenting on, attaching files to, or logging work against Jira issues from agent workflows.
+metadata: {"openclaw":{"emoji":"🎫","requires":{"bins":["jirac"]},"install":[{"id":"github-releases","kind":"download","label":"Install jirac from GitHub Releases","url":"https://github.com/mulhamna/jira-commands/releases","extract":false}],"homepage":"https://github.com/mulhamna/jira-commands"}}
 ---
 
 Use `jirac` as the Jira execution surface.
 
 ## Requirements
 
-- Require the `jirac` binary from a trusted installation source.
+- Require the `jirac` binary from the official `jira-commands` release source.
 - Require Jira authentication to be configured before use, typically via `jirac auth login` in the target environment.
 - Treat Jira credentials, local config, and attachment paths as sensitive.
 

--- a/clawhub/jirac/SKILL.md
+++ b/clawhub/jirac/SKILL.md
@@ -42,3 +42,7 @@ jirac issue attach PROJ-123 ./screenshot.png
 - Confirm intent before operations that may change workflow state, bulk-edit, delete, or overwrite issue content.
 - Confirm that local files selected for attachment are intended and safe to upload.
 - Keep Jira project keys, issue keys, and status names exact.
+
+## References
+
+- Install guide: `references/install.md`

--- a/clawhub/jirac/references/install.md
+++ b/clawhub/jirac/references/install.md
@@ -1,0 +1,54 @@
+# Install jirac
+
+Choose the installer that fits your environment.
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew tap mulhamna/tap
+brew install jira-commands
+```
+
+## Cargo
+
+```bash
+cargo install jira-commands
+```
+
+## GitHub Releases
+
+Download a prebuilt archive or binary from:
+
+- https://github.com/mulhamna/jira-commands/releases
+
+Prefer the packaged archives when available.
+
+Common release artifacts include:
+
+- `jirac-macos-aarch64.tar.gz`
+- `jirac-macos-x86_64.tar.gz`
+- `jirac-linux-aarch64.tar.gz`
+- `jirac-linux-x86_64.tar.gz`
+- `jirac-windows-x86_64.zip`
+
+After extracting, place `jirac` on your `PATH`.
+
+## Windows install script
+
+```powershell
+powershell -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))"
+```
+
+## macOS / Linux install script
+
+```bash
+curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | bash
+```
+
+## Verify install
+
+```bash
+jirac --version
+jirac auth login
+jirac auth status
+```


### PR DESCRIPTION
## Summary\n- add OpenClaw metadata for the ClawHub jirac skill\n- declare required binary, homepage, and official install source\n- make the install-source wording explicit in the skill requirements\n\n## Why\nClawHub still flags the skill as suspicious because the live skill instructions require the  binary, but the skill front matter did not declare the binary/install/homepage metadata the scanner expects. This aligns the published skill metadata with the documented behavior.\n\n## Testing\n- reviewed generated ClawHub page state and scanner complaint\n- verified the skill file now includes metadata.openclaw with bins/install/homepage\n