### PR TITLE
docs(clawhub): prioritize safer install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A fast, feature-rich Jira CLI built in Rust.
 
 It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes an interactive TUI, an [MCP server](#mcp-server) for editor/agent integrations, a [Claude Code plugin](#claude-code-plugin), and a separate ClawHub skill lane under `clawhub/jirac/`.
 
+The OpenClaw skill is also published on ClawHub: <https://clawhub.ai/mulhamna/jirac>
+
 ## Preview
 
 ![jirac TUI preview](assets/readme/sample_tui.jpeg)
@@ -281,6 +283,14 @@ jirac-mcp serve --transport streamable-http --host 127.0.0.1 --port 8787 --path 
 | Advanced | `jira_plan_list`, `jira_api_request` |
 
 Destructive tools (delete, archive, bulk operations) require `confirm: true`. The `jira_api_request` tool provides raw access to any Jira REST endpoint.
+
+## ClawHub skill
+
+`jirac` is also available as an OpenClaw skill on ClawHub:
+
+- <https://clawhub.ai/mulhamna/jirac>
+
+The ClawHub lane is intentionally separate from the Claude Code plugin lane. It documents the OpenClaw-facing skill surface and points users to supported `jirac` installation options before use.
 
 ## Claude Code plugin
 

--- a/clawhub/jirac/references/install.md
+++ b/clawhub/jirac/references/install.md
@@ -35,25 +35,9 @@ Common release artifacts include:
 
 After extracting, place `jirac` on your `PATH`.
 
-## Installer scripts (optional)
+## Additional note
 
-Use these only if you prefer the project-provided installer flow. Review the script before running it.
-
-### Windows PowerShell installer
-
-```powershell
-Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1' -OutFile install.ps1
-Get-Content ./install.ps1
-powershell -ExecutionPolicy Bypass -File ./install.ps1
-```
-
-### macOS / Linux installer
-
-```bash
-curl -fsSLo install.sh https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh
-cat ./install.sh
-bash ./install.sh
-```
+Project-provided installer scripts also exist in the repository for users who prefer to inspect them manually, but the recommended ClawHub install paths are Homebrew, Cargo, or a verified GitHub Releases download.
 
 ## Verify install
 

--- a/clawhub/jirac/references/install.md
+++ b/clawhub/jirac/references/install.md
@@ -1,21 +1,23 @@
 # Install jirac
 
-Choose the installer that fits your environment.
+Choose the installer that fits your environment. Prefer package managers or verified release archives before using installer scripts.
 
-## Homebrew (macOS / Linux)
+## Recommended options
+
+### Homebrew (macOS / Linux)
 
 ```bash
 brew tap mulhamna/tap
 brew install jira-commands
 ```
 
-## Cargo
+### Cargo
 
 ```bash
 cargo install jira-commands
 ```
 
-## GitHub Releases
+### GitHub Releases
 
 Download a prebuilt archive or binary from:
 
@@ -33,16 +35,24 @@ Common release artifacts include:
 
 After extracting, place `jirac` on your `PATH`.
 
-## Windows install script
+## Installer scripts (optional)
+
+Use these only if you prefer the project-provided installer flow. Review the script before running it.
+
+### Windows PowerShell installer
 
 ```powershell
-powershell -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))"
+Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1' -OutFile install.ps1
+Get-Content ./install.ps1
+powershell -ExecutionPolicy Bypass -File ./install.ps1
 ```
 
-## macOS / Linux install script
+### macOS / Linux installer
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | bash
+curl -fsSLo install.sh https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh
+cat ./install.sh
+bash ./install.sh
 ```
 
 ## Verify install


### PR DESCRIPTION
## Summary
- update the ClawHub install reference to prioritize safer install paths
- move installer scripts behind package manager and GitHub Releases guidance
- add ClawHub availability notes to the root README

## Why
PR #77 merged the metadata and reference-file groundwork, but the live ClawHub scanner still calls out install guidance because the reference content includes higher-risk remote script patterns. This follow-up makes safer install options the default and documents the published ClawHub listing in the main README.

## Testing
- reviewed the live ClawHub scanner feedback categories
- verified references/install.md now prefers Homebrew, Cargo, and GitHub Releases
- verified README.md mentions the ClawHub listing
