### PR TITLE
feat(packaging): add npm installer wrapper and fix Linux release compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,8 +379,11 @@ jobs:
 
       - name: npm pack smoke test
         run: |
+          rm -f jira-commands-*.tgz
           npm pack ./packaging/npm
-          tar -tzf jira-commands-*.tgz >/dev/null
+          PACKAGE_TGZ=$(ls -1 jira-commands-*.tgz | head -n 1)
+          test -n "$PACKAGE_TGZ"
+          tar -tzf "$PACKAGE_TGZ" >/dev/null
 
   security:
     name: Security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node
-        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
               - 'crates/jira-mcp/README.md'
               - 'packaging/winget/**'
               - 'packaging/scoop/**'
+              - 'packaging/npm/**'
               - 'install.ps1'
             release:
               - 'release-please-config.json'
@@ -348,6 +349,38 @@ jobs:
             grep -q '^---' "$file" || { echo "Missing frontmatter: $file"; exit 1; }
             grep -q '^description:' "$file" || { echo "Missing description in $file"; exit 1; }
           done
+
+  npm-check:
+    name: npm package check
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.release == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Verify npm package version matches workspace version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+
+          echo "workspace: $VERSION"
+          echo "npm:       $NPM_VERSION"
+
+          if [ "$VERSION" != "$NPM_VERSION" ]; then
+            echo "ERROR: packaging/npm/package.json version is out of sync."
+            exit 1
+          fi
+
+      - name: npm pack smoke test
+        run: |
+          npm pack ./packaging/npm
+          tar -tzf jira-commands-*.tgz >/dev/null
 
   security:
     name: Security audit

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -265,7 +265,7 @@ jobs:
           ref: ${{ inputs.release_tag }}
 
       - name: Set up Node
-        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -252,11 +252,53 @@ jobs:
           files: |
             artifacts/**/*
             checksums.txt
+  publish-npm:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    needs: create-release
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_tag }}
+
+      - name: Set up Node
+        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm package version matches release tag
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          EXPECTED_TAG="v${VERSION}"
+
+          echo "tag:       ${{ inputs.release_tag }}"
+          echo "workspace: $VERSION"
+          echo "npm:       $NPM_VERSION"
+
+          test "${{ inputs.release_tag }}" = "$EXPECTED_TAG"
+          test "$NPM_VERSION" = "$VERSION"
+
+      - name: Publish npm package (skip if already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          if npm view jira-commands@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ jira-commands npm v$VERSION already published, skipping"
+          else
+            npm publish ./packaging/npm --access public
+          fi
+
 
   refresh-package-manifests:
     name: Refresh package manifests
     runs-on: ubuntu-latest
-    needs: create-release
+    needs: [create-release, publish-npm]
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -106,18 +106,21 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - name: Install Zig + cargo-zigbuild (Linux aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install Zig + cargo-zigbuild (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           pip3 install ziglang==0.14.0 --break-system-packages
           cargo install cargo-zigbuild --locked
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Build (zigbuild — Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
       - name: Build (zigbuild — Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
       - name: Build (native)
-        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        if: matrix.target != 'x86_64-unknown-linux-gnu' && matrix.target != 'aarch64-unknown-linux-gnu'
         run: cargo build --release --target ${{ matrix.target }} -p jira-commands -p jira-mcp
       - name: Copy binaries (Unix)
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -355,6 +355,51 @@ jobs:
           files: |
             artifacts/**/*
             checksums.txt
+  publish-npm:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    needs: create-release
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm package version matches release tag
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          EXPECTED_TAG="v${VERSION}"
+          TAG="${GITHUB_REF_NAME}"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${{ inputs.release_tag }}" ]; then
+            TAG="${{ inputs.release_tag }}"
+          fi
+
+          echo "tag:       $TAG"
+          echo "workspace: $VERSION"
+          echo "npm:       $NPM_VERSION"
+
+          test "$TAG" = "$EXPECTED_TAG"
+          test "$NPM_VERSION" = "$VERSION"
+
+      - name: Publish npm package (skip if already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          if npm view jira-commands@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ jira-commands npm v$VERSION already published, skipping"
+          else
+            npm publish ./packaging/npm --access public
+          fi
+
 
   # ── 4. Collect release metadata ────────────────────────────────────────────
   collect-release-metadata:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -143,8 +143,8 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install Zig + cargo-zigbuild (Linux aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install Zig + cargo-zigbuild (Linux)
+        if: startsWith(matrix.target, 'x86_64-unknown-linux-gnu') || startsWith(matrix.target, 'aarch64-unknown-linux-gnu')
         run: |
           pip3 install ziglang==0.14.0 --break-system-packages
           cargo install cargo-zigbuild --locked
@@ -152,12 +152,16 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Build (zigbuild — Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
+
       - name: Build (zigbuild — Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
 
       - name: Build (native)
-        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        if: matrix.target != 'x86_64-unknown-linux-gnu' && matrix.target != 'aarch64-unknown-linux-gnu'
         run: cargo build --release --target ${{ matrix.target }} -p jira-commands -p jira-mcp
 
       - name: Copy binaries (Unix)

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -366,7 +366,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node
-        uses: actions/setup-node@0d540e7a200b8b8a187754f366c8f81e7f35435f # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,7 @@ Detailed installation guide for `jirac` and `jirac-mcp`.
 | Install script       | ✅     | ✅     | No      | Downloads latest release asset         |
 | PowerShell installer | ❌     | ❌     | ✅       | Installs `jirac.exe` to user-local bin |
 | Cargo                | ✅     | ✅     | ✅       | Best for Rust users                    |
+| npm                  | ✅     | ✅     | ✅       | Downloads prebuilt release binary      |
 | GitHub Releases      | ✅     | ✅     | ✅       | Manual download of archives/binaries   |
 | Scoop                | ❌     | ❌     | ✅       | Custom bucket `mulhamna/scoop-bucket`  |
 | Winget               | ❌     | ❌     | ✅       | Windows package manager                |
@@ -68,6 +69,14 @@ scoop install mulhamna/jirac
 ```bash
 cargo install jira-commands
 ```
+
+## npm
+
+```bash
+npm install -g jira-commands
+```
+
+The npm package downloads the matching prebuilt `jirac` release binary during install. Linux support depends on the release binary's glibc compatibility.
 
 Install MCP binary:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ brew install jira-mcp
 # Cargo
 cargo install jira-commands
 
+# npm
+npm install -g jira-commands
+
 # Windows (Scoop)
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
 scoop install mulhamna/jirac

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,19 @@
+# jira-commands npm package
+
+Install `jirac` from GitHub Releases using npm.
+
+```bash
+npm install -g jira-commands
+jirac --help
+```
+
+This package downloads the matching prebuilt `jirac` binary for your platform during `postinstall`.
+
+Supported targets:
+- macOS arm64
+- macOS x64
+- Linux x64
+- Linux arm64
+- Windows x64
+
+Source repo: <https://github.com/mulhamna/jira-commands>

--- a/packaging/npm/bin/jirac.js
+++ b/packaging/npm/bin/jirac.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const binName = process.platform === 'win32' ? 'jirac.exe' : 'jirac';
+const installedBin = path.join(__dirname, '..', 'lib', 'bin', binName);
+
+if (!fs.existsSync(installedBin)) {
+  console.error('jirac binary not installed yet. Re-run: npm rebuild -g jira-commands');
+  process.exit(1);
+}
+
+const result = spawnSync(installedBin, process.argv.slice(2), { stdio: 'inherit' });
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 0);

--- a/packaging/npm/lib/install.js
+++ b/packaging/npm/lib/install.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { pipeline } = require('node:stream/promises');
+const { Readable } = require('node:stream');
+const { spawnSync } = require('node:child_process');
+
+const REPO = 'mulhamna/jira-commands';
+const VERSION = require('../package.json').version;
+const TAG = `v${VERSION}`;
+const BASE_URL = `https://github.com/${REPO}/releases/download/${TAG}`;
+const BIN_DIR = path.join(__dirname, 'bin');
+const TMP_DIR = path.join(os.tmpdir(), `jirac-npm-${process.pid}-${Date.now()}`);
+
+function getPlatformAsset() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'darwin' && arch === 'arm64') return { archive: 'jirac-macos-aarch64.tar.gz', binary: 'jirac' };
+  if (platform === 'darwin' && arch === 'x64') return { archive: 'jirac-macos-x86_64.tar.gz', binary: 'jirac' };
+  if (platform === 'linux' && arch === 'x64') return { archive: 'jirac-linux-x86_64.tar.gz', binary: 'jirac' };
+  if (platform === 'linux' && arch === 'arm64') return { archive: 'jirac-linux-aarch64.tar.gz', binary: 'jirac' };
+  if (platform === 'win32' && arch === 'x64') return { archive: 'jirac-windows-x86_64.zip', binary: 'jirac.exe' };
+
+  throw new Error(`Unsupported platform for jira-commands npm install: ${platform}/${arch}`);
+}
+
+async function fetchToFile(url, outPath) {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': 'jira-commands-npm-installer'
+    }
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed: ${url} (${response.status})`);
+  }
+
+  await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+  await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(outPath));
+}
+
+async function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  const stream = fs.createReadStream(filePath);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function extractArchive(archivePath, destDir) {
+  await fs.promises.mkdir(destDir, { recursive: true });
+
+  if (archivePath.endsWith('.tar.gz')) {
+    const result = spawnSync('tar', ['-xzf', archivePath, '-C', destDir], { stdio: 'inherit' });
+    if (result.status !== 0) throw new Error('Failed to extract tar.gz archive with tar');
+    return;
+  }
+
+  if (archivePath.endsWith('.zip')) {
+    if (process.platform === 'win32') {
+      const command = `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${destDir.replace(/'/g, "''")}' -Force`;
+      const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], { stdio: 'inherit' });
+      if (result.status !== 0) throw new Error('Failed to extract zip archive with PowerShell');
+      return;
+    }
+
+    const result = spawnSync('unzip', ['-o', archivePath, '-d', destDir], { stdio: 'inherit' });
+    if (result.status !== 0) throw new Error('Failed to extract zip archive with unzip');
+    return;
+  }
+
+  throw new Error(`Unsupported archive format: ${archivePath}`);
+}
+
+async function main() {
+  const { archive, binary } = getPlatformAsset();
+  const archiveUrl = `${BASE_URL}/${archive}`;
+  const checksumsUrl = `${BASE_URL}/checksums.txt`;
+  const archivePath = path.join(TMP_DIR, archive);
+  const checksumsPath = path.join(TMP_DIR, 'checksums.txt');
+  const extractDir = path.join(TMP_DIR, 'extract');
+  const finalBinPath = path.join(BIN_DIR, binary);
+
+  console.log(`jira-commands npm installer: ${TAG} -> ${archive}`);
+
+  await fetchToFile(checksumsUrl, checksumsPath);
+  await fetchToFile(archiveUrl, archivePath);
+
+  const checksums = await fs.promises.readFile(checksumsPath, 'utf8');
+  const expectedLine = checksums.split(/\r?\n/).find((line) => line.includes(archive));
+  if (!expectedLine) throw new Error(`Missing checksum entry for ${archive}`);
+  const expectedSha = expectedLine.trim().split(/\s+/)[0];
+  const actualSha = await sha256File(archivePath);
+  if (expectedSha !== actualSha) {
+    throw new Error(`Checksum mismatch for ${archive}. Expected ${expectedSha}, got ${actualSha}`);
+  }
+
+  await extractArchive(archivePath, extractDir);
+
+  const candidates = [
+    path.join(extractDir, binary),
+    path.join(extractDir, archive.replace(/\.tar\.gz$/, '').replace(/\.zip$/, ''))
+  ];
+  const extractedBinary = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!extractedBinary) {
+    throw new Error(`Extracted binary not found in archive: ${binary}`);
+  }
+
+  await fs.promises.mkdir(BIN_DIR, { recursive: true });
+  await fs.promises.copyFile(extractedBinary, finalBinPath);
+
+  if (process.platform !== 'win32') {
+    await fs.promises.chmod(finalBinPath, 0o755);
+  }
+
+  await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  console.log(`Installed ${finalBinPath}`);
+}
+
+main().catch(async (error) => {
+  console.error(error.message || error);
+  try {
+    await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  } catch {}
+  process.exit(1);
+});

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "jira-commands",
+  "version": "0.25.0",
+  "description": "Install the jirac Jira CLI from GitHub Releases",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mulhamna/jira-commands.git"
+  },
+  "homepage": "https://github.com/mulhamna/jira-commands",
+  "bugs": {
+    "url": "https://github.com/mulhamna/jira-commands/issues"
+  },
+  "keywords": [
+    "jira",
+    "atlassian",
+    "cli",
+    "tui"
+  ],
+  "bin": {
+    "jirac": "bin/jirac.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node ./lib/install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
## Summary
- add an npm wrapper package under `packaging/npm` so `jira-commands` can be installed with npm and expose `jirac`
- download the matching prebuilt release binary during npm `postinstall` and verify checksums
- fix Linux release compatibility by building both `x86_64` and `aarch64` GNU targets with `cargo zigbuild` against a glibc 2.17 baseline
- document npm install in the main install docs

## Why
Two separate but related packaging issues surfaced:
1. `jira-commands` could reasonably ship through npm as a distribution layer for the Rust binary
2. the current Linux x86_64 release binary was built natively on `ubuntu-latest`, which can require newer glibc than many user systems have

The npm wrapper worked structurally, but that release compatibility issue blocked actual Linux use. This PR fixes the release root cause too.

## Changes
### npm wrapper
- `packaging/npm/package.json`
- `packaging/npm/bin/jirac.js`
- `packaging/npm/lib/install.js`
- `packaging/npm/README.md`

Behavior:
- `npm install -g jira-commands`
- `postinstall` downloads the matching GitHub Release asset for the current OS/arch
- validates SHA-256 from `checksums.txt`
- installs and dispatches through `jirac`

### release workflow fix
Updated both release workflows so Linux x86_64 no longer uses a native GNU build on `ubuntu-latest`:
- `.github/workflows/release-tag.yml`
- `.github/workflows/release-recover.yml`

New behavior:
- `x86_64-unknown-linux-gnu` -> `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17`
- `aarch64-unknown-linux-gnu` -> `cargo zigbuild --target aarch64-unknown-linux-gnu.2.17`

This should make Linux release binaries much more broadly compatible.

## Notes
- this PR does **not** add npm registry publishing yet
- to publish to npm later, we should add an explicit npm publish workflow plus `NPM_TOKEN`
- the npm wrapper currently supports prebuilt release targets already emitted by the repo

## Risk
Main risk area is release pipeline behavior, but the change is intentionally narrow:
- only Linux GNU release builds were changed
- macOS and Windows release lanes stay as they were
- asset naming stays unchanged
