### PR TITLE
fix(clawhub): correct github output delimiter

### DIFF
--- a/.github/workflows/clawhub-publish-jirac.yml
+++ b/.github/workflows/clawhub-publish-jirac.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
           {
-            echo "changelog<<'EOF'"
+            echo "changelog<<EOF"
             echo "$CHANGELOG"
             echo "EOF"
             echo "version=$VERSION"


### PR DESCRIPTION
## Summary
- fix the GitHub Actions output delimiter used for the ClawHub publish changelog output
- keep the existing auto-publish flow unchanged

## Why
- the merged workflow failed on main because the output delimiter was written as 
- GitHub Actions expects  when writing multi-line values to 