### PR TITLE
ci: decouple release packaging lanes

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -352,15 +352,14 @@ jobs:
             artifacts/**/*
             checksums.txt
 
-  # ── 4. Refresh in-repo package manifests ───────────────────────────────────
-  refresh-package-manifests:
-    name: Refresh package manifests
+  # ── 4. Collect release metadata ────────────────────────────────────────────
+  collect-release-metadata:
+    name: Collect release metadata
     runs-on: ubuntu-latest
     needs: create-release
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     outputs:
       version: ${{ steps.vars.outputs.version }}
       release_date: ${{ steps.vars.outputs.release_date }}
@@ -370,10 +369,6 @@ jobs:
       sha_linux_x86: ${{ steps.vars.outputs.sha_linux_x86 }}
       sha_windows_x86: ${{ steps.vars.outputs.sha_windows_x86 }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: main
-
       - name: Download checksums from release
         id: vars
         run: |
@@ -411,6 +406,19 @@ jobs:
             echo "release_date=$RELEASE_DATE"
           } >> "$GITHUB_OUTPUT"
 
+  refresh-package-manifests:
+    name: Refresh package manifests
+    runs-on: ubuntu-latest
+    needs: collect-release-metadata
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+
       - name: Refresh Winget source manifests
         run: |
           python3 - <<'EOF'
@@ -446,9 +454,9 @@ jobs:
               print(f'updated {path}')
           EOF
         env:
-          VERSION: ${{ steps.vars.outputs.version }}
-          RELEASE_DATE: ${{ steps.vars.outputs.release_date }}
-          SHA_WINDOWS_X86: ${{ steps.vars.outputs.sha_windows_x86 }}
+          VERSION: ${{ needs.collect-release-metadata.outputs.version }}
+          RELEASE_DATE: ${{ needs.collect-release-metadata.outputs.release_date }}
+          SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
 
       - name: Refresh Chocolatey source package
         run: |
@@ -480,22 +488,22 @@ jobs:
               print(f'updated {path}')
           EOF
         env:
-          VERSION: ${{ steps.vars.outputs.version }}
-          SHA_WINDOWS_X86: ${{ steps.vars.outputs.sha_windows_x86 }}
+          VERSION: ${{ needs.collect-release-metadata.outputs.version }}
+          SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
 
       - name: Create manifest refresh pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(packaging): refresh manifests for v${{ steps.vars.outputs.version }}"
-          branch: chore/package-manifests-v${{ steps.vars.outputs.version }}
+          commit-message: "chore(packaging): refresh manifests for v${{ needs.collect-release-metadata.outputs.version }}"
+          branch: chore/package-manifests-v${{ needs.collect-release-metadata.outputs.version }}
           delete-branch: true
-          title: "chore(packaging): refresh manifests for v${{ steps.vars.outputs.version }}"
+          title: "chore(packaging): refresh manifests for v${{ needs.collect-release-metadata.outputs.version }}"
           body: |
             ## Summary
 
-            - refresh in-repo Winget source manifests for v${{ steps.vars.outputs.version }}
-            - refresh in-repo Chocolatey package source for v${{ steps.vars.outputs.version }}
+            - refresh in-repo Winget source manifests for v${{ needs.collect-release-metadata.outputs.version }}
+            - refresh in-repo Chocolatey package source for v${{ needs.collect-release-metadata.outputs.version }}
             - update Windows installer URL and SHA256 from the published release
 
             ## Notes
@@ -514,17 +522,17 @@ jobs:
   update-homebrew:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
-    needs: refresh-package-manifests
+    needs: collect-release-metadata
     timeout-minutes: 10
     permissions:
       contents: read
     env:
-      VERSION: ${{ needs.refresh-package-manifests.outputs.version }}
-      SHA_MACOS_ARM: ${{ needs.refresh-package-manifests.outputs.sha_macos_arm }}
-      SHA_MACOS_X86: ${{ needs.refresh-package-manifests.outputs.sha_macos_x86 }}
-      SHA_LINUX_ARM: ${{ needs.refresh-package-manifests.outputs.sha_linux_arm }}
-      SHA_LINUX_X86: ${{ needs.refresh-package-manifests.outputs.sha_linux_x86 }}
-      SHA_WINDOWS_X86: ${{ needs.refresh-package-manifests.outputs.sha_windows_x86 }}
+      VERSION: ${{ needs.collect-release-metadata.outputs.version }}
+      SHA_MACOS_ARM: ${{ needs.collect-release-metadata.outputs.sha_macos_arm }}
+      SHA_MACOS_X86: ${{ needs.collect-release-metadata.outputs.sha_macos_x86 }}
+      SHA_LINUX_ARM: ${{ needs.collect-release-metadata.outputs.sha_linux_arm }}
+      SHA_LINUX_X86: ${{ needs.collect-release-metadata.outputs.sha_linux_x86 }}
+      SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
     steps:
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -581,13 +589,13 @@ jobs:
   publish-chocolatey:
     name: Publish Chocolatey package
     runs-on: windows-latest
-    needs: refresh-package-manifests
+    needs: collect-release-metadata
     timeout-minutes: 15
     permissions:
       contents: read
     env:
-      VERSION: ${{ needs.refresh-package-manifests.outputs.version }}
-      SHA_WINDOWS_X86: ${{ needs.refresh-package-manifests.outputs.sha_windows_x86 }}
+      VERSION: ${{ needs.collect-release-metadata.outputs.version }}
+      SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
       CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: winget-submit-${{ github.event.workflow_run.head_branch || github.event.inputs.release_tag }}
+  group: winget-submit-${{ github.event.workflow_run.head_branch || github.event.inputs.release_tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -23,8 +23,8 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event.workflow_run.conclusion == 'success' &&
-        (github.event.workflow_run.name == 'Release' || github.event.workflow_run.name == 'Release Recovery')
+        (github.event.workflow_run.name == 'Release' || github.event.workflow_run.name == 'Release Recovery') &&
+        github.event.workflow_run.event == 'push'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -46,15 +46,32 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RELEASE_TAG="${{ inputs.release_tag }}"
           else
-            RELEASE_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
+            RELEASE_TAG="${{ github.event.workflow_run.head_branch }}"
           fi
 
           test -n "$RELEASE_TAG"
+          case "$RELEASE_TAG" in
+            v*) ;;
+            *)
+              echo "Skipping Winget submit because workflow_run head_branch '$RELEASE_TAG' is not a release tag."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if ! gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Skipping Winget submit because GitHub release '$RELEASE_TAG' is not published yet."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           VERSION="${RELEASE_TAG#v}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download Windows ZIP and compute Winget SHA
+        if: steps.vars.outputs.skip != 'true'
         id: checksums
         run: |
           set -euo pipefail
@@ -68,6 +85,7 @@ jobs:
           echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
 
       - name: Submit Winget PR
+        if: steps.vars.outputs.skip != 'true'
         run: python3 .github/scripts/submit-winget-pr.py
         env:
           GH_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -24,7 +24,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         (github.event.workflow_run.name == 'Release' || github.event.workflow_run.name == 'Release Recovery') &&
-        github.event.workflow_run.event == 'push'
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- decouple Winget auto-submit from full release workflow success
- split release metadata collection from in-repo packaging refresh
- let Homebrew and Chocolatey depend only on published release metadata

## Why
- Chocolatey or packaging refresh failures should not block Winget submission
- Winget, Homebrew, and Chocolatey should run as independent release lanes after the GitHub release exists
- this reduces single choke points in the release DAG and makes post-release failures easier to recover

## Notes
- Winget auto-submit now self-checks that the release tag exists before submitting
- in-repo manifest refresh remains separate housekeeping and PR generation, not a blocker for downstream package lanes