### PR TITLE
fix(tui): render mentions and separate comments

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -273,11 +273,12 @@ jobs:
       - name: Sync npm package version from release version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
-          node - <<'EOF'
+          VERSION="$VERSION" node - <<'EOF'
           const fs = require('fs');
           const path = 'packaging/npm/package.json';
           const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
           pkg.version = process.env.VERSION;
+          if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
           EOF
           echo "synced npm package.json version to $VERSION"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -374,11 +374,12 @@ jobs:
       - name: Sync npm package version from release version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
-          node - <<'EOF'
+          VERSION="$VERSION" node - <<'EOF'
           const fs = require('fs');
           const path = 'packaging/npm/package.json';
           const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
           pkg.version = process.env.VERSION;
+          if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
           EOF
           echo "synced npm package.json version to $VERSION"

--- a/crates/jira-core/src/adf.rs
+++ b/crates/jira-core/src/adf.rs
@@ -21,6 +21,19 @@ fn render_node(node: &Value, out: &mut String, depth: usize) {
                 out.push_str(text);
             }
         }
+        "mention" => {
+            let mention_text = node
+                .get("attrs")
+                .and_then(|a| a.get("text"))
+                .and_then(|v| v.as_str())
+                .or_else(|| {
+                    node.get("attrs")
+                        .and_then(|a| a.get("id"))
+                        .and_then(|v| v.as_str())
+                })
+                .unwrap_or("@unknown");
+            out.push_str(mention_text);
+        }
         "hardBreak" => {
             out.push('\n');
         }

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -358,7 +358,14 @@ fn build_comment_lines(app: &App, palette: Palette) -> Vec<Line<'static>> {
                 Line::from(format!("{} comment(s)", comments.len())),
                 Line::from(""),
             ];
-            for comment in comments {
+            for (idx, comment) in comments.iter().enumerate() {
+                if idx > 0 {
+                    lines.push(Line::from(Span::styled(
+                        "─".repeat(48),
+                        Style::default().fg(palette.border),
+                    )));
+                    lines.push(Line::from(""));
+                }
                 let author = comment.author.clone().unwrap_or_else(|| "Unknown".into());
                 let created = comment.created.get(..10).unwrap_or(&comment.created);
                 lines.push(Line::from(vec![

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -362,7 +362,7 @@ fn build_comment_lines(app: &App, palette: Palette) -> Vec<Line<'static>> {
                 if idx > 0 {
                     lines.push(Line::from(Span::styled(
                         "─".repeat(48),
-                        Style::default().fg(palette.border),
+                        Style::default().fg(palette.muted),
                     )));
                     lines.push(Line::from(""));
                 }


### PR DESCRIPTION
## Summary
- render ADF `mention` nodes back to visible text in TUI comment views
- add clearer separators between comments in the TUI details panel

## Problem
Two comment UX bugs showed up in the TUI:
1. `@mentions` were missing when comments were rendered back into preview text
2. comment bodies visually ran together because there was no strong separator between entries

## Root cause
- `jira_core::adf::adf_to_text()` handled many ADF node types, but not `mention`
- comment rendering in `crates/jira/src/tui/render.rs` only used blank lines between entries, which was too weak once comments had multiline bodies

## Fix
- support ADF `mention` nodes in `adf_to_text()` by rendering `attrs.text` when available
- insert a horizontal separator between comment entries in the TUI comments tab

## Validation
- `cargo test -p jira-core adf`
