### PR TITLE
fix(ci): repair ClawHub publish setup-node pin

### DIFF
--- a/.github/workflows/clawhub-publish-jirac.yml
+++ b/.github/workflows/clawhub-publish-jirac.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@8c91899e31d0e68ef6c1c3b39a0e27f2f111052f # v4.0.4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
           node-version: 22
 


### PR DESCRIPTION
## Summary
- replace the broken `actions/setup-node` SHA in the ClawHub publish workflow with the valid v4.0.4 commit pin

## Why
- the current ClawHub publish workflow on `main` fails before execution starts because GitHub cannot resolve the pinned SHA
- this is independent from the Homebrew/install changes and should be fixed in a small isolated PR

## Evidence
- failing run: `ClawHub Publish jirac` on main
- error: `Unable to resolve action actions/setup-node@...`