### PR TITLE
fix(npm): publish package under @mulham28/jirac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,10 +364,19 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Verify npm package metadata is readable
+      - name: Verify npm package version matches workspace version
         run: |
-          node -e "const pkg=require('./packaging/npm/package.json'); if(!pkg.name||!pkg.version||!pkg.bin?.jirac){throw new Error('invalid npm package metadata')}"
-          echo "npm package metadata looks valid"
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+
+          echo "workspace: $VERSION"
+          echo "npm:       $NPM_VERSION"
+
+          if [ "$VERSION" != "$NPM_VERSION" ]; then
+            echo "ERROR: packaging/npm/package.json version is out of sync."
+            echo "Run: node scripts/sync-npm-version.mjs"
+            exit 1
+          fi
 
       - name: npm pack smoke test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
         run: |
           rm -f jira-commands-*.tgz
           npm pack ./packaging/npm
-          PACKAGE_TGZ=$(ls -1 jira-commands-*.tgz | head -n 1)
+          PACKAGE_TGZ=$(ls -1 mulham28-jirac-*.tgz | head -n 1)
           test -n "$PACKAGE_TGZ"
           tar -tzf "$PACKAGE_TGZ" >/dev/null
 

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -301,8 +301,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./packaging/npm/package.json').version")
-          if npm view jira-commands@"$VERSION" version >/dev/null 2>&1; then
-            echo "✓ jira-commands npm v$VERSION already published, skipping"
+          if npm view @mulham28/jirac@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
             npm publish ./packaging/npm --access public
           fi

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -407,8 +407,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./packaging/npm/package.json').version")
-          if npm view jira-commands@"$VERSION" version >/dev/null 2>&1; then
-            echo "✓ jira-commands npm v$VERSION already published, skipping"
+          if npm view @mulham28/jirac@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
             npm publish ./packaging/npm --access public
           fi

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ cargo install jira-commands
 ## npm
 
 ```bash
-npm install -g jira-commands
+npm install -g @mulham28/jirac
 ```
 
 The npm package downloads the matching prebuilt `jirac` release binary during install. Linux support depends on the release binary's glibc compatibility.

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,9 +1,9 @@
-# jira-commands npm package
+# @mulham28/jirac npm package
 
 Install `jirac` from GitHub Releases using npm.
 
 ```bash
-npm install -g jira-commands
+npm install -g @mulham28/jirac
 jirac --help
 ```
 

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulham28/jirac",
-  "version": "0.25.0",
+  "version": "0.26.1",
   "description": "Install the jirac Jira CLI from GitHub Releases",
   "license": "MIT OR Apache-2.0",
   "repository": {
@@ -26,7 +26,8 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "node ./lib/install.js"
+    "postinstall": "node ./lib/install.js",
+    "release:check": "node ../../scripts/sync-npm-version.mjs && git diff --exit-code -- packaging/npm/package.json"
   },
   "engines": {
     "node": ">=18"

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jira-commands",
+  "name": "@mulham28/jirac",
   "version": "0.25.0",
   "description": "Install the jirac Jira CLI from GitHub Releases",
   "license": "MIT OR Apache-2.0",

--- a/scripts/sync-npm-version.mjs
+++ b/scripts/sync-npm-version.mjs
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const versionPath = path.join(root, 'VERSION');
+const pkgPath = path.join(root, 'packaging', 'npm', 'package.json');
+
+const version = fs.readFileSync(versionPath, 'utf8').trim();
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+pkg.version = version;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log(`synced ${pkg.name} -> ${version}`);


### PR DESCRIPTION
## Summary
- rename the npm package from `jira-commands` to `@mulham28/jirac`
- update npm install docs and package README
- update CI/release workflows to check and publish the scoped package name

## Why
Recent release runs showed the npm workflow logic is now working, but publish still fails with:

- `403 Forbidden - PUT https://registry.npmjs.org/jira-commands`

Meanwhile an existing published package in your npm account (`pkgmap`) uses a scoped name (`@mulham28/pkgmap`).

Registry checks show:
- `@mulham28/jirac` -> 404 (available)
- `@mulham28/jira-commands` -> 404 (available)
- unscoped `jira-commands` publish is forbidden for the current token/account

Using `@mulham28/jirac` is the cleanest fit because it matches the CLI binary name.

## Effect
Users will install with:

```bash
npm install -g @mulham28/jirac
```

while still invoking:

```bash
jirac
```
