### PR TITLE
feat: improve ADF rendering, issue create ergonomics, and TUI workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ jirac issue list --jql "status = 'In Progress'"     # custom JQL
 jirac issue view PROJ-123                           # view detail
 jirac issue create -p PROJ                          # create (interactive)
 jirac issue create -p PROJ --type Bug --summary "Login fails on Safari"
+jirac issue render --input desc.md                  # preview Markdown -> ADF JSON
+jirac issue render --input desc.md --output text    # preview rendered plain text
 
 jirac issue update PROJ-123 --summary "New title"
 jirac issue update PROJ-123 --assignee user@co.com

--- a/crates/jira-core/src/adf.rs
+++ b/crates/jira-core/src/adf.rs
@@ -201,7 +201,8 @@ pub fn markdown_to_adf(markdown: &str) -> Value {
     use comrak::{parse_document, Arena, Options};
 
     let arena = Arena::new();
-    let options = Options::default();
+    let mut options = Options::default();
+    options.extension.table = true;
     let root = parse_document(&arena, markdown, &options);
 
     let mut content: Vec<Value> = Vec::new();
@@ -458,6 +459,13 @@ fn render_markdown_table<'a>(
         let mut cells: Vec<Value> = Vec::new();
         for cell in row.children() {
             let mut block_content: Vec<Value> = Vec::new();
+            let inline_content = collect_inline_children(cell, unsupported);
+            if !inline_content.is_empty() {
+                block_content.push(json!({
+                    "type": "paragraph",
+                    "content": inline_content
+                }));
+            }
             for child in cell.children() {
                 convert_node(child, &mut block_content, unsupported);
             }
@@ -527,9 +535,25 @@ mod tests {
     }
 
     #[test]
-    fn test_markdown_to_adf_table_falls_back_without_table_extension() {
+    fn test_markdown_to_adf_table_support() {
         let adf = markdown_to_adf("| Name | Status |\n| --- | --- |\n| API | Done |");
-        assert_eq!(adf["content"][0]["type"], "paragraph");
+        assert_eq!(adf["content"][0]["type"], "table");
+        assert_eq!(
+            adf["content"][0]["content"][0]["content"][0]["type"],
+            "tableHeader"
+        );
+        assert_eq!(
+            adf["content"][0]["content"][1]["content"][1]["type"],
+            "tableCell"
+        );
+        assert_eq!(
+            adf["content"][0]["content"][0]["content"][0]["content"][0]["content"][0]["text"],
+            "Name"
+        );
+        assert_eq!(
+            adf["content"][0]["content"][1]["content"][1]["content"][0]["content"][0]["text"],
+            "Done"
+        );
     }
 
     #[test]

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -561,11 +561,30 @@ impl JiraClient {
 
         #[derive(serde::Deserialize)]
         struct FieldMetaResponse {
-            fields: std::collections::HashMap<String, FieldMeta>,
+            fields: FieldCollection,
         }
 
         #[derive(serde::Deserialize)]
-        struct FieldMeta {
+        #[serde(untagged)]
+        enum FieldCollection {
+            Map(std::collections::HashMap<String, FieldMetaMap>),
+            List(Vec<FieldMetaEntry>),
+        }
+
+        #[derive(serde::Deserialize)]
+        struct FieldMetaMap {
+            name: String,
+            required: bool,
+            schema: Option<Value>,
+            #[serde(rename = "allowedValues")]
+            allowed_values: Option<Vec<Value>>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct FieldMetaEntry {
+            #[serde(rename = "fieldId")]
+            field_id: Option<String>,
+            key: Option<String>,
             name: String,
             required: bool,
             schema: Option<Value>,
@@ -578,28 +597,52 @@ impl JiraClient {
             .request(|| http.get(&url).headers(headers.clone()))
             .await?;
 
-        let fields = resp
-            .fields
-            .into_iter()
-            .map(|(id, meta)| {
-                let field_type = meta
-                    .schema
-                    .as_ref()
-                    .and_then(|s| s.get("type"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
+        let fields = match resp.fields {
+            FieldCollection::Map(fields) => fields
+                .into_iter()
+                .map(|(id, meta)| {
+                    let field_type = meta
+                        .schema
+                        .as_ref()
+                        .and_then(|s| s.get("type"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
 
-                Field {
-                    id,
-                    name: meta.name,
-                    field_type,
-                    required: meta.required,
-                    schema: meta.schema,
-                    allowed_values: meta.allowed_values,
-                }
-            })
-            .collect();
+                    Field {
+                        id,
+                        name: meta.name,
+                        field_type,
+                        required: meta.required,
+                        schema: meta.schema,
+                        allowed_values: meta.allowed_values,
+                    }
+                })
+                .collect(),
+            FieldCollection::List(fields) => fields
+                .into_iter()
+                .map(|meta| {
+                    let field_type = meta
+                        .schema
+                        .as_ref()
+                        .and_then(|s| s.get("type"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+
+                    let id = meta.field_id.or(meta.key).unwrap_or_default();
+
+                    Field {
+                        id,
+                        name: meta.name,
+                        field_type,
+                        required: meta.required,
+                        schema: meta.schema,
+                        allowed_values: meta.allowed_values,
+                    }
+                })
+                .collect(),
+        };
 
         Ok(fields)
     }
@@ -1297,5 +1340,100 @@ mod tests {
 
         let info = client.get_server_info().await.expect("server info");
         assert_eq!(info["deploymentType"], Value::String("Cloud".into()));
+    }
+
+    #[tokio::test]
+    async fn get_fields_for_issue_type_supports_map_response() {
+        let server = MockServer::start().await;
+        let expected = format!("Basic {}", base64_encode("dev@example.com:cloud-token"));
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/createmeta/TEST/issuetypes/10001"))
+            .and(header("authorization", expected.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "fields": {
+                    "summary": {
+                        "name": "Summary",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = JiraClient::new(JiraConfig {
+            profile_name: Some("cloud-main".into()),
+            base_url: server.uri(),
+            email: "dev@example.com".into(),
+            token: Some("cloud-token".into()),
+            project: None,
+            timeout_secs: 30,
+            deployment: JiraDeployment::Cloud,
+            auth_type: JiraAuthType::CloudApiToken,
+            api_version: 3,
+        });
+
+        let fields = client
+            .get_fields_for_issue_type("TEST", "10001")
+            .await
+            .expect("map response should parse");
+
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].id, "summary");
+        assert_eq!(fields[0].name, "Summary");
+        assert!(fields[0].required);
+        assert_eq!(fields[0].field_type, "string");
+    }
+
+    #[tokio::test]
+    async fn get_fields_for_issue_type_supports_list_response() {
+        let server = MockServer::start().await;
+        let expected = format!("Basic {}", base64_encode("dev@example.com:cloud-token"));
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/createmeta/TEST/issuetypes/10002"))
+            .and(header("authorization", expected.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "fields": [
+                    {
+                        "fieldId": "customfield_10553",
+                        "key": "customfield_10553",
+                        "name": "Labels (OSS)",
+                        "required": true,
+                        "schema": {
+                            "custom": "com.atlassian.jira.plugin.system.customfieldtypes:labels",
+                            "items": "string",
+                            "type": "array"
+                        },
+                        "allowedValues": []
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = JiraClient::new(JiraConfig {
+            profile_name: Some("cloud-main".into()),
+            base_url: server.uri(),
+            email: "dev@example.com".into(),
+            token: Some("cloud-token".into()),
+            project: None,
+            timeout_secs: 30,
+            deployment: JiraDeployment::Cloud,
+            auth_type: JiraAuthType::CloudApiToken,
+            api_version: 3,
+        });
+
+        let fields = client
+            .get_fields_for_issue_type("TEST", "10002")
+            .await
+            .expect("list response should parse");
+
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].id, "customfield_10553");
+        assert_eq!(fields[0].name, "Labels (OSS)");
+        assert!(fields[0].required);
+        assert_eq!(fields[0].field_type, "array");
     }
 }

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -38,6 +38,7 @@ jirac auth profiles
 jirac issue list
 jirac issue view MYPROJ-123
 jirac issue create -p MYPROJ
+jirac issue render --input desc.md
 jirac tui -p MYPROJ
 ```
 

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -80,6 +80,7 @@ pub enum IssueCommand {
     ///   jirac issue create -p PROJ -s "Sub-task" -t Sub-task --parent PROJ-100
     ///   jirac issue create -p PROJ -s "Feat" --description-file description.md
     ///   jirac issue create -p PROJ -s "Fix" --field story_points=5 --field customfield_10020=sprint1
+    ///   jirac issue create -p PROJ -s "Plan sprint work" --issue-type Task --sprint "Sprint 24"
     Create {
         /// Project key (e.g. PROJ)
         #[arg(short, long, value_name = "PROJECT")]
@@ -114,6 +115,9 @@ pub enum IssueCommand {
         /// Fix version name(s) to set (comma-separated, e.g. "v1.0,v1.1")
         #[arg(long, value_name = "VERSIONS")]
         fix_version: Option<String>,
+        /// Sprint to assign on create — accepts a sprint ID or exact sprint name
+        #[arg(long, value_name = "SPRINT_ID|NAME")]
+        sprint: Option<String>,
         /// Attach file(s) after creating the issue
         #[arg(long, value_name = "FILE")]
         attachments: Vec<std::path::PathBuf>,
@@ -667,6 +671,7 @@ pub async fn handle(
             components,
             parent,
             fix_version,
+            sprint,
             attachments,
             field,
             no_custom_fields,
@@ -685,6 +690,7 @@ pub async fn handle(
                 components,
                 parent,
                 fix_version,
+                sprint,
                 attachments,
                 field,
                 no_custom_fields,
@@ -921,6 +927,7 @@ async fn create_issue(
     components: Option<String>,
     parent: Option<String>,
     fix_version: Option<String>,
+    sprint: Option<String>,
     attachments: Vec<std::path::PathBuf>,
     field: Vec<String>,
     no_custom_fields: bool,
@@ -957,6 +964,12 @@ async fn create_issue(
         for (k, v) in interactive {
             custom_fields.entry(k).or_insert(v);
         }
+    }
+
+    if let Some(sprint) = sprint {
+        let (field_id, field_value) =
+            resolve_sprint_assignment(&client, &project_key, &issue_type_id, &sprint).await?;
+        custom_fields.insert(field_id, field_value);
     }
 
     let req = CreateIssueRequestV2 {
@@ -1589,6 +1602,132 @@ fn truncate(s: &str, max_len: usize) -> String {
         s.to_string()
     } else {
         format!("{}…", &s[..max_len.saturating_sub(1)])
+    }
+}
+
+async fn resolve_sprint_assignment(
+    client: &JiraClient,
+    project_key: &str,
+    issue_type_id: &str,
+    sprint: &str,
+) -> Result<(String, FieldValue)> {
+    if issue_type_id.is_empty() {
+        anyhow::bail!(
+            "Sprint assignment requires a resolved issue type so Jira fields can be inspected"
+        );
+    }
+
+    let fields = client
+        .get_fields_for_issue_type(project_key, issue_type_id)
+        .await
+        .context("Failed to inspect fields for sprint assignment")?;
+
+    let sprint_field = fields
+        .into_iter()
+        .find(|field| {
+            field.name.eq_ignore_ascii_case("Sprint")
+                || field
+                    .schema
+                    .as_ref()
+                    .and_then(|schema| schema.get("custom"))
+                    .and_then(|value| value.as_str())
+                    .map(|custom| custom.contains("gh-sprint"))
+                    .unwrap_or(false)
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Sprint is not available for project {} / this issue type on create",
+                project_key
+            )
+        })?;
+
+    let sprint_id = if let Ok(id) = sprint.trim().parse::<u64>() {
+        id
+    } else {
+        resolve_sprint_id_by_name(client, project_key, sprint).await?
+    };
+
+    Ok((
+        sprint_field.id,
+        FieldValue::Raw(serde_json::json!([{ "id": sprint_id }])),
+    ))
+}
+
+async fn resolve_sprint_id_by_name(
+    client: &JiraClient,
+    project_key: &str,
+    sprint_name: &str,
+) -> Result<u64> {
+    let boards = client
+        .raw_request(
+            "GET",
+            &format!("/rest/agile/1.0/board?projectKeyOrId={project_key}&maxResults=100"),
+            None,
+        )
+        .await
+        .context("Failed to list boards for sprint resolution")?
+        .unwrap_or(Value::Null);
+
+    let board_values = boards
+        .get("values")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Unexpected board response while resolving sprint"))?;
+
+    let mut matches = Vec::new();
+
+    for board in board_values {
+        let board_id = match board.get("id").and_then(Value::as_u64) {
+            Some(id) => id,
+            None => continue,
+        };
+
+        let response = client
+            .raw_request(
+                "GET",
+                &format!(
+                    "/rest/agile/1.0/board/{board_id}/sprint?state=active,future,closed&maxResults=100"
+                ),
+                None,
+            )
+            .await;
+
+        let Ok(Some(payload)) = response else {
+            continue;
+        };
+
+        if let Some(values) = payload.get("values").and_then(Value::as_array) {
+            for sprint in values {
+                let Some(name) = sprint.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+                if name.eq_ignore_ascii_case(sprint_name) {
+                    if let Some(id) = sprint.get("id").and_then(Value::as_u64) {
+                        matches.push((id, board_id, name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => anyhow::bail!(
+            "Sprint '{}' was not found on any sprint-enabled board for project {}",
+            sprint_name,
+            project_key
+        ),
+        1 => Ok(matches[0].0),
+        _ => {
+            let options = matches
+                .into_iter()
+                .map(|(id, board_id, name)| format!("{name} (id:{id}, board:{board_id})"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "Sprint '{}' matched multiple sprints. Use a numeric sprint ID instead: {}",
+                sprint_name,
+                options
+            )
+        }
     }
 }
 

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -276,6 +276,27 @@ pub enum IssueCommand {
         json: bool,
     },
 
+    /// Render and validate description content before sending it to Jira
+    ///
+    /// Useful for previewing how Markdown or plain text will be converted into
+    /// Atlassian Document Format (ADF), or for validating raw ADF JSON input.
+    ///
+    /// Examples:
+    ///   jirac issue render --input desc.md
+    ///   jirac issue render --input desc.md --format markdown --output text
+    ///   jirac issue render --input desc.adf.json --format adf
+    Render {
+        /// Input file to read. If omitted, reads from stdin.
+        #[arg(long, value_name = "FILE")]
+        input: Option<std::path::PathBuf>,
+        /// Input format: markdown (default), text, or adf
+        #[arg(long, value_name = "FORMAT", default_value = "markdown")]
+        format: String,
+        /// Output format: adf (default) or text
+        #[arg(long, value_name = "FORMAT", default_value = "adf")]
+        output: String,
+    },
+
     /// Manage comments on an issue
     ///
     /// List existing comments or add a new comment in Markdown.
@@ -724,6 +745,11 @@ pub async fn handle(
             )
             .await
         }
+        IssueCommand::Render {
+            input,
+            format,
+            output,
+        } => render_issue_content(input, format, output),
         IssueCommand::Comment { key, command } => comment(client, key, command).await,
         IssueCommand::Worklog { key, command } => worklog(client, key, command).await,
         IssueCommand::BulkTransition {
@@ -1464,7 +1490,68 @@ async fn list_fields(
     Ok(())
 }
 
+fn render_issue_content(
+    input: Option<std::path::PathBuf>,
+    format: String,
+    output: String,
+) -> Result<()> {
+    let content = read_render_input(input.as_deref())?;
+    let format = normalize_render_format(&format)?;
+    let output = normalize_render_output(&output)?;
+
+    let adf = match format {
+        "markdown" => jira_core::adf::markdown_to_adf(&content),
+        "text" => jira_core::adf::plain_text_to_adf(&content),
+        "adf" => serde_json::from_str::<Value>(&content)
+            .context("--format adf requires valid JSON ADF content")?,
+        _ => unreachable!(),
+    };
+
+    match output {
+        "adf" => println!("{}", serde_json::to_string_pretty(&adf)?),
+        "text" => println!("{}", jira_core::adf::adf_to_text(&adf)),
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn read_render_input(path: Option<&std::path::Path>) -> Result<String> {
+    match path {
+        Some(path) => std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read input file: {}", path.display())),
+        None => {
+            use std::io::Read;
+
+            let mut input = String::new();
+            std::io::stdin()
+                .read_to_string(&mut input)
+                .context("Failed to read stdin")?;
+            Ok(input)
+        }
+    }
+}
+
+fn normalize_render_format(value: &str) -> Result<&str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "markdown" | "md" => Ok("markdown"),
+        "text" | "txt" => Ok("text"),
+        "adf" | "json" => Ok("adf"),
+        other => {
+            anyhow::bail!("Unsupported input format '{other}'. Use one of: markdown, text, adf")
+        }
+    }
+}
+
+fn normalize_render_output(value: &str) -> Result<&str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "adf" | "json" => Ok("adf"),
+        "text" | "txt" => Ok("text"),
+        other => anyhow::bail!("Unsupported output format '{other}'. Use one of: adf, text"),
+    }
+}
 
 fn spinner_new(msg: impl Into<String>) -> ProgressBar {
     use std::io::IsTerminal;

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -947,13 +947,15 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             }
 
             AppAction::CreateSavedJql => {
+                let current_jql = (!app.jql.trim().is_empty()).then_some(app.jql.as_str());
                 suspend_tui(&mut terminal)?;
-                let result = tui_edit_saved_jql(None);
+                let result = tui_edit_saved_jql(None, current_jql);
                 resume_tui(&mut terminal)?;
                 match result {
                     Ok(Some(saved)) => {
                         app.prefs.saved_jqls.push(saved);
-                        app.clamp_saved_jql_selection();
+                        let new_index = app.prefs.saved_jqls.len().saturating_sub(1);
+                        app.saved_jql_state.select(Some(new_index));
                         match app.prefs.save() {
                             Ok(()) => app.set_status("✓ Saved query added", false),
                             Err(e) => app.set_status(
@@ -970,7 +972,7 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             AppAction::EditSavedJql(index) => {
                 let existing = app.prefs.saved_jqls.get(index).cloned();
                 suspend_tui(&mut terminal)?;
-                let result = tui_edit_saved_jql(existing.as_ref());
+                let result = tui_edit_saved_jql(existing.as_ref(), None);
                 resume_tui(&mut terminal)?;
                 match result {
                     Ok(Some(saved)) => {

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -25,8 +25,8 @@ use super::mode::Mode;
 use super::picker::PickerOption;
 use super::prefs::{SavedJql, TuiPreferences};
 use super::prompts::{
-    resume_tui, suspend_tui, tui_add_comment, tui_add_worklog, tui_create_issue, tui_edit_issue,
-    tui_edit_labels, tui_upload_attachment,
+    resume_tui, suspend_tui, tui_add_comment, tui_add_worklog, tui_confirm_delete_saved_jql,
+    tui_create_issue, tui_edit_issue, tui_edit_labels, tui_edit_saved_jql, tui_upload_attachment,
 };
 use super::render::ui;
 use super::theme::ThemeName;
@@ -92,6 +92,9 @@ pub(super) enum AppAction {
     SaveColumnPreferences,
     ResetColumnPreferences,
     ApplySavedJql(String),
+    CreateSavedJql,
+    EditSavedJql(usize),
+    DeleteSavedJql(usize),
     SaveTheme,
     LoadServerInfo,
     LoadConfigView,
@@ -311,6 +314,26 @@ impl App {
         self.saved_jql_state
             .selected()
             .and_then(|i| self.prefs.saved_jqls.get(i))
+    }
+
+    pub(super) fn selected_saved_jql_index(&self) -> Option<usize> {
+        self.saved_jql_state
+            .selected()
+            .filter(|index| *index < self.prefs.saved_jqls.len())
+    }
+
+    pub(super) fn clamp_saved_jql_selection(&mut self) {
+        if self.prefs.saved_jqls.is_empty() {
+            self.saved_jql_state.select(None);
+            return;
+        }
+
+        let idx = self
+            .saved_jql_state
+            .selected()
+            .map(|i| i.min(self.prefs.saved_jqls.len() - 1))
+            .unwrap_or(0);
+        self.saved_jql_state.select(Some(idx));
     }
 
     pub(super) fn selected_theme(&self) -> ThemeName {
@@ -920,6 +943,75 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
                         app.clear_status();
                     }
                     Err(e) => app.set_status(format!("Saved query failed: {e}"), true),
+                }
+            }
+
+            AppAction::CreateSavedJql => {
+                suspend_tui(&mut terminal)?;
+                let result = tui_edit_saved_jql(None);
+                resume_tui(&mut terminal)?;
+                match result {
+                    Ok(Some(saved)) => {
+                        app.prefs.saved_jqls.push(saved);
+                        app.clamp_saved_jql_selection();
+                        match app.prefs.save() {
+                            Ok(()) => app.set_status("✓ Saved query added", false),
+                            Err(e) => app.set_status(
+                                format!("Failed to save saved query preferences: {e}"),
+                                true,
+                            ),
+                        }
+                    }
+                    Ok(None) => app.set_status("Saved query create cancelled", false),
+                    Err(e) => app.set_status(format!("Saved query create failed: {e}"), true),
+                }
+            }
+
+            AppAction::EditSavedJql(index) => {
+                let existing = app.prefs.saved_jqls.get(index).cloned();
+                suspend_tui(&mut terminal)?;
+                let result = tui_edit_saved_jql(existing.as_ref());
+                resume_tui(&mut terminal)?;
+                match result {
+                    Ok(Some(saved)) => {
+                        if let Some(slot) = app.prefs.saved_jqls.get_mut(index) {
+                            *slot = saved;
+                        }
+                        app.saved_jql_state.select(Some(index));
+                        match app.prefs.save() {
+                            Ok(()) => app.set_status("✓ Saved query updated", false),
+                            Err(e) => app.set_status(
+                                format!("Failed to save saved query preferences: {e}"),
+                                true,
+                            ),
+                        }
+                    }
+                    Ok(None) => app.set_status("Saved query edit cancelled", false),
+                    Err(e) => app.set_status(format!("Saved query edit failed: {e}"), true),
+                }
+            }
+
+            AppAction::DeleteSavedJql(index) => {
+                let existing = app.prefs.saved_jqls.get(index).cloned();
+                if let Some(saved) = existing {
+                    suspend_tui(&mut terminal)?;
+                    let result = tui_confirm_delete_saved_jql(&saved);
+                    resume_tui(&mut terminal)?;
+                    match result {
+                        Ok(true) => {
+                            app.prefs.saved_jqls.remove(index);
+                            app.clamp_saved_jql_selection();
+                            match app.prefs.save() {
+                                Ok(()) => app.set_status("✓ Saved query deleted", false),
+                                Err(e) => app.set_status(
+                                    format!("Failed to save saved query preferences: {e}"),
+                                    true,
+                                ),
+                            }
+                        }
+                        Ok(false) => app.set_status("Saved query delete cancelled", false),
+                        Err(e) => app.set_status(format!("Saved query delete failed: {e}"), true),
+                    }
                 }
             }
 

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -66,6 +66,7 @@ pub(super) struct App {
     pub(super) theme_state: ListState,
     pub(super) server_info_lines: Vec<String>,
     pub(super) config_lines: Vec<String>,
+    pub(super) detail_scroll: u16,
 }
 
 pub(super) enum AppAction {
@@ -181,6 +182,7 @@ impl App {
             theme_state,
             server_info_lines: Vec::new(),
             config_lines: Vec::new(),
+            detail_scroll: 0,
         }
     }
 
@@ -267,17 +269,42 @@ impl App {
 
     pub(super) fn ensure_detail_context(&mut self) {
         if let Some(key) = self.selected_issue_key() {
+            let before = self.detail.issue_key.clone();
             self.detail.reset_for(&key);
+            if before != self.detail.issue_key {
+                self.reset_detail_scroll();
+            }
         }
     }
 
     pub(super) fn open_detail(&mut self) {
         self.focus = Focus::Detail;
         self.ensure_detail_context();
+        self.reset_detail_scroll();
     }
 
     pub(super) fn close_detail(&mut self) {
         self.focus = Focus::List;
+        self.reset_detail_scroll();
+    }
+
+    pub(super) fn reset_detail_scroll(&mut self) {
+        self.detail_scroll = 0;
+    }
+
+    pub(super) fn scroll_detail_down(&mut self, amount: u16) {
+        self.detail_scroll = self.detail_scroll.saturating_add(amount.max(1));
+    }
+
+    pub(super) fn scroll_detail_up(&mut self, amount: u16) {
+        self.detail_scroll = self.detail_scroll.saturating_sub(amount.max(1));
+    }
+
+    pub(super) fn set_active_tab(&mut self, tab: DetailTab) {
+        if self.active_tab != tab {
+            self.active_tab = tab;
+            self.reset_detail_scroll();
+        }
     }
 
     pub(super) fn selected_saved_jql(&self) -> Option<&SavedJql> {

--- a/crates/jira/src/tui/column.rs
+++ b/crates/jira/src/tui/column.rs
@@ -5,14 +5,19 @@ use ratatui::{
     widgets::Cell,
 };
 
-pub(super) const AVAILABLE_COLUMNS: [ColumnKind; 8] = [
+pub(super) const AVAILABLE_COLUMNS: [ColumnKind; 13] = [
     ColumnKind::Key,
     ColumnKind::Type,
     ColumnKind::Priority,
     ColumnKind::Status,
     ColumnKind::Assignee,
+    ColumnKind::Reporter,
+    ColumnKind::Project,
     ColumnKind::Created,
     ColumnKind::Updated,
+    ColumnKind::Labels,
+    ColumnKind::Components,
+    ColumnKind::FixVersions,
     ColumnKind::Summary,
 ];
 
@@ -23,8 +28,13 @@ pub(super) enum ColumnKind {
     Priority,
     Status,
     Assignee,
+    Reporter,
+    Project,
     Created,
     Updated,
+    Labels,
+    Components,
+    FixVersions,
     Summary,
 }
 
@@ -36,8 +46,13 @@ impl ColumnKind {
             ColumnKind::Priority => "Priority",
             ColumnKind::Status => "Status",
             ColumnKind::Assignee => "Assignee",
+            ColumnKind::Reporter => "Reporter",
+            ColumnKind::Project => "Project",
             ColumnKind::Created => "Created",
             ColumnKind::Updated => "Updated",
+            ColumnKind::Labels => "Labels",
+            ColumnKind::Components => "Components",
+            ColumnKind::FixVersions => "Fix Versions",
             ColumnKind::Summary => "Summary",
         }
     }
@@ -49,9 +64,14 @@ impl ColumnKind {
             ColumnKind::Priority => Constraint::Length(8),
             ColumnKind::Status => Constraint::Length(14),
             ColumnKind::Assignee => Constraint::Length(16),
+            ColumnKind::Reporter => Constraint::Length(16),
+            ColumnKind::Project => Constraint::Length(10),
             ColumnKind::Created => Constraint::Length(11),
             ColumnKind::Updated => Constraint::Length(11),
-            ColumnKind::Summary => Constraint::Min(15),
+            ColumnKind::Labels => Constraint::Min(14),
+            ColumnKind::Components => Constraint::Min(14),
+            ColumnKind::FixVersions => Constraint::Min(14),
+            ColumnKind::Summary => Constraint::Min(24),
         }
     }
 
@@ -69,6 +89,10 @@ impl ColumnKind {
             ColumnKind::Assignee => {
                 Cell::from(issue.assignee.clone().unwrap_or_else(|| "-".into()))
             }
+            ColumnKind::Reporter => {
+                Cell::from(issue.reporter.clone().unwrap_or_else(|| "-".into()))
+            }
+            ColumnKind::Project => Cell::from(issue.project_key.clone()),
             ColumnKind::Created => Cell::from(
                 issue
                     .created
@@ -85,14 +109,10 @@ impl ColumnKind {
                     .to_string(),
             )
             .style(Style::default().fg(Color::DarkGray)),
-            ColumnKind::Summary => {
-                let summary = if issue.summary.len() > 40 {
-                    format!("{}…", &issue.summary[..39])
-                } else {
-                    issue.summary.clone()
-                };
-                Cell::from(summary)
-            }
+            ColumnKind::Labels => Cell::from(join_string_array(issue, "labels")),
+            ColumnKind::Components => Cell::from(join_named_array(issue, "components")),
+            ColumnKind::FixVersions => Cell::from(join_named_array(issue, "fixVersions")),
+            ColumnKind::Summary => Cell::from(issue.summary.clone()),
         }
     }
 }
@@ -108,6 +128,39 @@ pub(super) fn status_color(status: &str) -> Color {
     } else {
         Color::White
     }
+}
+
+fn join_string_array(issue: &Issue, field: &str) -> String {
+    issue
+        .fields
+        .get(field)
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "-".into())
+}
+
+fn join_named_array(issue: &Issue, field: &str) -> String {
+    issue
+        .fields
+        .get(field)
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("name").and_then(|value| value.as_str()))
+                .map(|name| name.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "-".into())
 }
 
 pub(super) fn format_column_summary(columns: &[ColumnKind]) -> String {

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -127,12 +127,34 @@ fn handle_view_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Left | KeyCode::Char('h') => {
-            app.active_tab = app.active_tab.prev();
+            let next = app.active_tab.prev();
+            app.set_active_tab(next);
             AppAction::WarmActiveTab
         }
         KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => {
-            app.active_tab = app.active_tab.next();
+            let next = app.active_tab.next();
+            app.set_active_tab(next);
             AppAction::WarmActiveTab
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.scroll_detail_down(1);
+            AppAction::None
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.scroll_detail_up(1);
+            AppAction::None
+        }
+        KeyCode::PageDown => {
+            app.scroll_detail_down(8);
+            AppAction::None
+        }
+        KeyCode::PageUp => {
+            app.scroll_detail_up(8);
+            AppAction::None
+        }
+        KeyCode::Home => {
+            app.reset_detail_scroll();
+            AppAction::None
         }
         KeyCode::Char('t') => AppAction::FetchTransitions,
         KeyCode::Char('o') => AppAction::OpenBrowser,

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -468,6 +468,15 @@ fn handle_saved_jql_key(app: &mut App, code: KeyCode) -> AppAction {
             }
             AppAction::None
         }
+        KeyCode::Char('c') => AppAction::CreateSavedJql,
+        KeyCode::Char('e') => app
+            .selected_saved_jql_index()
+            .map(AppAction::EditSavedJql)
+            .unwrap_or(AppAction::None),
+        KeyCode::Char('d') => app
+            .selected_saved_jql_index()
+            .map(AppAction::DeleteSavedJql)
+            .unwrap_or(AppAction::None),
         _ => AppAction::None,
     }
 }

--- a/crates/jira/src/tui/prefs.rs
+++ b/crates/jira/src/tui/prefs.rs
@@ -83,6 +83,9 @@ impl TuiPreferences {
         if !self.visible_columns.contains(&ColumnKind::Summary) {
             self.visible_columns.push(ColumnKind::Summary);
         }
+
+        self.saved_jqls
+            .retain(|saved| !saved.name.trim().is_empty() && !saved.jql.trim().is_empty());
     }
 }
 

--- a/crates/jira/src/tui/prompts.rs
+++ b/crates/jira/src/tui/prompts.rs
@@ -155,13 +155,19 @@ pub(super) async fn tui_edit_issue(client: &JiraClient, key: &str) -> Result<boo
     Ok(true)
 }
 
-pub(super) fn tui_edit_saved_jql(existing: Option<&SavedJql>) -> Result<Option<SavedJql>> {
+pub(super) fn tui_edit_saved_jql(
+    existing: Option<&SavedJql>,
+    suggested_jql: Option<&str>,
+) -> Result<Option<SavedJql>> {
     use inquire::Text;
 
     println!("\n── Saved Query ─────────────────────────────────────");
 
     let name_default = existing.map(|saved| saved.name.as_str()).unwrap_or("");
-    let jql_default = existing.map(|saved| saved.jql.as_str()).unwrap_or("");
+    let jql_default = existing
+        .map(|saved| saved.jql.as_str())
+        .or(suggested_jql)
+        .unwrap_or("");
 
     let name = match Text::new("Name:")
         .with_default(name_default)

--- a/crates/jira/src/tui/prompts.rs
+++ b/crates/jira/src/tui/prompts.rs
@@ -8,6 +8,8 @@ use crossterm::{
 use jira_core::{model::UpdateIssueRequest, JiraClient};
 use ratatui::Terminal;
 
+use super::prefs::SavedJql;
+
 use crate::datetime::build_worklog_started;
 
 use super::picker::prompt_assignee_selection;
@@ -151,6 +153,46 @@ pub(super) async fn tui_edit_issue(client: &JiraClient, key: &str) -> Result<boo
 
     client.update_issue(key, req).await?;
     Ok(true)
+}
+
+pub(super) fn tui_edit_saved_jql(existing: Option<&SavedJql>) -> Result<Option<SavedJql>> {
+    use inquire::Text;
+
+    println!("\n── Saved Query ─────────────────────────────────────");
+
+    let name_default = existing.map(|saved| saved.name.as_str()).unwrap_or("");
+    let jql_default = existing.map(|saved| saved.jql.as_str()).unwrap_or("");
+
+    let name = match Text::new("Name:")
+        .with_default(name_default)
+        .prompt_skippable()?
+    {
+        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => return Ok(None),
+    };
+
+    let jql = match Text::new("JQL:")
+        .with_default(jql_default)
+        .prompt_skippable()?
+    {
+        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => return Ok(None),
+    };
+
+    Ok(Some(SavedJql { name, jql }))
+}
+
+pub(super) fn tui_confirm_delete_saved_jql(saved: &SavedJql) -> Result<bool> {
+    use inquire::Confirm;
+
+    println!("\n── Delete Saved Query ─────────────────────────────");
+    println!("  {}", saved.name);
+    println!("  {}\n", saved.jql);
+
+    Confirm::new("Delete this saved query?")
+        .with_default(false)
+        .prompt()
+        .map_err(Into::into)
 }
 
 pub(super) async fn tui_add_comment(client: &JiraClient, key: &str) -> Result<bool> {

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -119,7 +119,7 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
         Mode::ColumnPicker => " j/k:move  Space:toggle  a:all  Enter:save  Esc:cancel".to_string(),
         Mode::AssigneePicker => " type:search  j/k:move  Enter:assign  Esc:cancel".to_string(),
         Mode::ComponentPicker => " type:search  j/k:move  Space:toggle  Enter:save  Esc:cancel".to_string(),
-        Mode::SavedJqlPicker => " j/k:move  Enter:run query  Esc:cancel".to_string(),
+        Mode::SavedJqlPicker => " j/k:move  Enter:run  c:new  e:edit  d:delete  Esc:cancel".to_string(),
         Mode::ThemePicker => " j/k:move  Enter:apply theme  Esc:cancel".to_string(),
         _ => " Esc:back".to_string(),
     };
@@ -769,7 +769,16 @@ fn render_component_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palet
 }
 
 fn render_saved_jql_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
-    let popup_area = centered_rect(60, 60, area);
+    let popup_area = centered_rect(68, 68, area);
+    let [summary_area, list_area, hint_area] = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(4),
+        ])
+        .areas(popup_area);
+
     let items: Vec<ListItem> = app
         .prefs
         .saved_jqls
@@ -777,12 +786,42 @@ fn render_saved_jql_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Pal
         .map(|saved| ListItem::new(format!("{}  •  {}", saved.name, saved.jql)))
         .collect();
 
+    let selected_summary = if let Some(saved) = app.selected_saved_jql() {
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled("Selected: ", Style::default().fg(palette.muted)),
+                Span::styled(saved.name.clone(), Style::default().fg(palette.accent)),
+            ]),
+            Line::from(Span::styled(
+                saved.jql.clone(),
+                Style::default().fg(palette.header_fg),
+            )),
+        ])
+    } else {
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "No saved queries yet.",
+                Style::default().fg(palette.muted),
+            )),
+            Line::from(Span::styled(
+                "Press c to create one.",
+                Style::default().fg(palette.muted),
+            )),
+        ])
+    }
+    .block(
+        Block::default()
+            .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(palette.focus_border))
+            .title(" Saved Queries ")
+            .style(Style::default().bg(Color::Black)),
+    );
+
     let list = List::new(items)
         .block(
             Block::default()
-                .borders(Borders::ALL)
+                .borders(Borders::LEFT | Borders::RIGHT)
                 .border_style(Style::default().fg(palette.focus_border))
-                .title(" Saved Queries ")
                 .style(Style::default().bg(Color::Black)),
         )
         .highlight_style(
@@ -793,8 +832,22 @@ fn render_saved_jql_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Pal
         )
         .highlight_symbol("> ");
 
+    let hints = Paragraph::new(vec![
+        Line::from("↑/↓ move   Enter run   c create   e edit   d delete"),
+        Line::from("Esc cancel"),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(palette.focus_border))
+            .style(Style::default().bg(Color::Black)),
+    )
+    .style(Style::default().fg(palette.muted));
+
     f.render_widget(Clear, popup_area);
-    f.render_stateful_widget(list, popup_area, &mut app.saved_jql_state);
+    f.render_widget(selected_summary, summary_area);
+    f.render_stateful_widget(list, list_area, &mut app.saved_jql_state);
+    f.render_widget(hints, hint_area);
 }
 
 fn render_theme_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -874,7 +927,7 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) {
         Line::from("  ↑/k       Move up"),
         Line::from("  ↓/j       Move down"),
         Line::from("  Enter     Open split detail view"),
-        Line::from("  p         Open saved queries"),
+        Line::from("  p         Open saved queries (run/create/edit/delete)"),
         Line::from("  T         Open theme picker"),
         Line::from("  S         Show server info"),
         Line::from("  g         Show config file"),

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -106,7 +106,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
 fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
     let text = match &app.mode {
         Mode::Browse if app.focus == Focus::Detail => {
-            " ←/→:tab  Esc:back  t:transition  e:edit  a:assign  ;:comment  w:worklog  u:upload  o:browser  ?:help  q:quit"
+            " ↑/↓:scroll  PgUp/PgDn:fast scroll  Home:top  ←/→:tab  Esc:back  t:transition  e:edit  a:assign  ;:comment  w:worklog  u:upload  o:browser  ?:help  q:quit"
                 .to_string()
         }
         Mode::Browse => {
@@ -264,9 +264,10 @@ fn render_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(palette.focus_border))
-                .title(" Detail "),
+                .title(format!(" Detail  (scroll:{}) ", app.detail_scroll)),
         )
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.detail_scroll, 0));
     f.render_widget(paragraph, chunks[1]);
 }
 


### PR DESCRIPTION
## Summary

This PR improves three high-friction areas in `jirac`:

1. **ADF/content pipeline**
   - enable Markdown table -> ADF table conversion
   - add `jirac issue render` to preview Markdown/text/ADF conversion before sending content to Jira

2. **Issue create / fields ergonomics**
   - fix `jirac issue fields --required-only --json` for Jira instances that return createmeta `fields` as a list rather than a map
   - add first-class `--sprint <SPRINT_ID|NAME>` support to `jirac issue create`

3. **TUI usability**
   - add scrolling for long detail/comments/worklog content
   - expand available issue table columns
   - add saved query create/edit/delete flows
   - polish saved-query defaults using the active JQL

## Changes

### ADF / render
- enable Comrak table extension in `markdown_to_adf`
- improve Markdown table cell conversion
- add `jirac issue render`
  - supports `markdown`, `text`, and `adf` input
  - supports `adf` and `text` output
- document render examples in README files

### Fields / create flow
- make createmeta field parsing backward-compatible with both:
  - legacy `fields: { ... }`
  - newer `fields: [ ... ]`
- add parser tests for both response shapes
- add `--sprint <SPRINT_ID|NAME>` to `jirac issue create`
- resolve sprint by numeric ID or exact sprint name
- return clearer errors when sprint is unsupported or ambiguous

### TUI
- add detail pane scroll state and keyboard handling:
  - `j/k`, arrows, `PgUp/PgDn`, `Home`
- reset scroll when changing issue/tab
- expand issue table columns with:
  - Reporter
  - Project
  - Labels
  - Components
  - Fix Versions
- stop hard-truncating Summary at 40 chars in the column cell
- add saved query CRUD:
  - `c` create
  - `e` edit
  - `d` delete
  - `Enter` run
- show selected saved-query preview in the popup
- prefill new saved-query JQL from the active search and auto-select the newly created entry

## Verification

Ran full smoke checks:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build --all`

## Notes

- Verified the createmeta parsing fix against a real Jira repro where `issue fields --required-only --json` previously failed with:
  - `invalid type: sequence, expected a map`
- Verified sprint field availability on a scrum-backed project via read-only Jira checks
- No live issue-creation write test was performed for the new sprint create flow in order to avoid unintended Jira side effects