### PR TITLE
fix(release): sync npm package version and package files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -44,6 +44,10 @@
         {
           "type": "generic",
           "path": "/packaging/winget/jirac.installer.yaml"
+        },
+        {
+          "type": "generic",
+          "path": "/packaging/npm/package.json"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add `packaging/npm/package.json` to `release-please-config.json` extra-files
- include the npm package files under `packaging/npm/`
- improve the npm package README so the npm install path is clearer and more compelling

## Why
The release PR for `0.26.0` failed CI because Release Please bumped `VERSION` and the Rust/Cargo files, but did not update the npm package version under `packaging/npm/package.json`.

That caused the npm CI guard to fail with:
- workspace version: `0.26.0`
- npm package version: `0.25.0`

Also, if this branch is the safe path to fix the release lane, it should carry the npm package files themselves so the release PR is generated from a coherent main branch state.

## Effect
- future release-please PRs should keep the npm package version in sync automatically
- the npm package files are present on main, not only in the earlier feature branch
- the npm package README better explains why users would install `jira-commands` from npm

## Scope
Focused release/npm packaging follow-up. No Jira runtime behavior changes.
