### PR TITLE
fix(release): sync npm version before release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,8 +39,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  sync-npm-version:
+    name: Sync npm package version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      changed: ${{ steps.sync.outputs.changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Sync npm version from VERSION
+        id: sync
+        run: |
+          node scripts/sync-npm-version.mjs
+          if git diff --quiet -- packaging/npm/package.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit synced npm package version
+        if: steps.sync.outputs.changed == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add packaging/npm/package.json
+          git commit -m "chore(npm): sync package version with VERSION"
+          git push
+
   release-please:
     name: Release Please
+    needs: sync-npm-version
+    if: needs.sync-npm-version.outputs.changed != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary
- add a pre-step in `release-please.yml` to sync `packaging/npm/package.json` from `VERSION`
- auto-commit that sync on `main` when needed
- skip the same workflow's Release Please step on that run and let the follow-up push rerun Release Please from a clean aligned state

## Why
Release Please does not reliably rewrite `packaging/npm/package.json` for this repo's current setup, so release PRs were opening with:
- `VERSION = 0.26.2`
- `packaging/npm/package.json = 0.26.1`

That made the strict npm version CI check fail on release PRs.

## How this works
On every push to `main`:
1. sync npm package version from `VERSION`
2. if `package.json` changed, commit and push that small sync commit
3. do **not** run Release Please in the same workflow run
4. the follow-up push reruns the workflow, now with aligned files, and Release Please can generate/update the release PR cleanly

## Scope
Release automation only. No CLI/runtime behavior changes.
