### PR TITLE
fix(chocolatey): remove duplicate tools file mappings

### DIFF
--- a/packaging/chocolatey/jirac.nuspec
+++ b/packaging/chocolatey/jirac.nuspec
@@ -20,9 +20,5 @@
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
-    <file src="LICENSE" target="tools" />
-    <file src="LICENSE-MIT" target="tools" />
-    <file src="LICENSE-APACHE" target="tools" />
-    <file src="README.md" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
## Summary
- remove duplicate Chocolatey file mappings that pack multiple files into the same tools destination
- keep tools/** as the single packaged tools source
- unblock Chocolatey package creation during release

## Root cause
Chocolatey pack failed with: .
The nuspec mapped  and also mapped  and  into , causing destination collisions.

## Result
This should let the  job reach  instead of failing at .