### PR TITLE
fix(worklog): respect Jira user timezone for started timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1569,10 +1579,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.24.4"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "chrono-tz",
  "clap",
  "crossterm 0.29.0",
  "indicatif",
@@ -1591,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.24.4"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1611,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.24.4"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2179,7 +2190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -2189,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2198,7 +2218,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -2209,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2220,6 +2240,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -3334,7 +3363,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -3371,7 +3400,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook",
  "siphasher",

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -113,15 +113,18 @@ impl JiraClient {
         Ok(headers)
     }
 
-    /// Get the current authenticated user's accountId.
-    pub async fn get_myself(&self) -> Result<String> {
+    async fn get_myself_value(&self) -> Result<Value> {
         let headers = self.auth_headers()?;
         let url = self.platform_url("/myself");
 
         let http = &self.http;
-        let user: serde_json::Value = self
-            .request(|| http.get(&url).headers(headers.clone()))
-            .await?;
+        self.request(|| http.get(&url).headers(headers.clone()))
+            .await
+    }
+
+    /// Get the current authenticated user's accountId.
+    pub async fn get_myself(&self) -> Result<String> {
+        let user = self.get_myself_value().await?;
 
         user.get("accountId")
             .and_then(|v| v.as_str())
@@ -130,6 +133,15 @@ impl JiraClient {
                 status: 0,
                 message: "Could not get accountId from /myself".into(),
             })
+    }
+
+    /// Get the current authenticated user's Jira timezone (IANA name), if available.
+    pub async fn get_myself_timezone(&self) -> Result<Option<String>> {
+        let user = self.get_myself_value().await?;
+        Ok(user
+            .get("timeZone")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()))
     }
 
     /// Resolve an assignee string to a Jira accountId.

--- a/crates/jira/Cargo.toml
+++ b/crates/jira/Cargo.toml
@@ -30,4 +30,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 indicatif = "0.17"
 open = "5"
 chrono = { version = "0.4", default-features = true }
+chrono-tz = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1956,11 +1956,21 @@ async fn worklog_add(client: JiraClient, key: String, options: WorklogAddOptions
         range,
     } = options;
 
+    let jira_timezone = if date.is_some() || start.is_some() || range.is_some() {
+        client
+            .get_myself_timezone()
+            .await
+            .context("Failed to fetch Jira user timezone")?
+    } else {
+        None
+    };
+
     if let Some(range) = range {
-        return worklog_add_range(client, key, time, comment, start, range).await;
+        return worklog_add_range(client, key, time, comment, start, range, jira_timezone).await;
     }
 
-    let started = build_worklog_started(date.as_deref(), start.as_deref())?;
+    let started =
+        build_worklog_started(date.as_deref(), start.as_deref(), jira_timezone.as_deref())?;
 
     let spinner = spinner_new(format!("Logging {time} on {key}..."));
     let log = client
@@ -1982,6 +1992,7 @@ async fn worklog_add_range(
     comment: Option<String>,
     start: Option<String>,
     range: WorklogRangeOptions,
+    jira_timezone: Option<String>,
 ) -> Result<()> {
     let WorklogRangeOptions {
         from,
@@ -2006,7 +2017,8 @@ async fn worklog_add_range(
         let date_label = date.format("%Y-%m-%d").to_string();
         pb.set_message(format!("{} ({})", key, date_label));
 
-        let started = build_worklog_started_for_date(date, start.as_deref())?;
+        let started =
+            build_worklog_started_for_date(date, start.as_deref(), jira_timezone.as_deref())?;
         match client
             .add_worklog(&key, &time, comment.as_deref(), Some(&started))
             .await

--- a/crates/jira/src/datetime.rs
+++ b/crates/jira/src/datetime.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Result};
 use chrono::{
-    Datelike, Local, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Weekday,
+    Datelike, Local, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc, Weekday,
 };
+use chrono_tz::Tz;
 
 /// Build a Jira worklog `started` timestamp.
 ///
@@ -12,39 +13,70 @@ use chrono::{
 /// - date + start => combine both
 ///
 /// Output format: `YYYY-MM-DDTHH:MM:SS.000+ZZZZ`
-pub fn build_worklog_started(date: Option<&str>, start: Option<&str>) -> Result<Option<String>> {
+pub fn build_worklog_started(
+    date: Option<&str>,
+    start: Option<&str>,
+    timezone: Option<&str>,
+) -> Result<Option<String>> {
     if date.is_none() && start.is_none() {
         return Ok(None);
     }
 
-    let now = Local::now();
+    let timezone = timezone.map(parse_timezone).transpose()?;
+    let (current_date, current_time) = current_parts(timezone.as_ref());
 
     let date = match date {
         Some(value) => Some(parse_date(value)?),
-        None => Some(now.date_naive()),
+        None => Some(current_date),
     };
 
     let time = match start {
         Some(value) => Some(parse_time(value)?),
-        None => Some(now.time()),
+        None => Some(current_time),
     };
 
-    let local = resolve_local_datetime(date.expect("date set"), time.expect("time set"))?;
-
-    Ok(Some(format_started(local)))
+    Ok(Some(resolve_started(
+        date.expect("date set"),
+        time.expect("time set"),
+        timezone.as_ref(),
+    )?))
 }
 
 /// Build a Jira worklog `started` timestamp for a specific date.
 ///
 /// When `start` is omitted, the current local time is used.
-pub fn build_worklog_started_for_date(date: NaiveDate, start: Option<&str>) -> Result<String> {
+pub fn build_worklog_started_for_date(
+    date: NaiveDate,
+    start: Option<&str>,
+    timezone: Option<&str>,
+) -> Result<String> {
+    let timezone = timezone.map(parse_timezone).transpose()?;
     let time = match start {
         Some(value) => parse_time(value)?,
-        None => Local::now().time(),
+        None => current_parts(timezone.as_ref()).1,
     };
 
-    let local = resolve_local_datetime(date, time)?;
-    Ok(format_started(local))
+    resolve_started(date, time, timezone.as_ref())
+}
+
+fn current_parts(timezone: Option<&Tz>) -> (NaiveDate, NaiveTime) {
+    match timezone {
+        Some(timezone) => {
+            let now = Utc::now().with_timezone(timezone);
+            (now.date_naive(), now.time())
+        }
+        None => {
+            let now = Local::now();
+            (now.date_naive(), now.time())
+        }
+    }
+}
+
+fn resolve_started(date: NaiveDate, time: NaiveTime, timezone: Option<&Tz>) -> Result<String> {
+    match timezone {
+        Some(timezone) => resolve_timezone_datetime(date, time, timezone).map(format_started),
+        None => resolve_local_datetime(date, time).map(format_started),
+    }
 }
 
 /// Build an inclusive list of dates for a worklog range.
@@ -85,6 +117,28 @@ pub fn build_worklog_range_dates(
     Ok(dates)
 }
 
+fn resolve_timezone_datetime(
+    date: NaiveDate,
+    time: NaiveTime,
+    timezone: &Tz,
+) -> Result<chrono::DateTime<Tz>> {
+    let naive = NaiveDateTime::new(date, time);
+    let zoned = match timezone.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(first, _) => first,
+        LocalResult::None => {
+            return Err(anyhow!(
+                "Could not resolve time for started timestamp in timezone {}: {} {}",
+                timezone.name(),
+                naive.date(),
+                naive.time().format("%H:%M:%S")
+            ))
+        }
+    };
+
+    Ok(zoned)
+}
+
 fn resolve_local_datetime(date: NaiveDate, time: NaiveTime) -> Result<chrono::DateTime<Local>> {
     let naive = NaiveDateTime::new(date, time);
     let local = match Local.from_local_datetime(&naive) {
@@ -102,14 +156,27 @@ fn resolve_local_datetime(date: NaiveDate, time: NaiveTime) -> Result<chrono::Da
     Ok(local)
 }
 
-fn format_started(local: chrono::DateTime<Local>) -> String {
-    local.format("%Y-%m-%dT%H:%M:%S.000%z").to_string()
+fn format_started<Tz>(datetime: chrono::DateTime<Tz>) -> String
+where
+    Tz: chrono::TimeZone,
+    Tz::Offset: std::fmt::Display,
+{
+    datetime.format("%Y-%m-%dT%H:%M:%S.000%z").to_string()
 }
 
 fn parse_date(value: &str) -> Result<NaiveDate> {
     NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").map_err(|_| {
         anyhow!(
             "Invalid date '{}'. Expected format: YYYY-MM-DD",
+            value.trim()
+        )
+    })
+}
+
+fn parse_timezone(value: &str) -> Result<Tz> {
+    value.trim().parse::<Tz>().map_err(|_| {
+        anyhow!(
+            "Invalid Jira timezone '{}'. Expected an IANA timezone like Asia/Jakarta",
             value.trim()
         )
     })
@@ -134,12 +201,12 @@ mod tests {
 
     #[test]
     fn returns_none_when_no_inputs_are_provided() {
-        assert!(build_worklog_started(None, None).unwrap().is_none());
+        assert!(build_worklog_started(None, None, None).unwrap().is_none());
     }
 
     #[test]
     fn builds_timestamp_when_date_and_time_are_provided() {
-        let started = build_worklog_started(Some("2026-04-21"), Some("09:30"))
+        let started = build_worklog_started(Some("2026-04-21"), Some("09:30"), None)
             .unwrap()
             .unwrap();
 
@@ -148,15 +215,32 @@ mod tests {
     }
 
     #[test]
+    fn builds_timestamp_in_jira_timezone_when_provided() {
+        let started =
+            build_worklog_started(Some("2026-04-21"), Some("08:00"), Some("Asia/Jakarta"))
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(started, "2026-04-21T08:00:00.000+0700");
+    }
+
+    #[test]
     fn rejects_invalid_date() {
-        let err = build_worklog_started(Some("21-04-2026"), Some("09:30")).unwrap_err();
+        let err = build_worklog_started(Some("21-04-2026"), Some("09:30"), None).unwrap_err();
         assert!(err.to_string().contains("Invalid date"));
     }
 
     #[test]
     fn rejects_invalid_time() {
-        let err = build_worklog_started(Some("2026-04-21"), Some("9.30")).unwrap_err();
+        let err = build_worklog_started(Some("2026-04-21"), Some("9.30"), None).unwrap_err();
         assert!(err.to_string().contains("Invalid start time"));
+    }
+
+    #[test]
+    fn rejects_invalid_timezone() {
+        let err = build_worklog_started(Some("2026-04-21"), Some("08:00"), Some("Mars/Olympus"))
+            .unwrap_err();
+        assert!(err.to_string().contains("Invalid Jira timezone"));
     }
 
     #[test]

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1527,7 +1527,21 @@ pub async fn run_tui(
                             Some(comment)
                         };
 
-                        let started = match crate::datetime::build_worklog_started(date, start) {
+                        let jira_timezone = match client.get_myself_timezone().await {
+                            Ok(timezone) => timezone,
+                            Err(e) => {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("Failed to fetch Jira timezone: {e}"));
+                                }
+                                continue;
+                            }
+                        };
+
+                        let started = match crate::datetime::build_worklog_started(
+                            date,
+                            start,
+                            jira_timezone.as_deref(),
+                        ) {
                             Ok(s) => s,
                             Err(e) => {
                                 if let Some(m) = app.modal.as_mut() {
@@ -1630,6 +1644,16 @@ pub async fn run_tui(
                             continue;
                         }
 
+                        let jira_timezone = match client.get_myself_timezone().await {
+                            Ok(timezone) => timezone,
+                            Err(e) => {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("Failed to fetch Jira timezone: {e}"));
+                                }
+                                continue;
+                            }
+                        };
+
                         let total = dates.len();
                         let confirm_token = format!(
                             "{}|{}|{}|{}|{}|{}|{}",
@@ -1678,7 +1702,9 @@ pub async fn run_tui(
                         for date in dates {
                             let date_label = date.format("%Y-%m-%d").to_string();
                             let started = match crate::datetime::build_worklog_started_for_date(
-                                date, start,
+                                date,
+                                start,
+                                jira_timezone.as_deref(),
                             ) {
                                 Ok(s) => s,
                                 Err(e) => {


### PR DESCRIPTION
## Summary

This PR fixes worklog `started` timestamp handling so explicit start times follow the active Jira user's configured timezone instead of the host machine timezone.

This ensures that when a user enters a start time such as `08:00`, the worklog is created as `08:00` in that Jira user's timezone, regardless of where the CLI/TUI is being run.

## Problem

Previously, worklog start timestamps were built using the host timezone.

That caused incorrect results when:
- the machine running `jirac` used a different timezone than the Jira user profile
- users entered explicit start times for worklogs or bulk worklogs
- the same input time was expected to stay aligned with the Jira account timezone

For example, entering `08:00` could be shifted unexpectedly if the host timezone differed from the Jira user's configured timezone.

## Changes

- add support for resolving the active Jira user's timezone from `/myself`
- use the Jira user timezone when building worklog `started` timestamps
- apply the fix to:
  - single worklog creation
  - range/bulk worklog creation
  - CLI flow
  - TUI flow
- add test coverage for timezone-aware timestamp generation
- add validation for invalid timezone values

## Behavior

### Before
- worklog start timestamps used the host timezone

### After
- worklog start timestamps use the active Jira user's configured timezone

This means:
- `08:00` is interpreted as `08:00` in the Jira user's timezone
- behavior stays correct even if the CLI/TUI is run from another country or machine timezone

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p jira-commands`