### PR TITLE
fix: match archived artifact paths in release checksums

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -389,11 +389,11 @@ jobs:
           echo "=== checksums.txt ==="
           cat checksums.txt
 
-          SHA_MACOS_ARM=$(grep ' jirac-macos-aarch64.tar.gz$' checksums.txt | awk '{print $1}')
-          SHA_MACOS_X86=$(grep ' jirac-macos-x86_64.tar.gz$'  checksums.txt | awk '{print $1}')
-          SHA_LINUX_ARM=$(grep ' jirac-linux-aarch64.tar.gz$'  checksums.txt | awk '{print $1}')
-          SHA_LINUX_X86=$(grep ' jirac-linux-x86_64.tar.gz$'   checksums.txt | awk '{print $1}')
-          SHA_WINDOWS_X86=$(grep ' jirac-windows-x86_64.zip$' checksums.txt | awk '{print $1}')
+          SHA_MACOS_ARM=$(grep -E '(^|/)jirac-macos-aarch64\.tar\.gz$' checksums.txt | awk '{print $1}')
+          SHA_MACOS_X86=$(grep -E '(^|/)jirac-macos-x86_64\.tar\.gz$'  checksums.txt | awk '{print $1}')
+          SHA_LINUX_ARM=$(grep -E '(^|/)jirac-linux-aarch64\.tar\.gz$'  checksums.txt | awk '{print $1}')
+          SHA_LINUX_X86=$(grep -E '(^|/)jirac-linux-x86_64\.tar\.gz$'   checksums.txt | awk '{print $1}')
+          SHA_WINDOWS_X86=$(grep -E '(^|/)jirac-windows-x86_64\.zip$' checksums.txt | awk '{print $1}')
 
           test -n "$SHA_MACOS_ARM"
           test -n "$SHA_MACOS_X86"


### PR DESCRIPTION
## Summary
- fix release manifest refresh parsing for packaged artifact checksums
- match archive filenames even when checksums.txt stores artifact subpaths

## Why
The release job now writes checksums for files under artifact subdirectories like `artifacts/.../jirac-macos-aarch64.tar.gz`, but the manifest refresh step still expected bare filenames at the end of the line. That caused checksum extraction to fail and skipped downstream package refresh jobs.

## Impact
- fixes release-time refresh of Winget/Chocolatey/Homebrew metadata
- narrow hotfix, no source/runtime behavior changes
