### PR TITLE
fix: trigger release-please after squash merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,4 @@ Licensed under [MIT](LICENSE-MIT) OR [Apache-2.0](LICENSE-APACHE).
 ---
 
 <sub>**jirac** is an independent, community-built tool. It is not affiliated with, endorsed by, or sponsored by Atlassian. "Jira" is a trademark of Atlassian.</sub>
+


### PR DESCRIPTION
Small follow-up to re-enter the release-please flow after PR #101 was squash-merged with a non-conventional title, which prevented release-please from parsing it as a user-facing change.