### PR TITLE
feat(tui): in-TUI modal for edit, comment, and upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1407,11 +1407,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tui-textarea",
 ]
 
 [[package]]
 name = "jira-core"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1431,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3167,6 +3168,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "typed-arena"

--- a/crates/jira/Cargo.toml
+++ b/crates/jira/Cargo.toml
@@ -19,6 +19,7 @@ jira-core = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.29"
 crossterm = "0.28"
+tui-textarea = "0.7"
 inquire = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde = { workspace = true }

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -21,12 +21,13 @@ use ratatui::{
 
 use super::column::{format_column_summary, ColumnKind};
 use super::keys;
+use super::modal::{Modal, ModalKind};
 use super::mode::Mode;
 use super::picker::PickerOption;
 use super::prefs::{SavedJql, TuiPreferences};
 use super::prompts::{
-    resume_tui, suspend_tui, tui_add_comment, tui_add_worklog, tui_confirm_delete_saved_jql,
-    tui_create_issue, tui_edit_issue, tui_edit_labels, tui_edit_saved_jql, tui_upload_attachment,
+    resume_tui, suspend_tui, tui_add_worklog, tui_confirm_delete_saved_jql, tui_create_issue,
+    tui_edit_labels, tui_edit_saved_jql,
 };
 use super::render::ui;
 use super::theme::ThemeName;
@@ -67,6 +68,8 @@ pub(super) struct App {
     pub(super) server_info_lines: Vec<String>,
     pub(super) config_lines: Vec<String>,
     pub(super) detail_scroll: u16,
+    pub(super) modal: Option<Modal>,
+    pub(super) prev_mode: Option<Mode>,
 }
 
 pub(super) enum AppAction {
@@ -99,6 +102,8 @@ pub(super) enum AppAction {
     LoadServerInfo,
     LoadConfigView,
     WarmActiveTab,
+    SubmitModal,
+    CancelModal,
 }
 
 impl App {
@@ -186,6 +191,23 @@ impl App {
             server_info_lines: Vec::new(),
             config_lines: Vec::new(),
             detail_scroll: 0,
+            modal: None,
+            prev_mode: None,
+        }
+    }
+
+    pub(super) fn open_modal(&mut self, modal: Modal) {
+        self.prev_mode = Some(self.mode.clone());
+        self.modal = Some(modal);
+        self.mode = Mode::Modal;
+    }
+
+    pub(super) fn close_modal(&mut self) {
+        self.modal = None;
+        if let Some(prev) = self.prev_mode.take() {
+            self.mode = prev;
+        } else {
+            self.mode = Mode::Browse;
         }
     }
 
@@ -503,7 +525,7 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             continue;
         }
 
-        match keys::handle_key(&mut app, key.code) {
+        match keys::handle_key(&mut app, key) {
             AppAction::Quit => break,
 
             AppAction::Refresh => {
@@ -788,20 +810,20 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             }
 
             AppAction::EditIssue(key) => {
-                suspend_tui(&mut terminal)?;
-                let result = tui_edit_issue(&client, &key).await;
-                resume_tui(&mut terminal)?;
-                match result {
-                    Ok(true) => {
-                        let jql = app.jql.clone();
-                        if let Ok(r) = client.search_issues(&jql, None, Some(50)).await {
-                            app.set_issues(r.issues);
-                        }
-                        app.set_status(format!("✓ Updated {key}"), false);
-                    }
-                    Ok(false) => app.set_status("Edit cancelled", false),
-                    Err(e) => app.set_status(format!("Edit failed: {e}"), true),
-                }
+                let (summary, description) = app
+                    .issues
+                    .iter()
+                    .find(|i| i.key == key)
+                    .map(|issue| {
+                        let desc = issue
+                            .description
+                            .as_ref()
+                            .map(jira_core::adf::adf_to_text)
+                            .unwrap_or_default();
+                        (issue.summary.clone(), desc)
+                    })
+                    .unwrap_or_default();
+                app.open_modal(Modal::edit_issue(key, summary, description));
             }
 
             AppAction::AssignIssue(assignee) => {
@@ -823,18 +845,7 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             }
 
             AppAction::AddComment(key) => {
-                suspend_tui(&mut terminal)?;
-                let result = tui_add_comment(&client, &key).await;
-                resume_tui(&mut terminal)?;
-                match result {
-                    Ok(true) => {
-                        app.detail.comments = None;
-                        app.warm_active_tab(&client).await;
-                        app.set_status(format!("✓ Comment added to {key}"), false)
-                    }
-                    Ok(false) => app.set_status("Comment cancelled", false),
-                    Err(e) => app.set_status(format!("Comment failed: {e}"), true),
-                }
+                app.open_modal(Modal::add_comment(key));
             }
 
             AppAction::AddWorklog(key) => {
@@ -888,20 +899,120 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
             }
 
             AppAction::UploadAttachment(key) => {
-                suspend_tui(&mut terminal)?;
-                let result = tui_upload_attachment(&client, &key).await;
-                resume_tui(&mut terminal)?;
-                match result {
-                    Ok(true) => {
-                        let jql = app.jql.clone();
-                        if let Ok(r) = client.search_issues(&jql, None, Some(50)).await {
-                            app.set_issues(r.issues);
-                            app.warm_active_tab(&client).await;
+                app.open_modal(Modal::upload_attachment(key));
+            }
+
+            AppAction::CancelModal => {
+                app.close_modal();
+                app.set_status("Cancelled", false);
+            }
+
+            AppAction::SubmitModal => {
+                let Some(modal) = app.modal.as_ref() else {
+                    continue;
+                };
+                let kind = modal.kind.clone();
+                match kind {
+                    ModalKind::EditIssue { key } => {
+                        let summary = modal.field_text(0);
+                        let description = modal.field_text(1);
+                        let summary_trim = summary.trim();
+                        if summary_trim.is_empty() {
+                            if let Some(m) = app.modal.as_mut() {
+                                m.set_error("Summary cannot be empty");
+                            }
+                            continue;
                         }
-                        app.set_status(format!("✓ Attachment uploaded to {key}"), false)
+                        let req = UpdateIssueRequest {
+                            summary: Some(summary_trim.to_string()),
+                            description: Some(description),
+                            ..Default::default()
+                        };
+                        if let Some(m) = app.modal.as_mut() {
+                            m.busy = true;
+                        }
+                        terminal.draw(|f| ui(f, &mut app))?;
+                        match client.update_issue(&key, req).await {
+                            Ok(()) => {
+                                app.close_modal();
+                                let jql = app.jql.clone();
+                                if let Ok(r) = client.search_issues(&jql, None, Some(50)).await {
+                                    app.set_issues(r.issues);
+                                }
+                                app.set_status(format!("✓ Updated {key}"), false);
+                            }
+                            Err(e) => {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("Update failed: {e}"));
+                                }
+                            }
+                        }
                     }
-                    Ok(false) => app.set_status("Upload cancelled", false),
-                    Err(e) => app.set_status(format!("Upload failed: {e}"), true),
+                    ModalKind::AddComment { key } => {
+                        let body = modal.field_text(0);
+                        let body_trim = body.trim();
+                        if body_trim.is_empty() {
+                            if let Some(m) = app.modal.as_mut() {
+                                m.set_error("Comment cannot be empty");
+                            }
+                            continue;
+                        }
+                        if let Some(m) = app.modal.as_mut() {
+                            m.busy = true;
+                        }
+                        terminal.draw(|f| ui(f, &mut app))?;
+                        match client.add_comment(&key, body_trim).await {
+                            Ok(_) => {
+                                app.close_modal();
+                                app.detail.comments = None;
+                                app.warm_active_tab(&client).await;
+                                app.set_status(format!("✓ Comment added to {key}"), false);
+                            }
+                            Err(e) => {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("Comment failed: {e}"));
+                                }
+                            }
+                        }
+                    }
+                    ModalKind::UploadAttachment { key } => {
+                        let raw = modal.field_text(0);
+                        let path_str = raw.trim();
+                        if path_str.is_empty() {
+                            if let Some(m) = app.modal.as_mut() {
+                                m.set_error("Path cannot be empty");
+                            }
+                            continue;
+                        }
+                        let expanded = shellexpand_tilde(path_str);
+                        let path = std::path::PathBuf::from(expanded.as_ref());
+                        if !path.exists() {
+                            if let Some(m) = app.modal.as_mut() {
+                                m.set_error(format!("File not found: {path_str}"));
+                            }
+                            continue;
+                        }
+                        if let Some(m) = app.modal.as_mut() {
+                            m.busy = true;
+                        }
+                        terminal.draw(|f| ui(f, &mut app))?;
+                        match client.upload_attachment(&key, &path).await {
+                            Ok(_) => {
+                                app.close_modal();
+                                let jql = app.jql.clone();
+                                if let Ok(r) = client.search_issues(&jql, None, Some(50)).await {
+                                    app.set_issues(r.issues);
+                                    app.warm_active_tab(&client).await;
+                                }
+                                app.set_status(format!("✓ Attachment uploaded to {key}"), false);
+                            }
+                            Err(e) => {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("Upload failed: {e}"));
+                                }
+                            }
+                        }
+                    }
                 }
             }
 
@@ -1099,4 +1210,15 @@ pub async fn run_tui(client: JiraClient, project: Option<String>) -> Result<()> 
     terminal.show_cursor()?;
 
     Ok(())
+}
+
+fn shellexpand_tilde(path: &str) -> std::borrow::Cow<'_, str> {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            let mut p = std::path::PathBuf::from(home);
+            p.push(stripped);
+            return std::borrow::Cow::Owned(p.to_string_lossy().into_owned());
+        }
+    }
+    std::borrow::Cow::Borrowed(path)
 }

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -1,13 +1,26 @@
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyEvent};
 
 use super::app::{App, AppAction};
 use super::column::AVAILABLE_COLUMNS;
+use super::modal::{handle_modal_key, ModalOutcome};
 use super::mode::Mode;
 use super::panel::Focus;
 use super::prefs::TuiPreferences;
 
-pub(super) fn handle_key(app: &mut App, code: KeyCode) -> AppAction {
+pub(super) fn handle_key(app: &mut App, event: KeyEvent) -> AppAction {
+    let code = event.code;
     match &app.mode {
+        Mode::Modal => {
+            let Some(modal) = app.modal.as_mut() else {
+                app.close_modal();
+                return AppAction::None;
+            };
+            match handle_modal_key(modal, event) {
+                ModalOutcome::Cancel => AppAction::CancelModal,
+                ModalOutcome::Submit => AppAction::SubmitModal,
+                ModalOutcome::Continue => AppAction::None,
+            }
+        }
         Mode::Browse => {
             if app.focus == Focus::Detail {
                 handle_view_key(app, code)

--- a/crates/jira/src/tui/mod.rs
+++ b/crates/jira/src/tui/mod.rs
@@ -1,6 +1,7 @@
 mod app;
 mod column;
 mod keys;
+mod modal;
 mod mode;
 mod panel;
 mod picker;

--- a/crates/jira/src/tui/modal.rs
+++ b/crates/jira/src/tui/modal.rs
@@ -1,0 +1,276 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+use tui_textarea::TextArea;
+
+use super::theme::Palette;
+
+#[derive(Debug, Clone)]
+pub(super) enum ModalKind {
+    EditIssue { key: String },
+    AddComment { key: String },
+    UploadAttachment { key: String },
+}
+
+impl ModalKind {
+    pub(super) fn title(&self) -> String {
+        match self {
+            ModalKind::EditIssue { key } => format!(" Edit {key} "),
+            ModalKind::AddComment { key } => format!(" Comment on {key} "),
+            ModalKind::UploadAttachment { key } => format!(" Attach to {key} "),
+        }
+    }
+
+    pub(super) fn hint(&self) -> &'static str {
+        match self {
+            ModalKind::EditIssue { .. } => " Tab: next field   Ctrl+S: save   Esc: cancel ",
+            ModalKind::AddComment { .. } => " Ctrl+S: send   Esc: cancel ",
+            ModalKind::UploadAttachment { .. } => " Enter/Ctrl+S: upload   Esc: cancel ",
+        }
+    }
+}
+
+pub(super) struct ModalField {
+    pub label: &'static str,
+    pub area: TextArea<'static>,
+    pub multiline: bool,
+}
+
+pub(super) struct Modal {
+    pub kind: ModalKind,
+    pub fields: Vec<ModalField>,
+    pub focus: usize,
+    pub error: Option<String>,
+    pub busy: bool,
+}
+
+impl Modal {
+    pub(super) fn edit_issue(key: String, summary: String, description: String) -> Self {
+        let mut summary_area = TextArea::from(vec![summary]);
+        summary_area.set_cursor_line_style(Style::default());
+
+        let mut desc_lines: Vec<String> = description.split('\n').map(|s| s.to_string()).collect();
+        if desc_lines.is_empty() {
+            desc_lines.push(String::new());
+        }
+        let mut desc_area = TextArea::from(desc_lines);
+        desc_area.set_cursor_line_style(Style::default());
+
+        Self {
+            kind: ModalKind::EditIssue { key },
+            fields: vec![
+                ModalField {
+                    label: "Summary",
+                    area: summary_area,
+                    multiline: false,
+                },
+                ModalField {
+                    label: "Description (markdown)",
+                    area: desc_area,
+                    multiline: true,
+                },
+            ],
+            focus: 0,
+            error: None,
+            busy: false,
+        }
+    }
+
+    pub(super) fn add_comment(key: String) -> Self {
+        let mut area = TextArea::default();
+        area.set_cursor_line_style(Style::default());
+        Self {
+            kind: ModalKind::AddComment { key },
+            fields: vec![ModalField {
+                label: "Comment",
+                area,
+                multiline: true,
+            }],
+            focus: 0,
+            error: None,
+            busy: false,
+        }
+    }
+
+    pub(super) fn upload_attachment(key: String) -> Self {
+        let mut area = TextArea::default();
+        area.set_cursor_line_style(Style::default());
+        Self {
+            kind: ModalKind::UploadAttachment { key },
+            fields: vec![ModalField {
+                label: "File path",
+                area,
+                multiline: false,
+            }],
+            focus: 0,
+            error: None,
+            busy: false,
+        }
+    }
+
+    pub(super) fn next_field(&mut self) {
+        if self.fields.is_empty() {
+            return;
+        }
+        self.focus = (self.focus + 1) % self.fields.len();
+    }
+
+    pub(super) fn prev_field(&mut self) {
+        if self.fields.is_empty() {
+            return;
+        }
+        self.focus = (self.focus + self.fields.len() - 1) % self.fields.len();
+    }
+
+    pub(super) fn field_text(&self, idx: usize) -> String {
+        self.fields
+            .get(idx)
+            .map(|f| f.area.lines().join("\n"))
+            .unwrap_or_default()
+    }
+
+    pub(super) fn set_error(&mut self, msg: impl Into<String>) {
+        self.error = Some(msg.into());
+        self.busy = false;
+    }
+}
+
+pub(super) enum ModalOutcome {
+    Cancel,
+    Submit,
+    Continue,
+}
+
+/// Forward a key event to the focused textarea, with submit/cancel/nav handling.
+pub(super) fn handle_modal_key(modal: &mut Modal, key: KeyEvent) -> ModalOutcome {
+    if modal.busy {
+        return ModalOutcome::Continue;
+    }
+
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => ModalOutcome::Cancel,
+        (KeyCode::Char('s'), KeyModifiers::CONTROL)
+        | (KeyCode::Char('S'), KeyModifiers::CONTROL) => ModalOutcome::Submit,
+        (KeyCode::Tab, _) => {
+            modal.next_field();
+            ModalOutcome::Continue
+        }
+        (KeyCode::BackTab, _) => {
+            modal.prev_field();
+            ModalOutcome::Continue
+        }
+        (KeyCode::Enter, _) => {
+            let multiline = modal
+                .fields
+                .get(modal.focus)
+                .map(|f| f.multiline)
+                .unwrap_or(false);
+            if !multiline {
+                return ModalOutcome::Submit;
+            }
+            forward_to_focus(modal, key);
+            ModalOutcome::Continue
+        }
+        _ => {
+            forward_to_focus(modal, key);
+            ModalOutcome::Continue
+        }
+    }
+}
+
+fn forward_to_focus(modal: &mut Modal, key: KeyEvent) {
+    if let Some(field) = modal.fields.get_mut(modal.focus) {
+        field.area.input(key);
+    }
+}
+
+pub(super) fn render_modal(f: &mut Frame, modal: &Modal, palette: Palette, area: Rect) {
+    let outer = centered_rect(80, 80, area);
+    f.render_widget(Clear, outer);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(palette.focus_border))
+        .title(modal.kind.title())
+        .title_bottom(modal.kind.hint());
+    let inner = block.inner(outer);
+    f.render_widget(block, outer);
+
+    let mut constraints: Vec<Constraint> = Vec::new();
+    for field in &modal.fields {
+        if field.multiline {
+            constraints.push(Constraint::Min(5));
+        } else {
+            constraints.push(Constraint::Length(3));
+        }
+    }
+    constraints.push(Constraint::Length(2)); // status row
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+
+    for (idx, field) in modal.fields.iter().enumerate() {
+        let focused = idx == modal.focus;
+        let border_style = if focused {
+            Style::default()
+                .fg(palette.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette.focus_border)
+        };
+
+        let mut area_widget = field.area.clone();
+        area_widget.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(format!(" {} ", field.label)),
+        );
+        if !focused {
+            area_widget.set_cursor_style(Style::default());
+        }
+        f.render_widget(&area_widget, chunks[idx]);
+    }
+
+    let status_idx = chunks.len() - 1;
+    let status_text = if modal.busy {
+        "Working...".to_string()
+    } else if let Some(err) = &modal.error {
+        format!("⚠ {err}")
+    } else {
+        String::new()
+    };
+    let status_style = if modal.error.is_some() {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default().fg(palette.muted)
+    };
+    let status = Paragraph::new(status_text).style(status_style);
+    f.render_widget(status, chunks[status_idx]);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[0]
+}

--- a/crates/jira/src/tui/mode.rs
+++ b/crates/jira/src/tui/mode.rs
@@ -11,4 +11,5 @@ pub(super) enum Mode {
     ServerInfo,
     ConfigView,
     ThemePicker,
+    Modal,
 }

--- a/crates/jira/src/tui/prompts.rs
+++ b/crates/jira/src/tui/prompts.rs
@@ -110,51 +110,6 @@ pub(super) async fn tui_create_issue(
     Ok(Some(issue.key))
 }
 
-pub(super) async fn tui_edit_issue(client: &JiraClient, key: &str) -> Result<bool> {
-    use inquire::Text;
-
-    println!("\n── Edit {key} ──────────────────────────────────────");
-    println!("  Leave a field blank to keep its current value.\n");
-
-    let summary = Text::new("New summary (blank to skip):")
-        .prompt_skippable()?
-        .and_then(|s| {
-            if s.trim().is_empty() {
-                None
-            } else {
-                Some(s.trim().to_string())
-            }
-        });
-
-    let assignee =
-        prompt_assignee_selection(client, "Search new assignee (name/email, blank to skip):")
-            .await?;
-
-    let priority = Text::new("New priority (blank to skip):")
-        .prompt_skippable()?
-        .and_then(|s| {
-            if s.trim().is_empty() {
-                None
-            } else {
-                Some(s.trim().to_string())
-            }
-        });
-
-    if summary.is_none() && assignee.is_none() && priority.is_none() {
-        return Ok(false);
-    }
-
-    let req = UpdateIssueRequest {
-        summary,
-        assignee,
-        priority,
-        ..Default::default()
-    };
-
-    client.update_issue(key, req).await?;
-    Ok(true)
-}
-
 pub(super) fn tui_edit_saved_jql(
     existing: Option<&SavedJql>,
     suggested_jql: Option<&str>,
@@ -199,20 +154,6 @@ pub(super) fn tui_confirm_delete_saved_jql(saved: &SavedJql) -> Result<bool> {
         .with_default(false)
         .prompt()
         .map_err(Into::into)
-}
-
-pub(super) async fn tui_add_comment(client: &JiraClient, key: &str) -> Result<bool> {
-    use inquire::Text;
-
-    println!("\n── Add Comment to {key} ─────────────────────────────");
-
-    let body = match Text::new("Comment (blank to cancel):").prompt_skippable()? {
-        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
-        _ => return Ok(false),
-    };
-
-    client.add_comment(key, &body).await?;
-    Ok(true)
 }
 
 pub(super) async fn tui_add_worklog(client: &JiraClient, key: &str) -> Result<bool> {
@@ -300,24 +241,5 @@ pub(super) async fn tui_edit_labels(client: &JiraClient, key: &str) -> Result<bo
     };
 
     client.update_issue(key, req).await?;
-    Ok(true)
-}
-
-pub(super) async fn tui_upload_attachment(client: &JiraClient, key: &str) -> Result<bool> {
-    use inquire::Text;
-
-    println!("\n── Upload Attachment to {key} ────────────────────────");
-
-    let path_str = match Text::new("File path (blank to cancel):").prompt_skippable()? {
-        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
-        _ => return Ok(false),
-    };
-
-    let path = std::path::PathBuf::from(&path_str);
-    if !path.exists() {
-        anyhow::bail!("File not found: {path_str}");
-    }
-
-    client.upload_attachment(key, &path).await?;
     Ok(true)
 }

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use super::app::App;
 use super::column::{format_column_summary, AVAILABLE_COLUMNS};
+use super::modal::render_modal;
 use super::mode::Mode;
 use super::panel::{DetailTab, Focus};
 use super::theme::{Palette, ThemeName};
@@ -47,6 +48,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         Mode::ServerInfo => " Jira CLI — Server ".to_string(),
         Mode::ConfigView => " Jira CLI — Config ".to_string(),
         Mode::ThemePicker => " Jira CLI — Themes ".to_string(),
+        Mode::Modal => " Jira CLI ".to_string(),
     };
 
     let header = Paragraph::new(title).style(
@@ -100,6 +102,12 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
             render_browse(f, app, chunks[1], palette);
             render_text_popup(f, " Config View ", &app.config_lines, size, palette);
         }
+        Mode::Modal => {
+            render_browse(f, app, chunks[1], palette);
+            if let Some(modal) = app.modal.as_ref() {
+                render_modal(f, modal, palette, size);
+            }
+        }
     }
 }
 
@@ -121,6 +129,9 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
         Mode::ComponentPicker => " type:search  j/k:move  Space:toggle  Enter:save  Esc:cancel".to_string(),
         Mode::SavedJqlPicker => " j/k:move  Enter:run  c:new  e:edit  d:delete  Esc:cancel".to_string(),
         Mode::ThemePicker => " j/k:move  Enter:apply theme  Esc:cancel".to_string(),
+        Mode::Modal => {
+            " Tab:next field  Ctrl+S:submit  Enter:newline (multiline)  Esc:cancel".to_string()
+        }
         _ => " Esc:back".to_string(),
     };
 


### PR DESCRIPTION
## Summary
  - Replace `suspend_tui` + inquire prompts for **Edit Issue (`e`)**, **Add Comment (`;`)**, and
  **Upload Attachment (`u`)** with an in-TUI modal popup. The terminal no longer drops out of the
  ratatui frame for these flows.
  - Edit Issue now exposes a **Description** field (multi-line, prefilled from the issue's current
  ADF), in addition to Summary — previously the TUI had no way to edit description at all.
  - Comment is now multi-line; upload supports `~/` path expansion.
                                                                                                    
  ## Why
  The previous flows called `suspend_tui()` and dropped to inquire single-line prompts, which felt  
  jarring (TUI disappears) and could not handle multi-line bodies. Long descriptions and            
  multi-paragraph comments were impossible to author from the TUI.
                                                                                                    
  ## What changed                                           
  - **New module** `crates/jira/src/tui/modal.rs` — generic modal component (built on
  `tui-textarea`) with multi-field support, Tab/BackTab navigation, `Ctrl+S` submit, `Esc` cancel,  
  inline error row, and busy state during API calls.
  - **`Mode::Modal`** variant added; `App` gains `modal: Option<Modal>` and `prev_mode` so closing  
  the popup restores Browse/Detail focus.                                                           
  - **Action wiring**: `EditIssue` / `AddComment` / `UploadAttachment` now open a modal; new
  `SubmitModal` / `CancelModal` actions handle async API calls in the event loop (`update_issue`,   
  `add_comment`, `upload_attachment`).                      
  - **Key dispatch**: `keys::handle_key` now receives a full `KeyEvent` (modifiers required for     
  `Ctrl+S`); Modal mode forwards input to `handle_modal_key`.                                       
  - **Render overlay**: 80%×80% centered popup with `Clear` widget; status row at the bottom shows
  errors / "Working..." without closing the modal.                                                  
  - **Cleanup**: removed dead `tui_edit_issue`, `tui_add_comment`, `tui_upload_attachment` from
  `prompts.rs`.                                                                                     
  - **Dependency**: `tui-textarea = "0.7"` added to `crates/jira/Cargo.toml`.
                                                                                                    
  ## Keybindings (in modal)                                 
  | Key | Action |                                                                                  
  |-----|--------|                                          
  | `Tab` / `Shift+Tab` | Next / previous field |                                                   
  | `Enter` | Newline (multi-line fields) or submit (single-line fields) |
  | `Ctrl+S` | Submit |                                                                             
  | `Esc` | Cancel |                                                                                
                                                                                                    
  ## Test plan                                                                                      
  - [x] `e` on a selected issue opens the modal with current Summary + Description prefilled; edit
  both, `Ctrl+S` saves; list refreshes.                                                             
  - [x] `;` opens an empty multi-line comment textarea; `Enter` inserts a newline; `Ctrl+S` posts
  the comment; comments tab refreshes.                                                              
  - [x] `u` opens a single-line path field; `~/path/to/file` resolves; missing file shows inline
  error without closing the modal; valid file uploads.                                              
  - [x] `Esc` from any modal cancels and restores prior mode.
  - [x] `cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings &&  
  cargo test --all && cargo build --all` all green.