### PR TITLE
fix(release): correct scoop workflow paths

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -414,17 +414,18 @@ jobs:
           path: bucket
 
       - name: Verify Scoop manifest exists
-        run: test -f bucket/jirac.json
+        run: test -f bucket/bucket/jirac.json
 
       - name: Update Scoop manifest
-        run: python3 .github/scripts/update_scoop_manifest.py
+        working-directory: bucket
+        run: python3 ../.github/scripts/update_scoop_manifest.py
 
       - name: Commit and push Scoop manifest
         run: |
           cd bucket
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add jirac.json
+          git add bucket/jirac.json
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: bump jirac to v${VERSION}"
           git push

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -648,17 +648,18 @@ jobs:
           path: bucket
 
       - name: Verify Scoop manifest exists
-        run: test -f bucket/jirac.json
+        run: test -f bucket/bucket/jirac.json
 
       - name: Update Scoop manifest
-        run: python3 .github/scripts/update_scoop_manifest.py
+        working-directory: bucket
+        run: python3 ../.github/scripts/update_scoop_manifest.py
 
       - name: Commit and push Scoop manifest
         run: |
           cd bucket
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add jirac.json
+          git add bucket/jirac.json
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: bump jirac to v${VERSION}"
           git push


### PR DESCRIPTION
## Summary
- fix Scoop manifest path checks in release workflows
- run the Scoop updater from the checked out bucket repo directory
- stage the nested `bucket/jirac.json` path correctly before commit

## Why
The Scoop bucket repository is checked out into `bucket/`, so the manifest actually lives at `bucket/bucket/jirac.json` during the workflow run. The previous steps were checking and staging the wrong path.
