### PR TITLE
fix(release): sync npm package version during publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,18 +364,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Verify npm package version matches workspace version
+      - name: Verify npm package metadata is readable
         run: |
-          VERSION=$(cat VERSION | tr -d '[:space:]')
-          NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
-
-          echo "workspace: $VERSION"
-          echo "npm:       $NPM_VERSION"
-
-          if [ "$VERSION" != "$NPM_VERSION" ]; then
-            echo "ERROR: packaging/npm/package.json version is out of sync."
-            exit 1
-          fi
+          node -e "const pkg=require('./packaging/npm/package.json'); if(!pkg.name||!pkg.version||!pkg.bin?.jirac){throw new Error('invalid npm package metadata')}"
+          echo "npm package metadata looks valid"
 
       - name: npm pack smoke test
         run: |

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -270,6 +270,18 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Sync npm package version from release version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          node - <<'EOF'
+          const fs = require('fs');
+          const path = 'packaging/npm/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.version = process.env.VERSION;
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+          EOF
+          echo "synced npm package.json version to $VERSION"
+
       - name: Verify npm package version matches release tag
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -371,6 +371,18 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Sync npm package version from release version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          node - <<'EOF'
+          const fs = require('fs');
+          const path = 'packaging/npm/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.version = process.env.VERSION;
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+          EOF
+          echo "synced npm package.json version to $VERSION"
+
       - name: Verify npm package version matches release tag
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')


### PR DESCRIPTION
## Summary
- stop requiring `packaging/npm/package.json` to match `VERSION` in normal CI
- explicitly rewrite the npm package version from `VERSION` inside release publish workflows before npm publish

## Root cause
Release Please fetches `packaging/npm/package.json`, but with the current `simple` strategy plus generic `extra-files`, it does **not** rewrite the JSON `version` field.

That means release PRs can legitimately have:
- `VERSION = 0.26.0`
- `packaging/npm/package.json = 0.25.0`

So the previous CI guard was failing on a condition Release Please does not satisfy automatically.

## What this changes
- CI still validates npm package metadata and `npm pack`, but no longer assumes Release Please will keep the npm JSON version in sync on release PR branches
- release workflows now sync `packaging/npm/package.json` from `VERSION` right before npm publish, then verify the tag/version alignment

## Why this is safer
This moves version synchronization into a path we explicitly control, instead of depending on unsupported or unreliable generic JSON bump behavior from Release Please.
