### PR TITLE
fix(ci): allow release-please npm version lag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,11 +368,20 @@ jobs:
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          HEAD_REF="${GITHUB_HEAD_REF:-}"
 
           echo "workspace: $VERSION"
           echo "npm:       $NPM_VERSION"
+          echo "head_ref:  $HEAD_REF"
 
           if [ "$VERSION" != "$NPM_VERSION" ]; then
+            if [[ "$HEAD_REF" == release-please--branches--* ]]; then
+              echo "Release Please branch version mismatch detected."
+              echo "This branch is expected to lag because release-please does not rewrite packaging/npm/package.json in this repo's current setup."
+              echo "The publish workflows still resync packaging/npm/package.json from VERSION before npm publish."
+              exit 0
+            fi
+
             echo "ERROR: packaging/npm/package.json version is out of sync."
             echo "Run: node scripts/sync-npm-version.mjs"
             exit 1


### PR DESCRIPTION
## Summary
- allow the npm version sync check to pass on `release-please--branches--*` PRs when `packaging/npm/package.json` lags the bumped `VERSION`

## Why
Observed logs on release PRs show:
- `workspace: 0.26.2`
- `npm: 0.26.1`

This is happening because the current `release-please` setup bumps `VERSION` and Cargo files, but does **not** rewrite `packaging/npm/package.json` in the generated release PR branch.

That behavior persists even after clearing stale release-please branches and regenerating the PR from current `main`.

## Safety
- normal branches still fail when npm package version drifts from `VERSION`
- only release-please PR branches get this exception
- the release/publish workflows still resync `packaging/npm/package.json` from `VERSION` before npm publish
