### PR TITLE
fix(winget): use actual Windows archive executable path

### DIFF
--- a/.github/scripts/submit-winget-pr.py
+++ b/.github/scripts/submit-winget-pr.py
@@ -45,7 +45,7 @@ PackageVersion: {VERSION}
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: jirac.exe
+  - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
 ReleaseDate: {RELEASE_DATE}
 Installers:

--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -4,7 +4,7 @@ PackageVersion: 0.16.3
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: jirac.exe
+  - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
 ReleaseDate: 2026-04-24
 Installers:


### PR DESCRIPTION
## Summary
- update the Winget nested installer path to match the real Windows ZIP contents
- use  instead of 
- keep the portable command alias as 

## Why
The latest microsoft/winget-pkgs validation failed with  because the archive does not contain ; it contains .