### PR TITLE
chore: add issue templates and refresh CLAUDE.md workspace map

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,129 @@
+name: Bug report
+description: Report a defect in jirac, jirac-mcp, jira-core, or the Claude Code plugin
+title: "[bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the form below so we can reproduce and triage quickly.
+
+        Before submitting:
+        - Search [existing issues](https://github.com/mulhamna/jira-commands/issues?q=is%3Aissue) to avoid duplicates.
+        - Run `jirac --version` and confirm you're on the latest release.
+        - If the bug involves your Jira instance, **redact** any tokens, emails, or private project keys from logs.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `jirac --version` (or `jirac-mcp --version`).
+      placeholder: "jirac 0.19.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project is affected?
+      options:
+        - jirac (CLI)
+        - jirac (TUI)
+        - jirac-mcp (MCP server)
+        - jira-core (library)
+        - Claude Code plugin / skill
+        - Homebrew / Chocolatey / Winget packaging
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - Homebrew
+        - Chocolatey
+        - Winget
+        - cargo install
+        - Built from source
+        - GitHub release binary
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: jira-tier
+    attributes:
+      label: Jira tier
+      options:
+        - Jira Cloud (Free / Standard / Premium / Enterprise)
+        - Jira Data Center / Server
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: OS + version (e.g. `macOS 15.2`, `Ubuntu 24.04`, `Windows 11 23H2`).
+      placeholder: "macOS 15.2 (arm64)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Clear, short description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Exact commands, flags, and inputs. Use code blocks.
+      placeholder: |
+        1. `jirac issue create --project ABC --type Task --summary "..."`
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message and any panic / stack trace.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Output with `RUST_LOG=debug` if applicable. **Redact tokens, emails, and private data.**
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and found no duplicate.
+          required: true
+        - label: I redacted any sensitive data (tokens, emails, internal URLs) from logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/mulhamna/jira-commands/discussions
+    about: Ask questions and discuss usage in GitHub Discussions instead of filing an issue.
+  - name: Security vulnerability
+    url: https://github.com/mulhamna/jira-commands/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,88 @@
+name: Feature request
+description: Propose a new feature, enhancement, or API addition
+title: "[feat]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an idea. Please describe the problem first, then the solution. This makes it easier to evaluate alternatives.
+
+        Before submitting:
+        - Search [existing issues](https://github.com/mulhamna/jira-commands/issues?q=is%3Aissue) and [discussions](https://github.com/mulhamna/jira-commands/discussions) for prior art.
+        - Check the [README](https://github.com/mulhamna/jira-commands/blob/main/README.md) and [CHANGELOG](https://github.com/mulhamna/jira-commands/blob/main/CHANGELOG.md) — your idea may already exist or be planned.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project would this affect?
+      options:
+        - jirac (CLI)
+        - jirac (TUI)
+        - jirac-mcp (MCP server)
+        - jira-core (library)
+        - Claude Code plugin / skill
+        - Packaging (Homebrew / Chocolatey / Winget)
+        - Documentation
+        - Other / cross-cutting
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem are you trying to solve? Why does the current behavior fall short?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior. Include CLI flags, TUI keybindings, API signatures, or MCP tool shapes if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you discarded them.
+    validations:
+      required: false
+
+  - type: textarea
+    id: api-impact
+    attributes:
+      label: Public API / breaking-change impact
+      description: Does this affect `jira-core` public API, CLI flag surface, or MCP tool schemas? Note any backwards-compat concerns.
+    validations:
+      required: false
+
+  - type: textarea
+    id: jira-references
+    attributes:
+      label: Jira REST API references
+      description: Link to relevant Atlassian docs (REST API v3, Agile API, etc.) if this depends on a specific endpoint.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, related issues, or examples from other tools.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and discussions for duplicates.
+          required: true
+        - label: I'm willing to discuss design trade-offs before implementation.
+          required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,19 +29,49 @@ Rust CLI for Atlassian Jira (`jirac` binary). Focus: full custom field via dynam
 
 ```
 crates/
-├── jira-core/    # PUBLIC LIBRARY: API client, auth, model, ADF parser (crates.io: "jira-core")
-├── jira/         # BINARY: clap CLI + TUI (crates.io: "jira-commands", binary: jirac)
-└── jira-mcp/     # MCP SERVER: typed Jira tools via rmcp (crates.io: "jira-mcp", binary: jirac-mcp)
+├── jira-core/                  # PUBLIC LIBRARY (crates.io: "jira-core")
+│   └── src/
+│       ├── adf.rs              # Atlassian Document Format parser
+│       ├── auth.rs             # auth + multi-profile (Cloud + Data Center)
+│       ├── client.rs           # JiraClient — REST API surface
+│       ├── config.rs           # JiraConfig loader (figment: toml + env)
+│       ├── error.rs            # JiraError + Result alias
+│       ├── field_cache.rs      # custom-field id ↔ name resolution cache
+│       └── model/              # attachment, comment, field, issue, sprint, worklog
+├── jira/                       # BINARY (crates.io: "jira-commands", binary: jirac)
+│   └── src/
+│       ├── main.rs
+│       ├── datetime.rs         # datetime helpers
+│       ├── cli/                # clap commands: api, auth, issue, plan
+│       └── tui/                # ratatui TUI — modular split
+│           ├── app.rs          # event loop coordinator
+│           ├── column.rs       # column layout
+│           ├── keys.rs         # keybinding map
+│           ├── mode.rs         # app mode state
+│           ├── panel.rs        # split-pane logic
+│           ├── picker.rs       # native pickers
+│           ├── prefs.rs        # prefs overlay
+│           ├── prompts.rs      # inline prompts
+│           ├── render.rs       # frame render
+│           └── theme.rs        # color theme
+└── jira-mcp/                   # MCP SERVER (crates.io: "jira-mcp", binary: jirac-mcp)
+    └── src/
+        ├── main.rs
+        ├── lib.rs
+        ├── app.rs              # MCP app wiring
+        ├── server.rs           # rmcp server impl
+        ├── models.rs           # MCP tool I/O types
+        └── error.rs
 plugin/
-├── .claude-plugin/  # Claude Code plugin metadata (plugin.json)
-└── skills/          # 12 skills: api, attach, bulk-transition, comment, create-issue, fields, jql, list-issues, transition, update-issue, view-issue, worklog
+├── .claude-plugin/             # Claude Code plugin metadata (plugin.json)
+└── skills/                     # 12 skills: api, attach, bulk-transition, comment, create-issue, fields, jql, list-issues, transition, update-issue, view-issue, worklog
 ```
 
 ### Crate responsibilities
 
-- **`jira-core`** — public API: `JiraClient`, model types, ADF parser, auth, error types. Can be used as a library dependency.
-- **`jira/`** — clap commands, TUI (ratatui + crossterm), interactive prompts (inquire). Binary: `jirac`.
-- **`jira-mcp/`** — MCP server via `rmcp`, exposes `jira-core` as MCP tools for LLM clients.
+- **`jira-core`** — public API: `JiraClient`, model types (split under `model/`), ADF parser, auth (Cloud + Data Center multi-profile), `FieldCache` for custom-field resolution, error types. Library dependency.
+- **`jira/`** — clap commands (`cli/{api,auth,issue,plan}.rs`), modular TUI (ratatui + crossterm, 10 submodules under `tui/`), interactive prompts (inquire), datetime helpers. Binary: `jirac`.
+- **`jira-mcp/`** — MCP server via `rmcp`, split into `app.rs` (wiring) + `server.rs` (impl) + `models.rs` (I/O types). Exposes `jira-core` as MCP tools for LLM clients. Binary: `jirac-mcp`.
 
 ---
 


### PR DESCRIPTION
## Summary

  - Add GitHub issue templates (`bug_report.yml`, `feature_request.yml`) plus a `config.yml` that disables blank issues
  and routes questions to Discussions and security reports to GitHub Security Advisories.
  - Refresh `CLAUDE.md` workspace map and crate responsibilities to reflect the modular layout: `jira-core` submodules
  (`adf`, `auth`, `client`, `config`, `error`, `field_cache`, `model/*`), `jira/cli/` split, the 10-module `jira/tui/`
  refactor, and the `jira-mcp` `app`/`server`/`models` split.

  ## Why

  - Contributors filing issues currently start from a blank box, which leads to missing repro steps, version info, and
  (worst case) leaked tokens. YAML forms enforce structure and a redaction checkbox.
  - `CLAUDE.md` was written before the recent TUI modular refactor and the multi-profile auth work, so its workspace map
  no longer matches `crates/`. New contributors and future Claude sessions need an accurate guide.

  ## Scope

  - Docs and repo metadata only. No code changes in `crates/`, no dependency updates, no CI workflow edits.
  - Conventional Commits used: `docs(claude):` and `chore(github):` — neither triggers a release-please version bump.

  ## Test plan

  - [x] Confirm `.github/ISSUE_TEMPLATE/` renders correctly on GitHub (open the "New issue" page on the branch fork or
  after merge)
  - [x] Confirm `config.yml` blocks blank issues and surfaces both contact links (Discussions, Security Advisories)
  - [x] Re-read `CLAUDE.md` workspace tree against `ls crates/*/src/` output to verify accuracy
  - [x] Verify CI passes (`ci.yml`, `security.yml`); release-please does not open or update a Release PR