### PR TITLE
fix(release): align scoop lane with bucket layout

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -417,8 +417,9 @@ jobs:
         run: test -f bucket/bucket/jirac.json
 
       - name: Update Scoop manifest
-        working-directory: bucket
-        run: python3 ../.github/scripts/update_scoop_manifest.py
+        env:
+          SCOOP_MANIFEST_PATH: bucket/bucket/jirac.json
+        run: python3 .github/scripts/update_scoop_manifest.py
 
       - name: Commit and push Scoop manifest
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -651,8 +651,9 @@ jobs:
         run: test -f bucket/bucket/jirac.json
 
       - name: Update Scoop manifest
-        working-directory: bucket
-        run: python3 ../.github/scripts/update_scoop_manifest.py
+        env:
+          SCOOP_MANIFEST_PATH: bucket/bucket/jirac.json
+        run: python3 .github/scripts/update_scoop_manifest.py
 
       - name: Commit and push Scoop manifest
         run: |


### PR DESCRIPTION
## Summary
- keep the existing jira-commands release flow intact
- only fix the Scoop bucket lane to match the actual scoop-bucket layout
- use the nested manifest path consistently in both release workflows

## Why
The Scoop bucket repo is checked out at `bucket/`, and the manifest lives at `bucket/bucket/jirac.json` inside the runner workspace. The workflow must verify and update that exact path consistently.
