### PR TITLE
Improve TUI pickers, repo docs, and security checks

### DIFF
--- a/.github/workflows/clawhub-publish-jirac.yml
+++ b/.github/workflows/clawhub-publish-jirac.yml
@@ -31,12 +31,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@8c91899e31d0e68ef6c1c3b39a0e27f2f111052f # v4.0.4
         with:
           node-version: 22
 
       - name: Install ClawHub CLI
-        run: npm install -g clawhub
+        run: npm install -g clawhub@latest
 
       - name: Validate auth
         run: |

--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -4,9 +4,7 @@ on:
   pull_request_target:
     types: [labeled, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: pr-automerge-${{ github.event.pull_request.number }}
@@ -18,6 +16,9 @@ jobs:
       github.event.pull_request.draft == false &&
       contains(github.event.pull_request.labels.*.name, 'automerge')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge (squash) for labeled PRs only
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,9 +32,7 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write       # push version-bump commits + tags
-  pull-requests: write  # create/update the Release PR
+permissions: {}
 
 concurrency:
   group: release-please
@@ -45,6 +43,9 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write       # push version-bump commits + tags
+      pull-requests: write  # create/update the Release PR
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,10 +36,7 @@ jobs:
         uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: autobuild
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+          build-mode: none
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,34 @@ permissions:
   contents: read
 
 jobs:
+  # ── 0. CodeQL / static analysis ───────────────────────────────────────────
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["rust"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: autobuild
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+
   # ── 1. CVE scan (rustsec advisory database) ───────────────────────────────
   # Uses plain shell commands instead of rustsec/audit-check action to avoid
   # GitHub Issues creation (which requires elevated token scopes and fails on

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Require Winget token
         run: test -n "${GH_TOKEN}"
 
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Resolve release tag
         id: vars
         run: |

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -36,11 +36,6 @@ jobs:
       - name: Require Winget token
         run: test -n "${GH_TOKEN}"
 
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
       - name: Resolve release tag
         id: vars
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to jirac
+
+Thanks for contributing to `jirac`.
+
+This repository contains multiple delivery lanes that move together but are not identical:
+- Rust workspace crates under `crates/`
+- GitHub release automation under `.github/workflows/`
+- packaging metadata under `packaging/winget/`
+- Claude plugin assets under `plugin/` and `.claude-plugin/`
+- ClawHub skill assets under `clawhub/jirac/`
+
+## Local development
+
+Prerequisites:
+- Rust stable toolchain
+- `cargo` and standard Rust development tooling
+- a Jira Cloud account plus API token for real integration testing
+
+Useful commands:
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo check --workspace --all-targets
+cargo test -p jira-core
+cargo test -p jira-commands
+cargo test -p jira-mcp
+cargo audit
+```
+
+Run the CLI locally:
+
+```bash
+cargo run -p jira-commands -- issue list
+cargo run -p jira-commands -- tui -p PROJ
+```
+
+## Repo layout
+
+- `crates/jira-core/`: shared Jira client and models
+- `crates/jira/`: main `jirac` CLI and TUI
+- `crates/jira-mcp/`: MCP server binary
+- `.github/workflows/`: CI, security, release, and packaging automation
+- `packaging/winget/`: in-repo Winget manifests
+- `plugin/` and `.claude-plugin/`: Claude plugin assets and marketplace metadata
+- `clawhub/jirac/`: ClawHub skill lane
+
+## Change impact guide
+
+When you change one area, check the related lanes too.
+
+### Rust workspace changes
+
+If you change code in `crates/`:
+- run `fmt`, `clippy`, `check`, and relevant tests
+- review README examples if user-facing behavior changed
+- confirm release artifacts and install docs still match binary names
+
+### Version or release changes
+
+If you change versioning or release files:
+- check `VERSION`
+- check root `CHANGELOG.md`
+- check `Cargo.toml` plus crate versions in `crates/*/Cargo.toml`
+- check `release-please-config.json`
+- check `.release-please-manifest.json`
+- review `.github/workflows/release-please.yml`, `release-tag.yml`, and `release-recover.yml`
+
+### Workflow changes
+
+If you edit `.github/workflows/*.yml`:
+- keep permissions least-privilege
+- prefer pinned actions where practical
+- verify whether the change affects PR checks, `main` pushes, tags, or manual recovery flows
+- do not assume green PR CI proves tag or release paths are safe
+
+### Winget packaging changes
+
+If you update Windows packaging or release artifact naming:
+- check `packaging/winget/jirac.yaml`
+- check `packaging/winget/jirac.locale.en-US.yaml`
+- check `packaging/winget/jirac.installer.yaml`
+- check `.github/workflows/winget-submit.yml`
+- confirm published asset names and checksums still match expectations
+
+### Claude plugin changes
+
+If you touch `plugin/` or `.claude-plugin/`:
+- keep `plugin/VERSION` aligned with `plugin/.claude-plugin/plugin.json`
+- keep `.claude-plugin/marketplace.json` version metadata in sync
+- update `plugin/CHANGELOG.md` when versioned behavior changes
+
+### ClawHub skill changes
+
+If you update `clawhub/jirac/`:
+- keep `clawhub/jirac/SKILL.md` metadata valid
+- keep `clawhub/jirac/VERSION` current
+- review `clawhub-publish-jirac.yml`
+- update references/docs under the same skill lane if behavior changed
+
+## Pull request guidance
+
+Please prefer focused PRs with a clear theme:
+- feature work
+- workflow hardening
+- release fixes
+- docs-only improvements
+
+If a PR touches release automation, call that out explicitly in the description and mention what downstream paths were considered.
+
+## Release safety notes
+
+Release-related workflows are intentionally conservative.
+When changing them:
+- preserve the current release semantics unless there is a clear reason to change behavior
+- prefer the smallest fix that removes risk or noise
+- verify the exact path you changed: PR, push to `main`, tag release, or manual recovery
+
+## Documentation
+
+If user-facing behavior changes, update the relevant docs in the same branch:
+- `README.md`
+- `plugin/README.md`
+- `packaging/winget/README.md`
+- `clawhub/jirac/references/`
+
+That keeps release assets, docs, and automation from drifting apart.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # jirac
 
-A fast, feature-rich Jira CLI built in Rust.
+A fast, polished Jira CLI and TUI built in Rust.
 
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-`jirac` is an opinionated Jira terminal client that fills the gaps left by existing CLIs: **full custom field support** via runtime introspection, **native attachment uploads**, **cursor-based pagination**, and full compatibility with **Jira REST API v3**.
+`jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports **custom fields discovered at runtime**, **native attachment uploads**, **cursor-based pagination**, and broad **Jira REST API v3** coverage.
 
-It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes an interactive TUI, an [MCP server](#mcp-server) for editor/agent integrations, a [Claude Code plugin](#claude-code-plugin), and a separate ClawHub skill lane under `clawhub/jirac/`.
+It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes:
+- an interactive terminal UI for browsing and updating issues,
+- an [MCP server](#mcp-server) for editor and agent integrations,
+- a [Claude Code plugin](#claude-code-plugin), and
+- a separate ClawHub skill lane under `clawhub/jirac/`.
 
 The OpenClaw skill is also published on ClawHub: <https://clawhub.ai/mulhamna/jirac>
 
@@ -74,6 +78,14 @@ Once published there, installation will be:
 ```powershell
 winget install mulhamna.jirac
 ```
+
+## Why jirac
+
+- Fast CLI and interactive TUI in one tool
+- Better support for custom Jira fields than most lightweight CLIs
+- Built for practical issue management, not only read-only queries
+- Cross-platform release artifacts for macOS, Linux, and Windows
+- Extra integration lanes for MCP, Claude Code, and ClawHub
 
 ## Quick start
 
@@ -184,11 +196,11 @@ Common shortcuts:
 | `C`         | Open column settings popup |
 | `c`         | Create issue |
 | `e`         | Edit issue |
-| `a`         | Search and assign issue |
+| `a`         | Search and assign issue with a picker |
 | `t`         | Transition issue |
 | `w`         | Add worklog |
 | `l`         | Manage labels |
-| `m`         | Search and set project-scoped components |
+| `m`         | Search and set project-scoped components with a multi-select picker |
 | `u`         | Upload attachment |
 | `o`         | Open in browser |
 | `r`         | Refresh issue list |

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1001,6 +1001,10 @@ impl std::fmt::Display for PickerOption {
     }
 }
 
+fn normalize_picker_query(input: &str) -> String {
+    input.trim().to_lowercase()
+}
+
 fn prompt_search_term(prompt: &str) -> Result<Option<String>> {
     use inquire::Text;
 
@@ -1015,19 +1019,137 @@ fn prompt_search_term(prompt: &str) -> Result<Option<String>> {
     }))
 }
 
-async fn prompt_assignee_selection(client: &JiraClient, prompt: &str) -> Result<Option<String>> {
-    use inquire::Select;
+fn picker_option_matches(option: &PickerOption, query: &str) -> bool {
+    let query = normalize_picker_query(query);
+    if query.is_empty() {
+        return true;
+    }
 
+    let haystack = normalize_picker_query(&format!("{} {}", option.label, option.value));
+    haystack.contains(&query)
+}
+
+fn pick_single_option(prompt: &str, options: Vec<PickerOption>) -> Result<Option<PickerOption>> {
+    use inquire::{Select, Text};
+
+    let mut filtered = options.clone();
+    if filtered.is_empty() {
+        return Ok(None);
+    }
+
+    loop {
+        let selected = Select::new(prompt, filtered.clone())
+            .with_help_message("Enter to choose, Esc to cancel, or pick 'Search again' to refine")
+            .prompt_skippable()?;
+
+        let Some(selected) = selected else {
+            return Ok(None);
+        };
+
+        if selected.value != "__search_again__" {
+            return Ok(Some(selected));
+        }
+
+        let Some(query) = Text::new("Refine search:").prompt_skippable()? else {
+            return Ok(None);
+        };
+        let query = normalize_picker_query(&query);
+        if query.is_empty() {
+            continue;
+        }
+
+        filtered = options
+            .iter()
+            .filter(|option| {
+                option.value == "__search_again__"
+                    || option.value == "me"
+                    || picker_option_matches(option, &query)
+            })
+            .cloned()
+            .collect();
+
+        if filtered
+            .iter()
+            .all(|option| option.value == "__search_again__")
+        {
+            println!("  No matches for '{query}'. Try another search.");
+            filtered = options.clone();
+        }
+    }
+}
+
+fn pick_multi_options(
+    prompt: &str,
+    options: Vec<PickerOption>,
+) -> Result<Option<Vec<PickerOption>>> {
+    use inquire::{MultiSelect, Text};
+
+    let mut filtered = options.clone();
+    if filtered.is_empty() {
+        return Ok(None);
+    }
+
+    loop {
+        let selected = MultiSelect::new(prompt, filtered.clone())
+            .with_help_message(
+                "Space toggles, Enter confirms, Esc cancels. Choose 'Search again' to refine.",
+            )
+            .prompt_skippable()?;
+
+        let Some(selected) = selected else {
+            return Ok(None);
+        };
+
+        if !selected
+            .iter()
+            .any(|option| option.value == "__search_again__")
+        {
+            return Ok(Some(selected));
+        }
+
+        let Some(query) = Text::new("Refine component search:").prompt_skippable()? else {
+            return Ok(None);
+        };
+        let query = normalize_picker_query(&query);
+        if query.is_empty() {
+            continue;
+        }
+
+        filtered = options
+            .iter()
+            .filter(|option| {
+                option.value == "__search_again__" || picker_option_matches(option, &query)
+            })
+            .cloned()
+            .collect();
+
+        if filtered
+            .iter()
+            .all(|option| option.value == "__search_again__")
+        {
+            println!("  No components matched '{query}'. Try another search.");
+            filtered = options.clone();
+        }
+    }
+}
+
+async fn prompt_assignee_selection(client: &JiraClient, prompt: &str) -> Result<Option<String>> {
     let query = match prompt_search_term(prompt)? {
         Some(query) => query,
         None => return Ok(None),
     };
 
     let users = client.search_users(&query).await?;
-    let mut options = vec![PickerOption {
-        value: "me".to_string(),
-        label: "Assign to me".to_string(),
-    }];
+    let mut options = vec![
+        PickerOption {
+            value: "me".to_string(),
+            label: "Assign to me".to_string(),
+        },
+        PickerOption {
+            value: "__search_again__".to_string(),
+            label: "Search again...".to_string(),
+        },
+    ];
 
     for user in users {
         let display = user
@@ -1050,11 +1172,12 @@ async fn prompt_assignee_selection(client: &JiraClient, prompt: &str) -> Result<
             continue;
         }
 
-        let label = if email.is_empty() {
-            display.to_string()
-        } else {
-            format!("{display} <{email}>")
-        };
+        let mut parts = vec![display.to_string()];
+        if !email.is_empty() {
+            parts.push(format!("<{email}>"));
+        }
+        parts.push(format!("accountId: {account_id}"));
+        let label = parts.join("  •  ");
 
         if !options.iter().any(|option| option.value == account_id) {
             options.push(PickerOption {
@@ -1064,12 +1187,12 @@ async fn prompt_assignee_selection(client: &JiraClient, prompt: &str) -> Result<
         }
     }
 
-    if options.len() == 1 {
+    if options.len() <= 2 {
         println!("  No matching users found.");
         return Ok(None);
     }
 
-    let selected = Select::new("Pick assignee:", options).prompt_skippable()?;
+    let selected = pick_single_option("Pick assignee:", options)?;
     Ok(selected.map(|option| option.value))
 }
 
@@ -1078,10 +1201,8 @@ async fn prompt_project_components(
     project_key: &str,
     prompt: &str,
 ) -> Result<Option<Vec<String>>> {
-    use inquire::MultiSelect;
-
     let query = match prompt_search_term(prompt)? {
-        Some(query) => query.to_lowercase(),
+        Some(query) => normalize_picker_query(&query),
         None => return Ok(None),
     };
 
@@ -1098,22 +1219,28 @@ async fn prompt_project_components(
                 label: name.to_string(),
             })
         })
-        .filter(|option| option.label.to_lowercase().contains(&query))
+        .filter(|option| picker_option_matches(option, &query))
         .collect();
 
     options.sort_by_key(|a| a.label.to_lowercase());
     options.dedup_by(|a, b| a.value == b.value);
+    options.insert(
+        0,
+        PickerOption {
+            value: "__search_again__".to_string(),
+            label: "Search again...".to_string(),
+        },
+    );
 
-    if options.is_empty() {
+    if options.len() == 1 {
         println!("  No matching components found for project {project_key}.");
         return Ok(None);
     }
 
-    let selected = MultiSelect::new(
+    let selected = pick_multi_options(
         "Pick components (space to toggle, enter to confirm):",
         options,
-    )
-    .prompt_skippable()?;
+    )?;
 
     let Some(selected) = selected else {
         return Ok(None);
@@ -1121,8 +1248,14 @@ async fn prompt_project_components(
 
     let values = selected
         .into_iter()
+        .filter(|option| option.value != "__search_again__")
         .map(|option| option.value)
         .collect::<Vec<_>>();
+
+    if values.is_empty() {
+        return Ok(None);
+    }
+
     Ok(Some(values))
 }
 

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1252,10 +1252,6 @@ async fn prompt_project_components(
         .map(|option| option.value)
         .collect::<Vec<_>>();
 
-    if values.is_empty() {
-        return Ok(None);
-    }
-
     Ok(Some(values))
 }
 


### PR DESCRIPTION
## Summary

This PR groups together a conservative repo hardening pass, TUI usability improvements, and documentation cleanup without intentionally changing the existing release flow.

## What changed

### TUI UX
- improved assignee selection with a clearer picker flow
- added refine-and-search-again behavior for picker-driven selection
- improved component selection with a more usable multi-select picker

### Docs
- polished the main README positioning and feature framing
- clarified TUI shortcut descriptions
- added `CONTRIBUTING.md` with repository workflow, validation commands, and a change-impact map for release/package/plugin/skill lanes

### Security and workflow hardening
- removed the risky checkout pattern from `winget-submit.yml`
- pinned `actions/setup-node` in `clawhub-publish-jirac.yml`
- tightened workflow permissions in `release-please.yml` and `pr-automerge.yml`
- added CodeQL analysis to `security.yml`

## Validation

- `cargo fmt --all`
- `cargo check -p jira-commands`
- `cargo check -p jira-core`
- `cargo check -p jira-mcp`
- `cargo audit` (0 vulnerabilities; advisory output was informational/transitive)

## Notes

- release-related workflow changes were kept intentionally conservative
- this PR fixes the highest-risk workflow issue first and improves least-privilege posture without redesigning release automation
- branch protection / GitHub settings posture is intentionally handled outside this PR
