### PR TITLE
fix(actions): hash the Windows zip for winget

### DIFF
--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -56,14 +56,15 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download checksums from release
+      - name: Download Windows ZIP and compute Winget SHA
         id: checksums
         run: |
           set -euo pipefail
           RELEASE_TAG="${{ steps.vars.outputs.release_tag }}"
           RELEASE_DATE=$(date -u +%F)
-          curl -fsSL "https://github.com/mulhamna/jira-commands/releases/download/${RELEASE_TAG}/checksums.txt" -o checksums.txt
-          SHA_WINDOWS_X86=$(grep "jirac-windows-x86_64" checksums.txt | awk '{print $1}')
+          ASSET_URL="https://github.com/mulhamna/jira-commands/releases/download/${RELEASE_TAG}/jirac-windows-x86_64.zip"
+          curl -fsSL "$ASSET_URL" -o jirac-windows-x86_64.zip
+          SHA_WINDOWS_X86=$(sha256sum jirac-windows-x86_64.zip | awk '{print $1}')
           test -n "$SHA_WINDOWS_X86"
           echo "sha_windows_x86=$SHA_WINDOWS_X86" >> "$GITHUB_OUTPUT"
           echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -11,7 +11,7 @@ This directory stores the source manifests for publishing `jirac` to the Windows
 ## Update flow
 
 1. Publish a GitHub release with the Windows archive asset.
-2. Release CI refreshes the in-repo manifests under `packaging/winget/` using the published release version, URL, SHA256, and release date.
+2. Release CI refreshes the in-repo manifests under `packaging/winget/` using the published release version, URL, ZIP asset SHA256, and release date.
 3. Validate the manifest set with `winget validate` or the Windows Package Manager validation tooling.
 4. Submit the updated manifests to the Windows Package Manager community repository.
 


### PR DESCRIPTION
## Summary
- compute the Winget installer SHA from the released Windows ZIP asset
- stop reusing the executable checksum from checksums.txt for the Winget manifest
- clarify the packaging note in the Winget README

## Why
Microsoft winget validation reported a hash mismatch because the workflow was using the checksum of the extracted executable, while Winget validates the downloaded ZIP installer asset.