### PR TITLE
feat: add Jira Data Center multi-profile auth support

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -606,8 +606,8 @@ jobs:
             Set-Content $nuspec
 
           (Get-Content $installScript -Raw) `
-            -replace "\$url64 = '.*'", "`$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v$env:VERSION/jirac-windows-x86_64.zip'" `
-            -replace "\$checksum64 = '.*'", "`$checksum64 = '$env:SHA_WINDOWS_X86'" |
+            -replace '(?m)^\$url64 = ''.*''$', "`$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v$env:VERSION/jirac-windows-x86_64.zip'" `
+            -replace '(?m)^\$checksum64 = ''.*''$', "`$checksum64 = '$env:SHA_WINDOWS_X86'" |
             Set-Content $installScript
 
       - name: Stage Chocolatey package files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ Format: [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
 
 ---
 
-## Unreleased
-
-### Features
-
-* **auth:** add multi-profile login for Jira Cloud and Jira Data Center
-* **auth:** add active profile switching and profile-aware status/logout flows
-* **datacenter:** support bearer PAT auth, basic auth, and automatic REST API v2 selection
-
 ## [0.17.1](https://github.com/mulhamna/jira-commands/compare/v0.17.0...v0.17.1) (2026-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
 
 ---
 
+## Unreleased
+
+### Features
+
+* **auth:** add multi-profile login for Jira Cloud and Jira Data Center
+* **auth:** add active profile switching and profile-aware status/logout flows
+* **datacenter:** support bearer PAT auth, basic auth, and automatic REST API v2 selection
+
 ## [0.17.1](https://github.com/mulhamna/jira-commands/compare/v0.17.0...v0.17.1) (2026-04-24)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.16.5"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.16.5"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1421,15 +1421,17 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toml",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
 name = "jira-mcp"
-version = "0.16.5"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,12 +90,22 @@ choco install jirac
 Authenticate first:
 
 ```bash
+# Simple login (Cloud or Data Center)
 jirac auth login
+
+# Save separate accounts
+jirac auth login --profile work-cloud
+jirac auth login --profile client-dc
+
+# Switch active account later
+jirac auth use client-dc
 ```
 
 Then verify:
 
 ```bash
+jirac auth status
+jirac auth profiles
 jirac --help
 jirac tui --help
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,15 +4,15 @@ Detailed installation guide for `jirac` and `jirac-mcp`.
 
 ## Supported install paths
 
-| Method | macOS | Linux | Windows | Notes |
-| --- | --- | --- | --- | --- |
-| Homebrew | Yes | Yes | No | `jirac` formula via `mulhamna/tap` |
-| Install script | Yes | Yes | No | Downloads latest release asset |
-| PowerShell installer | No | No | Yes | Installs `jirac.exe` to user-local bin |
-| Cargo | Yes | Yes | Yes | Best for Rust users |
-| GitHub Releases | Yes | Yes | Yes | Manual download of archives/binaries |
-| Winget | No | No | Yes | Windows package manager |
-| Chocolatey | No | No | Yes | Windows package manager |
+| Method               | macOS | Linux | Windows | Notes                                  |
+| -------------------- | ----- | ----- | ------- | -------------------------------------- |
+| Homebrew             | ✅     | ✅     | No      | `jirac` formula via `mulhamna/tap`     |
+| Install script       | ✅     | ✅     | No      | Downloads latest release asset         |
+| PowerShell installer | ❌     | ❌     | ✅       | Installs `jirac.exe` to user-local bin |
+| Cargo                | ✅     | ✅     | ✅       | Best for Rust users                    |
+| GitHub Releases      | ✅     | ✅     | ✅       | Manual download of archives/binaries   |
+| Winget               | ❌     | ❌     | ✅       | Windows package manager                |
+| Chocolatey           | ❌     | ❌     | ✅       | Windows package manager                |
 
 ## Homebrew (macOS / Linux)
 
@@ -65,13 +65,13 @@ Download from:
 
 Preferred archives:
 
-| Platform | Archive |
-| --- | --- |
+| Platform            | Archive                      |
+| ------------------- | ---------------------------- |
 | macOS Apple Silicon | `jirac-macos-aarch64.tar.gz` |
-| macOS Intel | `jirac-macos-x86_64.tar.gz` |
-| Linux x86_64 | `jirac-linux-x86_64.tar.gz` |
-| Linux ARM64 | `jirac-linux-aarch64.tar.gz` |
-| Windows x86_64 | `jirac-windows-x86_64.zip` |
+| macOS Intel         | `jirac-macos-x86_64.tar.gz`  |
+| Linux x86_64        | `jirac-linux-x86_64.tar.gz`  |
+| Linux ARM64         | `jirac-linux-aarch64.tar.gz` |
+| Windows x86_64      | `jirac-windows-x86_64.zip`   |
 
 ## Winget (Windows)
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,0 +1,36 @@
+# Claude Code Plugin
+
+The `jirac` Claude Code plugin exposes Jira operations as slash commands inside Claude Code. The plugin namespace is `/jira:*`.
+
+The plugin has its own release lane under `plugin/`, with dedicated `plugin/VERSION` and `plugin/CHANGELOG.md` files. ClawHub publishing uses a separate skill lane under `clawhub/jirac/`.
+
+## Setup
+
+```bash
+# 1. Install the CLI that the plugin calls
+cargo install jira-commands
+jirac auth login
+```
+
+```text
+# 2. In Claude Code
+/plugin marketplace add mulhamna/jira-commands
+/plugin install jira@jira-commands
+```
+
+## Available skills
+
+| Skill                   | Description                             |
+| ----------------------- | --------------------------------------- |
+| `/jira:list-issues`     | List issues by project or JQL           |
+| `/jira:view-issue`      | View full issue detail                  |
+| `/jira:create-issue`    | Create a new issue                      |
+| `/jira:update-issue`    | Update an existing issue                |
+| `/jira:transition`      | Transition an issue                     |
+| `/jira:comment`         | List comments or add a Markdown comment |
+| `/jira:worklog`         | List, add, or delete worklogs           |
+| `/jira:fields`          | Inspect available field metadata        |
+| `/jira:bulk-transition` | Bulk transition issues via JQL          |
+| `/jira:attach`          | Upload a file to an issue               |
+| `/jira:jql`             | Build and run a JQL query               |
+| `/jira:api`             | Raw REST API passthrough                |

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Jira on the command line.
 | Raw API passthrough               |          ✅          |                             ❌                             |                              ❌                             |
 | Cursor-based pagination           |          ✅          |                        ❌ (offset)                         |                         ❌ (offset)                         |
 | MCP server                        |  ✅ (`jirac-mcp`)    |                             ❌                             |                              ❌                             |
+| Multi login / saved profiles      |          ✅          |                             ❌                             |                              ❌                             |
 | macOS / Linux / Windows           |   ✅ / ✅ / ✅       |                    ✅ / ✅ / Partial                       |                      ✅ / ✅ / ✅                           |
-| Jira Data Center / self-managed   |    Cloud + Data Center    |                  Cloud + self-managed                      |                     Cloud + self-managed                    |
+| Jira Data Center / self-managed   |   Cloud + Data Center   |                  Cloud + self-managed                      |                     Cloud + self-managed                    |
 - **JQL builder** — interactive prompt that helps you construct queries
 - **Raw API passthrough** — call any Jira REST endpoint directly
 - **MCP server** — expose Jira as typed tools for editors and AI agents ([docs](crates/jira-mcp/README.md))

--- a/README.md
+++ b/README.md
@@ -1,90 +1,85 @@
 # jirac
 
-A fast, polished Jira CLI and TUI built in Rust.
+Jira on the command line.
 
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
-[![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-`jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports **custom fields discovered at runtime**, **native attachment uploads**, **cursor-based pagination**, and broad **Jira REST API v3** coverage.
-
-It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes:
-- an interactive terminal UI for browsing and updating issues,
-- an [MCP server](#mcp-server) for editor and agent integrations,
-- a [Claude Code plugin](#claude-code-plugin), and
-- a separate ClawHub skill lane under `clawhub/jirac/`.
-
-The OpenClaw skill is also published on ClawHub: <https://clawhub.ai/mulhamna/jirac>
-
-## Preview
+`jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It talks directly to the Jira REST API v3 and discovers custom fields at runtime, so there is nothing to configure beyond your credentials.
 
 ![jirac TUI preview](assets/readme/sample_tui.jpeg)
-![jirac TUI preview JQL builder](assets/readme/sample-jql.jpeg)
 
-## Installation
+## Highlights
 
-See [INSTALL.md](INSTALL.md) for detailed steps.
+- **Interactive TUI** — browse, create, edit, transition, and assign issues without leaving the terminal
+- **Custom fields** — discovered at runtime via the API, not hardcoded
+- **Attachments** — upload files to any issue from the CLI
+- **Worklogs** — add, list, and delete time entries
+- **Bulk operations** — transition, update, or archive many issues at once with a single JQL query
 
-### Installation matrix
+## Comparison
 
-| Method | macOS | Linux | Windows | Notes |
-| --- | --- | --- | --- | --- |
-| Homebrew | Yes | Yes | No | `jirac` formula via `mulhamna/tap` |
-| Install script | Yes | Yes | No | Downloads latest release asset |
-| PowerShell installer | No | No | Yes | Installs `jirac.exe` to user-local bin |
-| Cargo | Yes | Yes | Yes | Best for Rust users |
-| GitHub Releases | Yes | Yes | Yes | Manual archive/binary download |
-| Winget | No | No | Yes | Windows package manager |
-| Chocolatey | No | No | Yes | Windows package manager |
+| Feature                           |      **jirac**       | [jira-cli](https://github.com/ankitpokhrel/jira-cli) (Go) | [jira-cmd](https://github.com/palashkulsh/jira-cmd) (Node) |
+| --------------------------------- | :------------------: | :--------------------------------------------------------: | :---------------------------------------------------------: |
+| Single binary, no runtime deps    |          ✅          |                             ✅                             |                          ❌ (npm)                           |
+| Interactive TUI                   |          ✅          |                             ✅                             |                              ❌                             |
+| Jira REST API version             |          v3          |                          v2 / v3                           |                             v2                              |
+| Custom fields (runtime discovery) |          ✅          |                    Partial (config-based)                  |                     Partial (field IDs)                     |
+| Attachment upload                 |          ✅          |                             ❌                             |                              ❌                             |
+| Worklogs (add / list / delete)    |          ✅          |                             ❌                             |                       Add / list only                       |
+| Bulk transition                   |          ✅          |                             ❌                             |                              ❌                             |
+| Bulk update                       |          ✅          |                             ❌                             |                              ❌                             |
+| Issue archive                     |          ✅          |                             ❌                             |                              ❌                             |
+| JQL builder (interactive)         |          ✅          |                             ❌                             |                              ❌                             |
+| Raw API passthrough               |          ✅          |                             ❌                             |                              ❌                             |
+| Cursor-based pagination           |          ✅          |                        ❌ (offset)                         |                         ❌ (offset)                         |
+| MCP server                        |  ✅ (`jirac-mcp`)    |                             ❌                             |                              ❌                             |
+| macOS / Linux / Windows           |   ✅ / ✅ / ✅       |                    ✅ / ✅ / Partial                       |                      ✅ / ✅ / ✅                           |
+| Jira Server (on-prem)             |      Cloud only      |                       Cloud + Server                       |                        Cloud + Server                       |
+- **JQL builder** — interactive prompt that helps you construct queries
+- **Raw API passthrough** — call any Jira REST endpoint directly
+- **MCP server** — expose Jira as typed tools for editors and AI agents ([docs](crates/jira-mcp/README.md))
 
-## Why jirac
+## Install
 
-| Feature                           |      **jirac**       | [jira-cli](https://github.com/ankitpokhrel/jira-cli) | [jira-cmd](https://github.com/palashkulsh/jira-cmd) |
-| --------------------------------- | :------------------: | :--------------------------------------------------: | :-------------------------------------------------: |
-| Language / runtime                | Rust (single binary) |                  Go (single binary)                  |                    Node.js (npm)                    |
-| Interactive TUI                   |         Yes          |                         Yes                          |                         No                          |
-| Jira REST API version             |          v3          |                       v2 / v3                        |                         v2                          |
-| Custom fields (runtime discovery) |         Yes          |                Partial (config-based)                |                 Partial (field IDs)                 |
-| Attachment upload                 |         Yes          |                          No                          |                         No                          |
-| Worklogs (add / list / delete)    |         Yes          |                          No                          |                   Add / list only                   |
-| Bulk transition                   |         Yes          |                          No                          |                         No                          |
-| Bulk update                       |         Yes          |                          No                          |                         No                          |
-| Issue archive                     |         Yes          |                          No                          |                         No                          |
-| JQL builder (interactive)         |         Yes          |                          No                          |                         No                          |
-| Raw API passthrough               |         Yes          |                          No                          |                         No                          |
-| Cursor-based pagination           |         Yes          |                     No (offset)                      |                     No (offset)                     |
-| MCP server                        |  Yes (`jirac-mcp`)   |                          No                          |                         No                          |
-| Claude Code plugin                |   Yes (12 skills)    |                          No                          |                         No                          |
-| Homebrew                          |         Yes          |                         Yes                          |                         No                          |
-| Winget                            |         Yes          |                          No                          |                         No                          |
-| Chocolatey                        |         Yes          |                          No                          |                         No                          |
-| macOS / Linux / Windows           |   Yes / Yes / Yes    |                 Yes / Yes / Partial                  |                   Yes / Yes / Yes                   |
-| Jira Server (on-prem)             |      Cloud only      |                    Cloud + Server                    |                   Cloud + Server                    |
+```bash
+# Homebrew (macOS / Linux)
+brew tap mulhamna/tap && brew install jira-commands
+
+# Cargo
+cargo install jira-commands
+
+# Windows (winget)
+winget install mulhamna.jirac
+
+# Windows (Chocolatey)
+choco install jirac
+```
+
+More methods (install script, PowerShell, GitHub Releases): [INSTALL.md](INSTALL.md)
 
 ## Quick start
 
-### 1. Create an API token
-
-Go to [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens) and create a new token.
-
-### 2. Authenticate
-
 ```bash
+# Authenticate
 jirac auth login
-```
 
-You will be prompted for your Jira base URL, email, and API token. Credentials are stored in `~/.config/jira/config.toml` with `600` permissions.
+# List your assigned issues
+jirac issue list
 
-### 3. Start using it
+# View an issue
+jirac issue view PROJ-123
 
-```bash
-jirac issue list                          # your assigned issues
-jirac issue list -p PROJ                  # issues in a project
-jirac issue view PROJ-123                 # view issue detail
-jirac issue create -p PROJ                # create (interactive)
-jirac issue transition PROJ-123 --to Done # transition
-jirac tui -p PROJ                         # interactive TUI
+# Create an issue (interactive)
+jirac issue create -p PROJ
+
+# Transition an issue
+jirac issue transition PROJ-123 --to "In Progress"
+
+# Launch the TUI
+jirac tui -p PROJ
 ```
 
 ## Usage
@@ -129,10 +124,8 @@ jirac issue archive -p PROJ -q 'status = Done AND updated < -90d'
 ### JQL builder
 
 ```bash
-jirac issue jql                                     # interactive
+jirac issue jql    # interactive query builder
 ```
-
-![jirac JQL builder](assets/readme/sample-jql.jpeg)
 
 ### Raw API passthrough
 
@@ -153,66 +146,18 @@ jirac plan list
 jirac auth login
 jirac auth status
 jirac auth update --token NEW_TOKEN
-jirac auth update --url https://new.atlassian.net
 jirac auth logout
 ```
 
 ## Interactive TUI
 
+The TUI is a full-screen terminal interface for browsing and managing issues. Press `?` inside the TUI for a complete shortcut reference.
+
 ```bash
-jirac tui
 jirac tui -p PROJ
 ```
 
-Common shortcuts:
-
-| Key         | Action                                                              |
-| ----------- | ------------------------------------------------------------------- |
-| `j` / `k`   | Navigate up / down                                                  |
-| `Enter`     | View issue                                                          |
-| `C`         | Open column settings popup                                          |
-| `c`         | Create issue                                                        |
-| `e`         | Edit issue                                                          |
-| `a`         | Open native assignee popup and assign issue                         |
-| `t`         | Transition issue                                                    |
-| `w`         | Add worklog                                                         |
-| `l`         | Manage labels                                                       |
-| `m`         | Open native component popup and set project-scoped components       |
-| `u`         | Upload attachment                                                   |
-| `o`         | Open in browser                                                     |
-| `r`         | Refresh issue list                                                  |
-| `/`         | JQL search                                                          |
-| `?`         | Show in-app help                                                    |
-| `q` / `Esc` | Quit or go back, depending on context                               |
-
-Inside column settings:
-
-| Key           | Action                       |
-| ------------- | ---------------------------- |
-| `Space`       | Toggle selected column       |
-| `a`           | Select all available columns |
-| `r`           | Reset to default columns     |
-| `s` / `Enter` | Save preferences             |
-| `Esc`         | Cancel without saving        |
-
-Inside assignee popup:
-
-| Key         | Action |
-| ----------- | ------ |
-| Type        | Filter assignee list from Jira |
-| `j` / `k`   | Move selection |
-| `Enter`     | Assign selected assignee |
-| `Esc`       | Cancel |
-
-Inside component popup:
-
-| Key         | Action |
-| ----------- | ------ |
-| Type        | Filter project components |
-| `j` / `k`   | Move selection |
-| `Space`     | Toggle selected component |
-| `Enter`     | Save selected components |
-| `Esc`       | Cancel |
+Full keybinding reference: [TUI.md](TUI.md)
 
 ## Configuration
 
@@ -236,106 +181,11 @@ export JIRA_TOKEN=your_api_token
 
 ## MCP server
 
-`jirac-mcp` exposes Jira as typed [Model Context Protocol](https://modelcontextprotocol.io) tools for editors, agents, and desktop apps.
-
-### Install
-
-```bash
-cargo install jira-mcp
-```
-
-Or use the release installer flow for your platform:
-
-```bash
-# macOS / Linux
-curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | BINARY=jirac-mcp bash
-```
-
-```powershell
-# Windows
-powershell -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))" -Binary jirac-mcp
-```
-
-### Run
-
-```bash
-# stdio (local MCP clients)
-jirac-mcp serve --transport stdio
-
-# Streamable HTTP (remote clients)
-jirac-mcp serve --transport streamable-http --host 127.0.0.1 --port 8787 --path /mcp
-```
-
-### Client configuration
-
-```json
-{
-  "mcpServers": {
-    "jira": {
-      "command": "jirac-mcp",
-      "args": ["serve", "--transport", "stdio"]
-    }
-  }
-}
-```
-
-### Available tools
-
-| Category | Tools                                                                                                        |
-| -------- | ------------------------------------------------------------------------------------------------------------ |
-| Auth     | `jira_auth_status`, `jira_auth_set_credentials`, `jira_auth_logout`                                          |
-| Issues   | `jira_issue_list`, `jira_issue_view`, `jira_issue_create`, `jira_issue_update`, `jira_issue_delete`          |
-| Metadata | `jira_issue_types_list`, `jira_issue_fields`, `jira_issue_transitions_list`                                  |
-| Workflow | `jira_issue_transition`, `jira_issue_attach`, `jira_worklog_list`, `jira_worklog_add`, `jira_worklog_delete` |
-| Bulk     | `jira_issue_bulk_transition`, `jira_issue_bulk_update`, `jira_issue_archive`                                 |
-| Advanced | `jira_plan_list`, `jira_api_request`                                                                         |
-
-Destructive tools (delete, archive, bulk operations) require `confirm: true`. The `jira_api_request` tool provides raw access to any Jira REST endpoint.
-
-## ClawHub skill
-
-`jirac` is also available as an OpenClaw skill on ClawHub:
-
-- <https://clawhub.ai/mulhamna/jirac>
-
-The ClawHub lane is intentionally separate from the Claude Code plugin lane. It documents the OpenClaw-facing skill surface and points users to supported `jirac` installation options before use.
-
-## Claude Code plugin
-
-The plugin namespace remains `/jira:*`, but the binary it invokes is `jirac`.
-
-The Claude Code plugin now has its own release lane under `plugin/`, with dedicated `plugin/VERSION` and `plugin/CHANGELOG.md` files. ClawHub publishing uses the dedicated skill lane under `clawhub/jirac/` rather than sharing the Claude plugin packaging.
-
-```bash
-# 1. Install the CLI that the plugin calls
-cargo install jira-commands
-jirac auth login
-```
-
-```text
-# 2. In Claude Code
-/plugin marketplace add mulhamna/jira-commands
-/plugin install jira@jira-commands
-```
-
-| Skill                   | Description                             |
-| ----------------------- | --------------------------------------- |
-| `/jira:list-issues`     | List issues by project or JQL           |
-| `/jira:view-issue`      | View full issue detail                  |
-| `/jira:create-issue`    | Create a new issue                      |
-| `/jira:update-issue`    | Update an existing issue                |
-| `/jira:transition`      | Transition an issue                     |
-| `/jira:comment`         | List comments or add a Markdown comment |
-| `/jira:worklog`         | List, add, or delete worklogs           |
-| `/jira:fields`          | Inspect available field metadata        |
-| `/jira:bulk-transition` | Bulk transition issues via JQL          |
-| `/jira:attach`          | Upload a file to an issue               |
-| `/jira:jql`             | Build and run a JQL query               |
-| `/jira:api`             | Raw REST API passthrough                |
+`jirac-mcp` exposes Jira as typed [Model Context Protocol](https://modelcontextprotocol.io) tools for editors, agents, and desktop apps. See the [jirac-mcp README](crates/jira-mcp/README.md) for setup and available tools.
 
 ## Using jira-core as a library
 
-The `jira-core` crate can be used independently as a Rust library:
+The `jira-core` crate can be used independently:
 
 ```toml
 [dependencies]
@@ -365,10 +215,8 @@ See [jira-core on crates.io](https://crates.io/crates/jira-core) for full API do
 ```bash
 git clone https://github.com/mulhamna/jira-commands
 cd jira-commands
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all
 cargo build --all
+cargo test --all
 ```
 
 ### Workspace layout
@@ -378,35 +226,31 @@ crates/
 ├── jira-core/     # Rust library — API client, auth, models, ADF parser
 ├── jira/          # CLI binary (jirac) — clap commands + ratatui TUI
 └── jira-mcp/      # MCP server binary (jirac-mcp) — rmcp-based
-plugin/
-└── .claude-plugin/  # Claude Code plugin (12 skills)
 ```
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## Upgrading from `jira` to `jirac`
 
-The supported CLI binary is `jirac`.
-
-If you still have old scripts, aliases, or wrappers that call `jira`, update them before upgrading. Release artifacts now ship `jirac` and `jirac-mcp` only.
+The binary was renamed from `jira` to `jirac`. Update any scripts or aliases:
 
 ```bash
-# Example shell alias update
 alias jira='jirac'
 ```
+
+## More documentation
+
+- [INSTALL.md](INSTALL.md) — all installation methods
+- [TUI guide](TUI.md) — full keybinding reference
+- [MCP server](crates/jira-mcp/README.md) — setup and tool list
+- [Claude Code plugin](PLUGIN.md) — slash commands for Claude Code
+- [ClawHub skill](https://clawhub.ai/mulhamna/jirac) — OpenClaw integration
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor guide
 
 ## License
 
 Licensed under [MIT](LICENSE-MIT) OR [Apache-2.0](LICENSE-APACHE).
 
-## Windows packaging
-
-- `install.ps1` is the direct Windows installer entrypoint
-- Winget manifest sources are maintained in `packaging/winget/`
-- Chocolatey package is published from official GitHub releases
-- GitHub Releases remain the source for release archives and checksums
-
 ---
 
 <sub>**jirac** is an independent, community-built tool. It is not affiliated with, endorsed by, or sponsored by Atlassian. "Jira" is a trademark of Atlassian.</sub>
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jira on the command line.
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-`jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It talks directly to the Jira REST API v3 and discovers custom fields at runtime, so there is nothing to configure beyond your credentials.
+`jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It supports Jira Cloud and Jira Data Center, stores multiple login profiles, and discovers custom fields at runtime so there is little to configure beyond your credentials.
 
 ![jirac TUI preview](assets/readme/sample_tui.jpeg)
 
@@ -25,7 +25,7 @@ Jira on the command line.
 | --------------------------------- | :------------------: | :--------------------------------------------------------: | :---------------------------------------------------------: |
 | Single binary, no runtime deps    |          ✅          |                             ✅                             |                          ❌ (npm)                           |
 | Interactive TUI                   |          ✅          |                             ✅                             |                              ❌                             |
-| Jira REST API version             |          v3          |                          v2 / v3                           |                             v2                              |
+| Jira REST API version             |        v2 / v3       |                          v2 / v3                           |                             v2                              |
 | Custom fields (runtime discovery) |          ✅          |                    Partial (config-based)                  |                     Partial (field IDs)                     |
 | Attachment upload                 |          ✅          |                             ❌                             |                              ❌                             |
 | Worklogs (add / list / delete)    |          ✅          |                             ❌                             |                       Add / list only                       |
@@ -37,7 +37,7 @@ Jira on the command line.
 | Cursor-based pagination           |          ✅          |                        ❌ (offset)                         |                         ❌ (offset)                         |
 | MCP server                        |  ✅ (`jirac-mcp`)    |                             ❌                             |                              ❌                             |
 | macOS / Linux / Windows           |   ✅ / ✅ / ✅       |                    ✅ / ✅ / Partial                       |                      ✅ / ✅ / ✅                           |
-| Jira Server (on-prem)             |      Cloud only      |                       Cloud + Server                       |                        Cloud + Server                       |
+| Jira Data Center / self-managed   |    Cloud + Data Center    |                  Cloud + self-managed                      |                     Cloud + self-managed                    |
 - **JQL builder** — interactive prompt that helps you construct queries
 - **Raw API passthrough** — call any Jira REST endpoint directly
 - **MCP server** — expose Jira as typed tools for editors and AI agents ([docs](crates/jira-mcp/README.md))
@@ -144,9 +144,24 @@ jirac plan list
 
 ```bash
 jirac auth login
+jirac auth profiles
+jirac auth use work-cloud
 jirac auth status
-jirac auth update --token NEW_TOKEN
-jirac auth logout
+jirac auth update --profile client-dc --token NEW_SECRET
+jirac auth logout --profile client-dc
+```
+
+### Multi-profile examples
+
+```bash
+# Jira Cloud
+jirac auth login --profile work-cloud
+
+# Jira Data Center with PAT
+jirac auth login --profile client-dc
+
+# Switch active account
+jirac auth use client-dc
 ```
 
 ## Interactive TUI
@@ -164,16 +179,33 @@ Full keybinding reference: [TUI.md](TUI.md)
 Config file: `~/.config/jira/config.toml`
 
 ```toml
+current_profile = "work-cloud"
+
+[profiles.work-cloud]
 base_url = "https://yourcompany.atlassian.net"
 email = "you@example.com"
 token = "your_api_token"
-project = "PROJ"           # optional default project
+project = "PROJ"
 timeout_secs = 30
+deployment = "cloud"
+auth_type = "cloud_api_token"
+api_version = 3
+
+[profiles.client-dc]
+base_url = "https://jira.company.internal"
+email = "ops-user"
+token = "your_pat"
+project = "OPS"
+timeout_secs = 30
+deployment = "data_center"
+auth_type = "datacenter_pat"
+api_version = 2
 ```
 
-Environment variables override the config file:
+Environment variables override the active profile:
 
 ```bash
+export JIRA_PROFILE=work-cloud
 export JIRA_URL=https://yourcompany.atlassian.net
 export JIRA_EMAIL=you@example.com
 export JIRA_TOKEN=your_api_token

--- a/TUI.md
+++ b/TUI.md
@@ -1,0 +1,60 @@
+# Interactive TUI
+
+```bash
+jirac tui
+jirac tui -p PROJ
+```
+
+The TUI provides a full-screen terminal interface for browsing and managing Jira issues.
+
+![jirac TUI preview](assets/readme/sample_tui.jpeg)
+
+## Keyboard shortcuts
+
+| Key         | Action                                                              |
+| ----------- | ------------------------------------------------------------------- |
+| `j` / `k`   | Navigate up / down                                                  |
+| `Enter`     | View issue                                                          |
+| `C`         | Open column settings popup                                          |
+| `c`         | Create issue                                                        |
+| `e`         | Edit issue                                                          |
+| `a`         | Open native assignee popup and assign issue                         |
+| `t`         | Transition issue                                                    |
+| `w`         | Add worklog                                                         |
+| `l`         | Manage labels                                                       |
+| `m`         | Open native component popup and set project-scoped components       |
+| `u`         | Upload attachment                                                   |
+| `o`         | Open in browser                                                     |
+| `r`         | Refresh issue list                                                  |
+| `/`         | JQL search                                                          |
+| `?`         | Show in-app help                                                    |
+| `q` / `Esc` | Quit or go back, depending on context                               |
+
+## Column settings
+
+| Key           | Action                       |
+| ------------- | ---------------------------- |
+| `Space`       | Toggle selected column       |
+| `a`           | Select all available columns |
+| `r`           | Reset to default columns     |
+| `s` / `Enter` | Save preferences             |
+| `Esc`         | Cancel without saving        |
+
+## Assignee popup
+
+| Key         | Action |
+| ----------- | ------ |
+| Type        | Filter assignee list from Jira |
+| `j` / `k`   | Move selection |
+| `Enter`     | Assign selected assignee |
+| `Esc`       | Cancel |
+
+## Component popup
+
+| Key         | Action |
+| ----------- | ------ |
+| Type        | Filter project components |
+| `j` / `k`   | Move selection |
+| `Space`     | Toggle selected component |
+| `Enter`     | Save selected components |
+| `Esc`       | Cancel |

--- a/crates/jira-core/Cargo.toml
+++ b/crates/jira-core/Cargo.toml
@@ -23,3 +23,7 @@ anyhow = "1"
 tracing = "0.1"
 comrak = "0.28"
 mime_guess = "2"
+
+[dev-dependencies]
+tempfile = "3"
+wiremock = "0.6"

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 
 use crate::{
     adf::markdown_to_adf,
-    config::JiraConfig,
+    config::{JiraAuthType, JiraConfig},
     error::{JiraError, Result},
     model::{
         attachment::Attachment,
@@ -23,7 +23,6 @@ use crate::{
     },
 };
 
-const PLATFORM_BASE: &str = "/rest/api/3";
 const AGILE_BASE: &str = "/rest/agile/1.0";
 const MAX_RETRIES: u32 = 3;
 
@@ -49,9 +48,9 @@ impl JiraClient {
 
     fn platform_url(&self, path: &str) -> String {
         format!(
-            "{}{}{}",
+            "{}/rest/api/{}{}",
             self.config.base_url.trim_end_matches('/'),
-            PLATFORM_BASE,
+            self.config.api_version,
             path
         )
     }
@@ -71,8 +70,13 @@ impl JiraClient {
             JiraError::Auth("No token configured. Run `jirac auth login` first.".into())
         })?;
 
-        let credentials = base64_encode(&format!("{}:{}", self.config.email, token));
-        let auth_value = format!("Basic {credentials}");
+        let auth_value = match self.config.auth_type {
+            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic => {
+                let credentials = base64_encode(&format!("{}:{}", self.config.email, token));
+                format!("Basic {credentials}")
+            }
+            JiraAuthType::DataCenterPat => format!("Bearer {token}"),
+        };
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -91,8 +95,13 @@ impl JiraClient {
             JiraError::Auth("No token configured. Run `jirac auth login` first.".into())
         })?;
 
-        let credentials = base64_encode(&format!("{}:{}", self.config.email, token));
-        let auth_value = format!("Basic {credentials}");
+        let auth_value = match self.config.auth_type {
+            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic => {
+                let credentials = base64_encode(&format!("{}:{}", self.config.email, token));
+                format!("Basic {credentials}")
+            }
+            JiraAuthType::DataCenterPat => format!("Bearer {token}"),
+        };
 
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -1156,4 +1165,75 @@ fn base64_encode(input: &str) -> String {
         i += 3;
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{JiraAuthType, JiraDeployment};
+    use wiremock::{
+        matchers::{header, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    #[tokio::test]
+    async fn data_center_pat_uses_bearer_and_api_v2() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/2/serverInfo"))
+            .and(header("authorization", "Bearer dc-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "deploymentType": "Data Center",
+                "version": "10.0.0"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = JiraClient::new(JiraConfig {
+            profile_name: Some("dc-main".into()),
+            base_url: server.uri(),
+            email: String::new(),
+            token: Some("dc-token".into()),
+            project: None,
+            timeout_secs: 30,
+            deployment: JiraDeployment::DataCenter,
+            auth_type: JiraAuthType::DataCenterPat,
+            api_version: 2,
+        });
+
+        let info = client.get_server_info().await.expect("server info");
+        assert_eq!(info["deploymentType"], Value::String("Data Center".into()));
+    }
+
+    #[tokio::test]
+    async fn cloud_auth_uses_basic_and_api_v3() {
+        let server = MockServer::start().await;
+        let expected = format!("Basic {}", base64_encode("dev@example.com:cloud-token"));
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/serverInfo"))
+            .and(header("authorization", expected.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "deploymentType": "Cloud",
+                "version": "1001.0.0"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = JiraClient::new(JiraConfig {
+            profile_name: Some("cloud-main".into()),
+            base_url: server.uri(),
+            email: "dev@example.com".into(),
+            token: Some("cloud-token".into()),
+            project: None,
+            timeout_secs: 30,
+            deployment: JiraDeployment::Cloud,
+            auth_type: JiraAuthType::CloudApiToken,
+            api_version: 3,
+        });
+
+        let info = client.get_server_info().await.expect("server info");
+        assert_eq!(info["deploymentType"], Value::String("Cloud".into()));
+    }
 }

--- a/crates/jira-core/src/config.rs
+++ b/crates/jira-core/src/config.rs
@@ -117,7 +117,9 @@ impl From<JiraProfileConfig> for JiraConfig {
 impl JiraConfig {
     /// Load the active profile from ~/.config/jira/config.toml and env vars.
     pub fn load() -> Result<Self> {
-        let profile_override = env::var("JIRA_PROFILE").ok().filter(|s| !s.trim().is_empty());
+        let profile_override = env::var("JIRA_PROFILE")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
         let store = JiraProfilesFile::load()?;
 
         let mut config = if let Some(profile_name) = profile_override.clone() {
@@ -179,7 +181,10 @@ impl JiraConfig {
     }
 
     pub fn requires_user_identity(&self) -> bool {
-        matches!(self.auth_type, JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic)
+        matches!(
+            self.auth_type,
+            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic
+        )
     }
 
     pub fn credential_label(&self) -> &'static str {
@@ -268,7 +273,8 @@ impl JiraProfilesFile {
             let mut store: JiraProfilesFile = toml::from_str(&content)
                 .map_err(|e| JiraError::Config(format!("Failed to parse config: {e}")))?;
             for profile in store.profiles.values_mut() {
-                profile.api_version = normalize_api_version(profile.api_version, &profile.deployment);
+                profile.api_version =
+                    normalize_api_version(profile.api_version, &profile.deployment);
             }
             return Ok(store);
         }
@@ -333,7 +339,9 @@ impl JiraProfilesFile {
 
     pub fn set_current_profile(&mut self, profile_name: &str) -> Result<()> {
         if !self.profiles.contains_key(profile_name) {
-            return Err(JiraError::Config(format!("Profile not found: {profile_name}")));
+            return Err(JiraError::Config(format!(
+                "Profile not found: {profile_name}"
+            )));
         }
         self.current_profile = Some(profile_name.to_string());
         Ok(())
@@ -341,7 +349,9 @@ impl JiraProfilesFile {
 
     pub fn remove_profile(&mut self, profile_name: &str) -> Result<()> {
         if self.profiles.remove(profile_name).is_none() {
-            return Err(JiraError::Config(format!("Profile not found: {profile_name}")));
+            return Err(JiraError::Config(format!(
+                "Profile not found: {profile_name}"
+            )));
         }
         if self.current_profile.as_deref() == Some(profile_name) {
             self.current_profile = self.profiles.keys().next().cloned();

--- a/crates/jira-core/src/config.rs
+++ b/crates/jira-core/src/config.rs
@@ -1,16 +1,69 @@
-use figment::{
-    providers::{Env, Format, Serialized, Toml},
-    Figment,
-};
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::{collections::BTreeMap, env, path::PathBuf};
 
 use crate::error::{JiraError, Result};
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum JiraDeployment {
+    #[default]
+    Cloud,
+    DataCenter,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum JiraAuthType {
+    #[default]
+    CloudApiToken,
+    DataCenterPat,
+    DataCenterBasic,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JiraConfig {
+    #[serde(default)]
+    pub profile_name: Option<String>,
+    pub base_url: String,
+    pub email: String,
+    pub token: Option<String>,
+    pub project: Option<String>,
+    pub timeout_secs: u64,
+    #[serde(default)]
+    pub deployment: JiraDeployment,
+    #[serde(default)]
+    pub auth_type: JiraAuthType,
+    #[serde(default = "default_api_version")]
+    pub api_version: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JiraProfileConfig {
+    pub base_url: String,
+    #[serde(default)]
+    pub email: String,
+    pub token: Option<String>,
+    pub project: Option<String>,
+    pub timeout_secs: u64,
+    #[serde(default)]
+    pub deployment: JiraDeployment,
+    #[serde(default)]
+    pub auth_type: JiraAuthType,
+    #[serde(default = "default_api_version")]
+    pub api_version: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct JiraProfilesFile {
+    pub current_profile: Option<String>,
+    #[serde(default)]
+    pub profiles: BTreeMap<String, JiraProfileConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LegacyJiraConfig {
     pub base_url: String,
     pub email: String,
     pub token: Option<String>,
@@ -18,46 +71,232 @@ pub struct JiraConfig {
     pub timeout_secs: u64,
 }
 
+fn default_api_version() -> u8 {
+    3
+}
+
 impl Default for JiraConfig {
     fn default() -> Self {
         Self {
+            profile_name: Some(default_profile_name()),
             base_url: String::new(),
             email: String::new(),
             token: None,
             project: None,
             timeout_secs: 30,
+            deployment: JiraDeployment::Cloud,
+            auth_type: JiraAuthType::CloudApiToken,
+            api_version: default_api_version(),
+        }
+    }
+}
+
+impl Default for JiraProfileConfig {
+    fn default() -> Self {
+        JiraConfig::default().into_profile()
+    }
+}
+
+impl From<JiraProfileConfig> for JiraConfig {
+    fn from(value: JiraProfileConfig) -> Self {
+        let api_version = normalize_api_version(value.api_version, &value.deployment);
+        Self {
+            profile_name: None,
+            base_url: value.base_url,
+            email: value.email,
+            token: value.token,
+            project: value.project,
+            timeout_secs: value.timeout_secs,
+            deployment: value.deployment,
+            auth_type: value.auth_type,
+            api_version,
         }
     }
 }
 
 impl JiraConfig {
-    /// Load config from ~/.config/jira/config.toml and env vars.
-    /// Returns default config if file doesn't exist.
+    /// Load the active profile from ~/.config/jira/config.toml and env vars.
     pub fn load() -> Result<Self> {
-        let config_path = config_file_path();
+        let profile_override = env::var("JIRA_PROFILE").ok().filter(|s| !s.trim().is_empty());
+        let store = JiraProfilesFile::load()?;
 
-        let mut figment = Figment::from(Serialized::defaults(JiraConfig::default()));
+        let mut config = if let Some(profile_name) = profile_override.clone() {
+            store
+                .profiles
+                .get(&profile_name)
+                .cloned()
+                .map(Into::into)
+                .unwrap_or_else(JiraConfig::default)
+        } else {
+            store.active_profile().map(Into::into).unwrap_or_default()
+        };
 
-        if config_path.exists() {
-            figment = figment.merge(Toml::file(&config_path));
-        }
+        config.profile_name = Some(
+            profile_override
+                .or_else(|| store.current_profile.clone())
+                .unwrap_or_else(default_profile_name),
+        );
+        config.apply_env_overrides();
+        config.api_version = normalize_api_version(config.api_version, &config.deployment);
 
-        figment = figment.merge(Env::prefixed("JIRA_").map(|key| {
-            let normalized = key.as_str().to_ascii_lowercase();
-            match normalized.as_str() {
-                "url" => "base_url".into(),
-                "email" => "email".into(),
-                "token" => "token".into(),
-                other => other.to_string().into(),
-            }
-        }));
-
-        figment
-            .extract()
-            .map_err(|e| JiraError::Config(e.to_string()))
+        Ok(config)
     }
 
-    /// Save config to ~/.config/jira/config.toml
+    pub fn into_profile(self) -> JiraProfileConfig {
+        let api_version = normalize_api_version(self.api_version, &self.deployment);
+        JiraProfileConfig {
+            base_url: self.base_url,
+            email: self.email,
+            token: self.token,
+            project: self.project,
+            timeout_secs: self.timeout_secs,
+            deployment: self.deployment,
+            auth_type: self.auth_type,
+            api_version,
+        }
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let profile_name = self
+            .profile_name
+            .clone()
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(default_profile_name);
+
+        let mut store = JiraProfilesFile::load()?;
+        store.current_profile = Some(profile_name.clone());
+        store
+            .profiles
+            .insert(profile_name, self.clone().into_profile().normalized());
+        store.save()
+    }
+
+    pub fn token_present(&self) -> bool {
+        self.token
+            .as_deref()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    }
+
+    pub fn requires_user_identity(&self) -> bool {
+        matches!(self.auth_type, JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic)
+    }
+
+    pub fn credential_label(&self) -> &'static str {
+        match self.auth_type {
+            JiraAuthType::CloudApiToken => "API token",
+            JiraAuthType::DataCenterPat => "Personal access token",
+            JiraAuthType::DataCenterBasic => "Password or personal access token",
+        }
+    }
+
+    pub fn user_label(&self) -> &'static str {
+        match self.auth_type {
+            JiraAuthType::DataCenterBasic => "Username",
+            _ => "Email address",
+        }
+    }
+
+    pub fn auth_header_kind(&self) -> &'static str {
+        match self.auth_type {
+            JiraAuthType::DataCenterPat => "Bearer",
+            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic => "Basic",
+        }
+    }
+
+    fn apply_env_overrides(&mut self) {
+        if let Ok(url) = env::var("JIRA_URL") {
+            self.base_url = url;
+        }
+        if let Ok(email) = env::var("JIRA_EMAIL") {
+            self.email = email;
+        }
+        if let Ok(token) = env::var("JIRA_TOKEN") {
+            self.token = Some(token);
+        }
+        if let Ok(project) = env::var("JIRA_PROJECT") {
+            self.project = if project.trim().is_empty() {
+                None
+            } else {
+                Some(project)
+            };
+        }
+        if let Ok(timeout_secs) = env::var("JIRA_TIMEOUT_SECS") {
+            if let Ok(value) = timeout_secs.parse::<u64>() {
+                self.timeout_secs = value;
+            }
+        }
+        if let Ok(deployment) = env::var("JIRA_DEPLOYMENT") {
+            if let Some(value) = parse_deployment(&deployment) {
+                self.deployment = value;
+            }
+        }
+        if let Ok(auth_type) = env::var("JIRA_AUTH_TYPE") {
+            if let Some(value) = parse_auth_type(&auth_type) {
+                self.auth_type = value;
+            }
+        }
+        if let Ok(api_version) = env::var("JIRA_API_VERSION") {
+            if let Ok(value) = api_version.parse::<u8>() {
+                self.api_version = value;
+            }
+        }
+    }
+}
+
+impl JiraProfileConfig {
+    fn normalized(mut self) -> Self {
+        self.api_version = normalize_api_version(self.api_version, &self.deployment);
+        self
+    }
+}
+
+impl JiraProfilesFile {
+    pub fn load() -> Result<Self> {
+        let config_path = config_file_path();
+        if !config_path.exists() {
+            return Ok(Self::default());
+        }
+
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| JiraError::Config(format!("Failed to read config: {e}")))?;
+
+        let parsed: toml::Value = toml::from_str(&content)
+            .map_err(|e| JiraError::Config(format!("Failed to parse config: {e}")))?;
+
+        if parsed.get("profiles").is_some() || parsed.get("current_profile").is_some() {
+            let mut store: JiraProfilesFile = toml::from_str(&content)
+                .map_err(|e| JiraError::Config(format!("Failed to parse config: {e}")))?;
+            for profile in store.profiles.values_mut() {
+                profile.api_version = normalize_api_version(profile.api_version, &profile.deployment);
+            }
+            return Ok(store);
+        }
+
+        let legacy: LegacyJiraConfig = toml::from_str(&content)
+            .map_err(|e| JiraError::Config(format!("Failed to parse legacy config: {e}")))?;
+
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            default_profile_name(),
+            JiraProfileConfig {
+                base_url: legacy.base_url,
+                email: legacy.email,
+                token: legacy.token,
+                project: legacy.project,
+                timeout_secs: legacy.timeout_secs,
+                deployment: JiraDeployment::Cloud,
+                auth_type: JiraAuthType::CloudApiToken,
+                api_version: default_api_version(),
+            },
+        );
+
+        Ok(Self {
+            current_profile: Some(default_profile_name()),
+            profiles,
+        })
+    }
+
     pub fn save(&self) -> Result<()> {
         let config_path = config_file_path();
         if let Some(parent) = config_path.parent() {
@@ -71,11 +310,42 @@ impl JiraConfig {
         std::fs::write(&config_path, toml_str)
             .map_err(|e| JiraError::Config(format!("Failed to write config: {e}")))?;
 
-        // Restrict permissions to owner-only (rw-------) on Unix
         #[cfg(unix)]
         std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600))
             .map_err(|e| JiraError::Config(format!("Failed to set config permissions: {e}")))?;
 
+        Ok(())
+    }
+
+    pub fn active_profile(&self) -> Option<JiraProfileConfig> {
+        let name = self
+            .current_profile
+            .clone()
+            .or_else(|| self.profiles.keys().next().cloned())?;
+        self.profiles.get(&name).cloned()
+    }
+
+    pub fn current_profile_name(&self) -> Option<String> {
+        self.current_profile
+            .clone()
+            .or_else(|| self.profiles.keys().next().cloned())
+    }
+
+    pub fn set_current_profile(&mut self, profile_name: &str) -> Result<()> {
+        if !self.profiles.contains_key(profile_name) {
+            return Err(JiraError::Config(format!("Profile not found: {profile_name}")));
+        }
+        self.current_profile = Some(profile_name.to_string());
+        Ok(())
+    }
+
+    pub fn remove_profile(&mut self, profile_name: &str) -> Result<()> {
+        if self.profiles.remove(profile_name).is_none() {
+            return Err(JiraError::Config(format!("Profile not found: {profile_name}")));
+        }
+        if self.current_profile.as_deref() == Some(profile_name) {
+            self.current_profile = self.profiles.keys().next().cloned();
+        }
         Ok(())
     }
 }
@@ -85,4 +355,160 @@ pub fn config_file_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join("jira")
         .join("config.toml")
+}
+
+pub fn parse_deployment(value: &str) -> Option<JiraDeployment> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "cloud" => Some(JiraDeployment::Cloud),
+        "datacenter" | "data_center" | "data-center" | "dc" | "self-managed" | "self_managed" => {
+            Some(JiraDeployment::DataCenter)
+        }
+        _ => None,
+    }
+}
+
+pub fn parse_auth_type(value: &str) -> Option<JiraAuthType> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "cloud_api_token" | "cloud-api-token" | "cloud" | "api-token" | "api_token" => {
+            Some(JiraAuthType::CloudApiToken)
+        }
+        "datacenter_pat" | "datacenter-pat" | "data_center_pat" | "dc-pat" | "pat" => {
+            Some(JiraAuthType::DataCenterPat)
+        }
+        "datacenter_basic" | "datacenter-basic" | "data_center_basic" | "dc-basic" | "basic" => {
+            Some(JiraAuthType::DataCenterBasic)
+        }
+        _ => None,
+    }
+}
+
+pub fn normalize_api_version(api_version: u8, deployment: &JiraDeployment) -> u8 {
+    if api_version == 0 {
+        match deployment {
+            JiraDeployment::Cloud => 3,
+            JiraDeployment::DataCenter => 2,
+        }
+    } else {
+        api_version
+    }
+}
+
+pub fn default_profile_name() -> String {
+    "default".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn set_config_home(temp_dir: &TempDir) {
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        std::env::set_var("HOME", temp_dir.path());
+        std::env::set_var("USERPROFILE", temp_dir.path());
+        std::env::set_var("APPDATA", temp_dir.path());
+        std::env::set_var("LOCALAPPDATA", temp_dir.path());
+    }
+
+    fn clear_config_home() {
+        std::env::remove_var("XDG_CONFIG_HOME");
+        std::env::remove_var("HOME");
+        std::env::remove_var("USERPROFILE");
+        std::env::remove_var("APPDATA");
+        std::env::remove_var("LOCALAPPDATA");
+        std::env::remove_var("JIRA_URL");
+        std::env::remove_var("JIRA_EMAIL");
+        std::env::remove_var("JIRA_TOKEN");
+        std::env::remove_var("JIRA_PROFILE");
+        std::env::remove_var("JIRA_DEPLOYMENT");
+        std::env::remove_var("JIRA_AUTH_TYPE");
+        std::env::remove_var("JIRA_API_VERSION");
+    }
+
+    #[test]
+    fn migrates_legacy_config_into_default_profile() {
+        let _guard = env_lock().lock().expect("env lock");
+        let temp_dir = TempDir::new().expect("tempdir");
+        clear_config_home();
+        set_config_home(&temp_dir);
+
+        std::fs::create_dir_all(config_file_path().parent().expect("parent")).expect("mkdir");
+        std::fs::write(
+            config_file_path(),
+            r#"base_url = "https://example.atlassian.net"
+email = "dev@example.com"
+token = "secret"
+project = "PROJ"
+timeout_secs = 55
+"#,
+        )
+        .expect("write");
+
+        let config = JiraConfig::load().expect("load legacy");
+        assert_eq!(config.profile_name.as_deref(), Some("default"));
+        assert_eq!(config.base_url, "https://example.atlassian.net");
+        assert_eq!(config.auth_type, JiraAuthType::CloudApiToken);
+        assert_eq!(config.api_version, 3);
+
+        clear_config_home();
+    }
+
+    #[test]
+    fn loads_named_profile_and_applies_env_overrides() {
+        let _guard = env_lock().lock().expect("env lock");
+        let temp_dir = TempDir::new().expect("tempdir");
+        clear_config_home();
+        set_config_home(&temp_dir);
+
+        let store = JiraProfilesFile {
+            current_profile: Some("cloud-main".into()),
+            profiles: BTreeMap::from([
+                (
+                    "cloud-main".into(),
+                    JiraProfileConfig {
+                        base_url: "https://example.atlassian.net".into(),
+                        email: "cloud@example.com".into(),
+                        token: Some("cloud-token".into()),
+                        project: Some("CLOUD".into()),
+                        timeout_secs: 30,
+                        deployment: JiraDeployment::Cloud,
+                        auth_type: JiraAuthType::CloudApiToken,
+                        api_version: 3,
+                    },
+                ),
+                (
+                    "dc-main".into(),
+                    JiraProfileConfig {
+                        base_url: "https://jira.internal".into(),
+                        email: String::new(),
+                        token: Some("dc-token".into()),
+                        project: Some("DC".into()),
+                        timeout_secs: 40,
+                        deployment: JiraDeployment::DataCenter,
+                        auth_type: JiraAuthType::DataCenterPat,
+                        api_version: 2,
+                    },
+                ),
+            ]),
+        };
+        store.save().expect("save");
+
+        std::env::set_var("JIRA_PROFILE", "dc-main");
+        std::env::set_var("JIRA_PROJECT", "OPS");
+
+        let config = JiraConfig::load().expect("load profile");
+        assert_eq!(config.profile_name.as_deref(), Some("dc-main"));
+        assert_eq!(config.base_url, "https://jira.internal");
+        assert_eq!(config.project.as_deref(), Some("OPS"));
+        assert_eq!(config.auth_type, JiraAuthType::DataCenterPat);
+        assert_eq!(config.api_version, 2);
+
+        clear_config_home();
+    }
 }

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, path::PathBuf};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use jira_core::{
-    config::{config_file_path, JiraConfig},
+    config::{
+        config_file_path, default_profile_name, parse_auth_type, parse_deployment, JiraConfig,
+        JiraProfilesFile,
+    },
     model::{
         field::{Field, FieldValue},
         CreateIssueRequestV2, UpdateIssueRequest,
@@ -29,13 +32,19 @@ pub struct JiraApp;
 impl JiraApp {
     pub fn auth_status(&self) -> AppResult<Value> {
         let config = self.load_config()?;
+        let store = JiraProfilesFile::load()?;
         Ok(json!({
-            "configured": !config.base_url.is_empty() && !config.email.is_empty(),
-            "url": value_or_null(config.base_url),
-            "email": value_or_null(config.email),
-            "token_present": config.token.is_some(),
+            "configured": !config.base_url.is_empty() && (!config.requires_user_identity() || !config.email.is_empty()),
+            "profile": config.profile_name.clone(),
+            "url": value_or_null(config.base_url.clone()),
+            "email": value_or_null(config.email.clone()),
+            "token_present": config.token_present(),
             "project": config.project,
             "timeout_secs": config.timeout_secs,
+            "deployment": format!("{:?}", config.deployment).to_lowercase(),
+            "auth_type": format!("{:?}", config.auth_type).to_lowercase(),
+            "api_version": config.api_version,
+            "profiles": store.profiles.keys().cloned().collect::<Vec<_>>(),
             "config_path": config_file_path().display().to_string()
         }))
     }
@@ -46,13 +55,29 @@ impl JiraApp {
             && args.token.is_none()
             && args.project.is_none()
             && args.timeout_secs.is_none()
+            && args.deployment.is_none()
+            && args.auth_type.is_none()
         {
             return Err(AppError::validation(
-                "Provide at least one of url, email, token, project, or timeout_secs",
+                "Provide at least one of url, email, token, project, timeout_secs, deployment, or auth_type",
             ));
         }
 
-        let mut config = self.load_config().unwrap_or_default();
+        let store = JiraProfilesFile::load().unwrap_or_default();
+        let profile_name = args
+            .profile
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| store.current_profile_name())
+            .unwrap_or_else(default_profile_name);
+
+        let mut config: JiraConfig = store
+            .profiles
+            .get(&profile_name)
+            .cloned()
+            .map(Into::into)
+            .unwrap_or_else(JiraConfig::default);
+        config.profile_name = Some(profile_name.clone());
 
         if let Some(url) = args.url {
             config.base_url = url.trim().to_string();
@@ -72,6 +97,21 @@ impl JiraApp {
         }
         if let Some(timeout_secs) = args.timeout_secs {
             config.timeout_secs = timeout_secs;
+        }
+        if let Some(deployment) = args.deployment {
+            config.deployment = parse_deployment(&deployment)
+                .ok_or_else(|| AppError::validation("deployment must be cloud or datacenter"))?;
+            config.api_version = 0;
+        }
+        if let Some(auth_type) = args.auth_type {
+            config.auth_type = parse_auth_type(&auth_type).ok_or_else(|| {
+                AppError::validation(
+                    "auth_type must be cloud_api_token, datacenter_pat, or datacenter_basic",
+                )
+            })?;
+        }
+        if !config.requires_user_identity() {
+            config.email.clear();
         }
 
         config.save()?;
@@ -467,12 +507,12 @@ impl JiraApp {
                 "Jira URL not configured. Set JIRA_URL or save credentials first.",
             ));
         }
-        if config.email.trim().is_empty() {
+        if config.requires_user_identity() && config.email.trim().is_empty() {
             return Err(AppError::auth_missing(
-                "Jira email not configured. Set JIRA_EMAIL or save credentials first.",
+                "Jira user identity not configured. Set JIRA_EMAIL or save credentials first.",
             ));
         }
-        if config.token.as_deref().unwrap_or("").trim().is_empty() {
+        if !config.token_present() {
             return Err(AppError::auth_missing(
                 "Jira API token not configured. Set JIRA_TOKEN or save credentials first.",
             ));
@@ -703,11 +743,14 @@ mod tests {
 
         let status = JiraApp
             .auth_set_credentials(AuthSetCredentialsArgs {
+                profile: None,
                 url: Some("https://example.atlassian.net".into()),
                 email: Some("dev@example.com".into()),
                 token: Some("secret".into()),
                 project: Some("PROJ".into()),
                 timeout_secs: Some(45),
+                deployment: None,
+                auth_type: None,
             })
             .expect("set credentials");
         assert_eq!(status["token_present"], Value::Bool(true));

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -11,11 +11,14 @@ pub struct ToolResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AuthSetCredentialsArgs {
+    pub profile: Option<String>,
     pub url: Option<String>,
     pub email: Option<String>,
     pub token: Option<String>,
     pub project: Option<String>,
     pub timeout_secs: Option<u64>,
+    pub deployment: Option<String>,
+    pub auth_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -1,152 +1,410 @@
 use anyhow::{Context, Result};
-use clap::Subcommand;
-use inquire::{Password, PasswordDisplayMode, Text};
-use jira_core::config::{config_file_path, JiraConfig};
+use clap::{Subcommand, ValueEnum};
+use inquire::{Password, PasswordDisplayMode, Select, Text};
+use jira_core::config::{
+    config_file_path, default_profile_name, JiraAuthType, JiraConfig, JiraDeployment,
+    JiraProfilesFile,
+};
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum DeploymentArg {
+    Cloud,
+    Datacenter,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum AuthTypeArg {
+    CloudApiToken,
+    DatacenterPat,
+    DatacenterBasic,
+}
 
 #[derive(Debug, Subcommand)]
 pub enum AuthCommand {
-    /// Set up Jira credentials — URL, email, and API token
+    /// Set up Jira credentials — URL, email/username, and token/password
     ///
     /// Credentials are saved to ~/.config/jira/config.toml (chmod 600 on Unix).
-    /// Override any field at runtime with environment variables:
-    ///   JIRA_URL, JIRA_EMAIL, JIRA_TOKEN
-    ///
-    /// API tokens are different from your Atlassian password.
-    /// Generate one at: https://id.atlassian.com/manage-profile/security/api-tokens
-    Login,
-
-    /// Remove the stored API token
-    ///
-    /// Clears only the token — URL and email are preserved.
-    /// Run `jirac auth login` again to set a new token.
-    Logout,
-
-    /// Show current authentication status and configuration
-    ///
-    /// Displays: Jira URL, email, token presence, config file path,
-    /// and default project key (if configured).
-    Status,
-
-    /// Update individual credential fields without re-running login
-    ///
-    /// Useful for rotating tokens or switching users without entering
-    /// all credentials again. Only provided flags are changed.
-    ///
-    /// Examples:
-    ///   jira auth update --token <new-token>
-    ///   jira auth update --email new@example.com
-    ///   jira auth update --url https://neworg.atlassian.net
-    ///   jira auth update --email new@example.com --token <token>
-    Update {
-        /// New Jira base URL (e.g. https://yourorg.atlassian.net)
+    /// Override the active runtime profile with environment variables:
+    ///   JIRA_PROFILE, JIRA_URL, JIRA_EMAIL, JIRA_TOKEN
+    Login {
+        /// Profile name to save as active (defaults to hostname-derived name)
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Jira base URL (e.g. https://yourorg.atlassian.net)
         #[arg(long, value_name = "URL")]
         url: Option<String>,
-        /// New email address
-        #[arg(long, value_name = "EMAIL")]
+        /// Email address or username depending on auth type
+        #[arg(long, value_name = "USER")]
         email: Option<String>,
-        /// New API token
-        #[arg(long, value_name = "TOKEN")]
+        /// API token / personal access token / password depending on auth type
+        #[arg(long, value_name = "SECRET")]
         token: Option<String>,
+        /// Default project key
+        #[arg(long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Request timeout in seconds
+        #[arg(long, value_name = "SECONDS")]
+        timeout_secs: Option<u64>,
+        /// Deployment target: cloud or datacenter
+        #[arg(long, value_enum)]
+        deployment: Option<DeploymentArg>,
+        /// Authentication mode
+        #[arg(long = "auth-type", value_enum)]
+        auth_type: Option<AuthTypeArg>,
+    },
+
+    /// Remove stored token(s) without deleting profile metadata
+    Logout {
+        /// Target a specific profile
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// Clear tokens for all saved profiles
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Show current authentication status and active profile
+    Status {
+        /// Show a specific profile instead of the active one
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+    },
+
+    /// List saved profiles
+    Profiles,
+
+    /// Switch the active profile
+    Use {
+        /// Profile name to activate
+        profile: String,
+    },
+
+    /// Update one profile without re-running login
+    Update {
+        /// Target a specific profile (defaults to active profile)
+        #[arg(long, value_name = "PROFILE")]
+        profile: Option<String>,
+        /// New Jira base URL
+        #[arg(long, value_name = "URL")]
+        url: Option<String>,
+        /// New email or username
+        #[arg(long, value_name = "USER")]
+        email: Option<String>,
+        /// New token / PAT / password
+        #[arg(long, value_name = "SECRET")]
+        token: Option<String>,
+        /// New default project (use empty string to clear)
+        #[arg(long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// New timeout in seconds
+        #[arg(long, value_name = "SECONDS")]
+        timeout_secs: Option<u64>,
+        /// New deployment target
+        #[arg(long, value_enum)]
+        deployment: Option<DeploymentArg>,
+        /// New auth mode
+        #[arg(long = "auth-type", value_enum)]
+        auth_type: Option<AuthTypeArg>,
     },
 }
 
 pub async fn handle(cmd: AuthCommand) -> Result<()> {
     match cmd {
-        AuthCommand::Login => login().await,
-        AuthCommand::Logout => logout().await,
-        AuthCommand::Status => status().await,
-        AuthCommand::Update { url, email, token } => update(url, email, token).await,
+        AuthCommand::Login {
+            profile,
+            url,
+            email,
+            token,
+            project,
+            timeout_secs,
+            deployment,
+            auth_type,
+        } => {
+            login(LoginArgs {
+                profile,
+                url,
+                email,
+                token,
+                project,
+                timeout_secs,
+                deployment,
+                auth_type,
+            })
+            .await
+        }
+        AuthCommand::Logout { profile, all } => logout(profile, all).await,
+        AuthCommand::Status { profile } => status(profile).await,
+        AuthCommand::Profiles => profiles().await,
+        AuthCommand::Use { profile } => use_profile(profile).await,
+        AuthCommand::Update {
+            profile,
+            url,
+            email,
+            token,
+            project,
+            timeout_secs,
+            deployment,
+            auth_type,
+        } => {
+            update(UpdateArgs {
+                profile,
+                url,
+                email,
+                token,
+                project,
+                timeout_secs,
+                deployment,
+                auth_type,
+            })
+            .await
+        }
     }
 }
 
-async fn login() -> Result<()> {
+struct LoginArgs {
+    profile: Option<String>,
+    url: Option<String>,
+    email: Option<String>,
+    token: Option<String>,
+    project: Option<String>,
+    timeout_secs: Option<u64>,
+    deployment: Option<DeploymentArg>,
+    auth_type: Option<AuthTypeArg>,
+}
+
+struct UpdateArgs {
+    profile: Option<String>,
+    url: Option<String>,
+    email: Option<String>,
+    token: Option<String>,
+    project: Option<String>,
+    timeout_secs: Option<u64>,
+    deployment: Option<DeploymentArg>,
+    auth_type: Option<AuthTypeArg>,
+}
+
+async fn login(args: LoginArgs) -> Result<()> {
     println!("Jira Authentication Setup");
     println!("─────────────────────────");
 
-    let base_url = Text::new("Jira base URL (e.g. https://yourorg.atlassian.net):")
-        .prompt()
-        .context("Failed to read URL")?;
+    let base_url = match args.url {
+        Some(url) => url.trim().to_string(),
+        None => Text::new("Jira base URL (e.g. https://yourorg.atlassian.net):")
+            .prompt()
+            .context("Failed to read URL")?
+            .trim()
+            .to_string(),
+    };
 
-    let email = Text::new("Email address:")
-        .prompt()
-        .context("Failed to read email")?;
+    let deployment = args
+        .deployment
+        .clone()
+        .map(Into::into)
+        .unwrap_or_else(|| infer_deployment(&base_url));
+    let deployment = if args.deployment.is_some() {
+        deployment
+    } else {
+        prompt_deployment(deployment.clone())?
+    };
 
-    let token = Password::new(
-        "API token (from https://id.atlassian.com/manage-profile/security/api-tokens):",
-    )
-    .with_display_mode(PasswordDisplayMode::Masked)
-    .prompt()
-    .context("Failed to read token")?;
+    let auth_type = args
+        .auth_type
+        .clone()
+        .map(Into::into)
+        .unwrap_or_else(|| default_auth_type(&deployment));
+    let auth_type = if args.auth_type.is_some() {
+        auth_type
+    } else {
+        prompt_auth_type(&deployment, auth_type.clone())?
+    };
 
-    let mut config = JiraConfig::load().unwrap_or_default();
-    config.base_url = base_url.trim().to_string();
-    config.email = email.trim().to_string();
-    config.token = Some(token);
+    let mut config = JiraConfig {
+        profile_name: None,
+        base_url,
+        email: String::new(),
+        token: None,
+        project: args.project.and_then(normalize_optional),
+        timeout_secs: args.timeout_secs.unwrap_or(30),
+        deployment,
+        auth_type,
+        api_version: 0,
+    };
 
+    if config.requires_user_identity() {
+        config.email = match args.email {
+            Some(email) => email.trim().to_string(),
+            None => Text::new(config.user_label())
+                .prompt()
+                .context("Failed to read user identity")?
+                .trim()
+                .to_string(),
+        };
+    }
+
+    let secret_prompt = format!("{}:", config.credential_label());
+    let secret = match args.token {
+        Some(token) => token,
+        None => Password::new(&secret_prompt)
+            .with_display_mode(PasswordDisplayMode::Masked)
+            .prompt()
+            .context("Failed to read secret")?,
+    };
+    config.token = Some(secret);
+
+    let profile_name = args
+        .profile
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| derive_profile_name(&config));
+    config.profile_name = Some(profile_name.clone());
     config.save().context("Failed to save config")?;
 
-    println!("\n✓ Credentials saved to {}", config_file_path().display());
+    println!("\n✓ Profile '{profile_name}' saved to {}", config_file_path().display());
+    println!("  Deployment: {}", deployment_label(&config.deployment));
+    println!("  Auth:       {}", auth_type_label(&config.auth_type));
 
     Ok(())
 }
 
-async fn logout() -> Result<()> {
-    let mut config = JiraConfig::load().unwrap_or_default();
+async fn logout(profile: Option<String>, all: bool) -> Result<()> {
+    let mut store = JiraProfilesFile::load().unwrap_or_default();
 
-    if config.email.is_empty() {
+    if store.profiles.is_empty() {
         println!("No credentials found.");
         return Ok(());
     }
 
-    config.token = None;
-    config.save().context("Failed to update config")?;
+    if all {
+        for config in store.profiles.values_mut() {
+            config.token = None;
+        }
+        store.save().context("Failed to update config")?;
+        println!("✓ Logged out from all profiles.");
+        return Ok(());
+    }
 
-    println!("✓ Logged out ({}).", config.email);
+    let target = profile
+        .or_else(|| store.current_profile_name())
+        .unwrap_or_else(default_profile_name);
+    let config = store
+        .profiles
+        .get_mut(&target)
+        .ok_or_else(|| anyhow::anyhow!("Profile not found: {target}"))?;
+    config.token = None;
+    store.current_profile = Some(target.clone());
+    store.save().context("Failed to update config")?;
+
+    println!("✓ Logged out from profile '{target}'.");
     Ok(())
 }
 
-async fn update(url: Option<String>, email: Option<String>, token: Option<String>) -> Result<()> {
-    if url.is_none() && email.is_none() && token.is_none() {
-        anyhow::bail!("Nothing to update. Use --url, --email, or --token.");
+async fn update(args: UpdateArgs) -> Result<()> {
+    if args.url.is_none()
+        && args.email.is_none()
+        && args.token.is_none()
+        && args.project.is_none()
+        && args.timeout_secs.is_none()
+        && args.deployment.is_none()
+        && args.auth_type.is_none()
+    {
+        anyhow::bail!(
+            "Nothing to update. Use --url, --email, --token, --project, --timeout-secs, --deployment, or --auth-type."
+        );
     }
 
-    let mut config = JiraConfig::load().unwrap_or_default();
+    let store = JiraProfilesFile::load().unwrap_or_default();
+    let target = args
+        .profile
+        .or_else(|| store.current_profile_name())
+        .unwrap_or_else(default_profile_name);
 
-    if let Some(u) = url {
-        config.base_url = u.trim().to_string();
-        println!("✓ URL updated.");
+    let mut config: JiraConfig = store
+        .profiles
+        .get(&target)
+        .cloned()
+        .map(Into::into)
+        .unwrap_or_else(JiraConfig::default);
+    config.profile_name = Some(target.clone());
+
+    if let Some(url) = args.url {
+        config.base_url = url.trim().to_string();
     }
-    if let Some(e) = email {
-        config.email = e.trim().to_string();
-        println!("✓ Email updated.");
+    if let Some(email) = args.email {
+        config.email = email.trim().to_string();
     }
-    if let Some(t) = token {
-        config.token = Some(t);
-        println!("✓ Token updated.");
+    if let Some(token) = args.token {
+        config.token = Some(token);
+    }
+    if let Some(project) = args.project {
+        config.project = normalize_optional(project);
+    }
+    if let Some(timeout_secs) = args.timeout_secs {
+        config.timeout_secs = timeout_secs;
+    }
+    if let Some(deployment) = args.deployment {
+        config.deployment = deployment.into();
+        if matches!(config.auth_type, JiraAuthType::CloudApiToken)
+            && matches!(config.deployment, JiraDeployment::DataCenter)
+        {
+            config.auth_type = JiraAuthType::DataCenterPat;
+        }
+        if matches!(config.auth_type, JiraAuthType::DataCenterPat | JiraAuthType::DataCenterBasic)
+            && matches!(config.deployment, JiraDeployment::Cloud)
+        {
+            config.auth_type = JiraAuthType::CloudApiToken;
+        }
+        config.api_version = 0;
+    }
+    if let Some(auth_type) = args.auth_type {
+        config.auth_type = auth_type.into();
+    }
+    if !config.requires_user_identity() {
+        config.email = String::new();
     }
 
     config.save().context("Failed to save config")?;
+    println!("✓ Profile '{target}' updated.");
     Ok(())
 }
 
-async fn status() -> Result<()> {
-    let config = JiraConfig::load().unwrap_or_default();
+async fn status(profile: Option<String>) -> Result<()> {
+    let store = JiraProfilesFile::load().unwrap_or_default();
+    let config = if let Some(profile_name) = profile.as_ref() {
+        let mut config: JiraConfig = store
+            .profiles
+            .get(profile_name)
+            .cloned()
+            .map(Into::into)
+            .ok_or_else(|| anyhow::anyhow!("Profile not found: {profile_name}"))?;
+        config.profile_name = Some(profile_name.clone());
+        config
+    } else {
+        JiraConfig::load().unwrap_or_default()
+    };
 
-    if config.base_url.is_empty() || config.email.is_empty() {
+    if config.base_url.is_empty() && !config.token_present() {
         println!("Not configured. Run `jirac auth login` to set up.");
         return Ok(());
     }
 
     println!("Authentication Status");
     println!("─────────────────────");
-    println!("  URL:   {}", config.base_url);
-    println!("  Email: {}", config.email);
-
-    if config.token.is_some() {
-        println!("  Token: ✓ stored in {}", config_file_path().display());
-    } else {
-        println!("  Token: ✗ not found — run `jirac auth login`");
+    println!(
+        "  Active profile: {}",
+        config.profile_name.as_deref().unwrap_or("default")
+    );
+    println!("  URL:            {}", config.base_url);
+    println!("  Deployment:     {}", deployment_label(&config.deployment));
+    println!("  Auth:           {}", auth_type_label(&config.auth_type));
+    if config.requires_user_identity() {
+        println!("  User:           {}", config.email);
     }
+    if config.token_present() {
+        println!("  Secret:         ✓ stored in {}", config_file_path().display());
+    } else {
+        println!("  Secret:         ✗ not found — run `jirac auth login`");
+    }
+    println!("  API version:    {}", config.api_version);
+    println!("  Profiles saved: {}", store.profiles.len().max(1));
 
     if let Some(project) = &config.project {
         println!("  Default project: {project}");
@@ -154,3 +412,164 @@ async fn status() -> Result<()> {
 
     Ok(())
 }
+
+async fn profiles() -> Result<()> {
+    let store = JiraProfilesFile::load().unwrap_or_default();
+    if store.profiles.is_empty() {
+        println!("No saved profiles. Run `jirac auth login` to create one.");
+        return Ok(());
+    }
+
+    println!("Saved profiles");
+    println!("──────────────");
+    let current = store.current_profile_name();
+    for (name, profile) in store.profiles {
+        let marker = if current.as_deref() == Some(name.as_str()) {
+            "*"
+        } else {
+            " "
+        };
+        let user_suffix = if profile.email.trim().is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", profile.email)
+        };
+        println!(
+            "{marker} {name} — {} · {} · api v{}{}",
+            deployment_label(&profile.deployment),
+            auth_type_label(&profile.auth_type),
+            profile.api_version,
+            user_suffix,
+        );
+    }
+
+    Ok(())
+}
+
+async fn use_profile(profile: String) -> Result<()> {
+    let mut store = JiraProfilesFile::load().unwrap_or_default();
+    store
+        .set_current_profile(&profile)
+        .context("Failed to switch profile")?;
+    store.save().context("Failed to save config")?;
+
+    println!("✓ Active profile set to '{profile}'.");
+    Ok(())
+}
+
+fn prompt_deployment(default: JiraDeployment) -> Result<JiraDeployment> {
+    let options = vec!["Cloud", "Data Center"];
+    let selection = Select::new("Deployment type:", options)
+        .with_starting_cursor(match default {
+            JiraDeployment::Cloud => 0,
+            JiraDeployment::DataCenter => 1,
+        })
+        .prompt()?;
+
+    Ok(match selection {
+        "Cloud" => JiraDeployment::Cloud,
+        _ => JiraDeployment::DataCenter,
+    })
+}
+
+fn prompt_auth_type(deployment: &JiraDeployment, default: JiraAuthType) -> Result<JiraAuthType> {
+    let options = match deployment {
+        JiraDeployment::Cloud => vec!["Cloud API token"],
+        JiraDeployment::DataCenter => vec!["Data Center PAT", "Data Center basic"],
+    };
+
+    let selection = Select::new("Authentication mode:", options)
+        .with_starting_cursor(match default {
+            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterPat => 0,
+            JiraAuthType::DataCenterBasic => 1,
+        })
+        .prompt()?;
+
+    Ok(match selection {
+        "Cloud API token" => JiraAuthType::CloudApiToken,
+        "Data Center basic" => JiraAuthType::DataCenterBasic,
+        _ => JiraAuthType::DataCenterPat,
+    })
+}
+
+fn infer_deployment(base_url: &str) -> JiraDeployment {
+    if base_url.contains("atlassian.net") {
+        JiraDeployment::Cloud
+    } else {
+        JiraDeployment::DataCenter
+    }
+}
+
+fn default_auth_type(deployment: &JiraDeployment) -> JiraAuthType {
+    match deployment {
+        JiraDeployment::Cloud => JiraAuthType::CloudApiToken,
+        JiraDeployment::DataCenter => JiraAuthType::DataCenterPat,
+    }
+}
+
+fn derive_profile_name(config: &JiraConfig) -> String {
+    let host = config
+        .base_url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or("jira")
+        .replace(':', "-");
+
+    if config.email.trim().is_empty() {
+        host
+    } else {
+        let user = config
+            .email
+            .split('@')
+            .next()
+            .unwrap_or("user")
+            .replace(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_', "-");
+        format!("{host}-{user}")
+    }
+}
+
+fn normalize_optional(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn deployment_label(value: &JiraDeployment) -> &'static str {
+    match value {
+        JiraDeployment::Cloud => "Cloud",
+        JiraDeployment::DataCenter => "Data Center",
+    }
+}
+
+fn auth_type_label(value: &JiraAuthType) -> &'static str {
+    match value {
+        JiraAuthType::CloudApiToken => "Cloud API token",
+        JiraAuthType::DataCenterPat => "Data Center PAT",
+        JiraAuthType::DataCenterBasic => "Data Center basic",
+    }
+}
+
+impl From<DeploymentArg> for JiraDeployment {
+    fn from(value: DeploymentArg) -> Self {
+        match value {
+            DeploymentArg::Cloud => JiraDeployment::Cloud,
+            DeploymentArg::Datacenter => JiraDeployment::DataCenter,
+        }
+    }
+}
+
+impl From<AuthTypeArg> for JiraAuthType {
+    fn from(value: AuthTypeArg) -> Self {
+        match value {
+            AuthTypeArg::CloudApiToken => JiraAuthType::CloudApiToken,
+            AuthTypeArg::DatacenterPat => JiraAuthType::DataCenterPat,
+            AuthTypeArg::DatacenterBasic => JiraAuthType::DataCenterBasic,
+        }
+    }
+}
+

--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -258,7 +258,10 @@ async fn login(args: LoginArgs) -> Result<()> {
     config.profile_name = Some(profile_name.clone());
     config.save().context("Failed to save config")?;
 
-    println!("\n✓ Profile '{profile_name}' saved to {}", config_file_path().display());
+    println!(
+        "\n✓ Profile '{profile_name}' saved to {}",
+        config_file_path().display()
+    );
     println!("  Deployment: {}", deployment_label(&config.deployment));
     println!("  Auth:       {}", auth_type_label(&config.auth_type));
 
@@ -347,8 +350,10 @@ async fn update(args: UpdateArgs) -> Result<()> {
         {
             config.auth_type = JiraAuthType::DataCenterPat;
         }
-        if matches!(config.auth_type, JiraAuthType::DataCenterPat | JiraAuthType::DataCenterBasic)
-            && matches!(config.deployment, JiraDeployment::Cloud)
+        if matches!(
+            config.auth_type,
+            JiraAuthType::DataCenterPat | JiraAuthType::DataCenterBasic
+        ) && matches!(config.deployment, JiraDeployment::Cloud)
         {
             config.auth_type = JiraAuthType::CloudApiToken;
         }
@@ -399,7 +404,10 @@ async fn status(profile: Option<String>) -> Result<()> {
         println!("  User:           {}", config.email);
     }
     if config.token_present() {
-        println!("  Secret:         ✓ stored in {}", config_file_path().display());
+        println!(
+            "  Secret:         ✓ stored in {}",
+            config_file_path().display()
+        );
     } else {
         println!("  Secret:         ✗ not found — run `jirac auth login`");
     }
@@ -520,12 +528,10 @@ fn derive_profile_name(config: &JiraConfig) -> String {
     if config.email.trim().is_empty() {
         host
     } else {
-        let user = config
-            .email
-            .split('@')
-            .next()
-            .unwrap_or("user")
-            .replace(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_', "-");
+        let user = config.email.split('@').next().unwrap_or("user").replace(
+            |ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_',
+            "-",
+        );
         format!("{host}-{user}")
     }
 }
@@ -572,4 +578,3 @@ impl From<AuthTypeArg> for JiraAuthType {
         }
     }
 }
-

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -126,13 +126,13 @@ fn build_client() -> Result<JiraClient> {
         );
     }
 
-    if config.email.is_empty() {
+    if config.requires_user_identity() && config.email.trim().is_empty() {
         anyhow::bail!(
-            "Email not configured. Run `jirac auth login` or set JIRA_EMAIL environment variable."
+            "User identity not configured. Run `jirac auth login` or set JIRA_EMAIL environment variable."
         );
     }
 
-    if config.token.is_none() {
+    if !config.token_present() {
         anyhow::bail!(
             "API token not found. Run `jirac auth login` or set JIRA_TOKEN environment variable."
         );


### PR DESCRIPTION
## Summary
- add profile-based multi-login for Jira Cloud and Jira Data Center
- support Data Center PAT/bearer auth, basic auth, and deployment-aware REST API version selection
- document the new login/profile flows and keep the Chocolatey publish fix in the same branch

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all
- cargo build --all
