### PR TITLE
chore(packaging): refresh manifests for v0.26.1

### DIFF
--- a/packaging/chocolatey/jirac.nuspec
+++ b/packaging/chocolatey/jirac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jirac</id>
-    <version>0.26.0</version>
+    <version>0.26.1</version>
     <packageSourceUrl>https://github.com/mulhamna/jira-commands</packageSourceUrl>
     <owners>mulhamna</owners>
     <title>jirac</title>
@@ -16,7 +16,7 @@
     <tags>jira atlassian cli tui rust mcp</tags>
     <summary>Jira terminal client with TUI, MCP support, and native release archives.</summary>
     <description>jirac is a fast Jira CLI and TUI built in Rust. It supports interactive issue browsing, transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.</description>
-    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v0.26.0</releaseNotes>
+    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v0.26.1</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'jirac'
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v0.26.0/jirac-windows-x86_64.zip'
-$checksum64 = '27df97ade9fe1f8b9aad0d32818706cf849095eb5b1a0e65b997e624f70ba0ac'
+$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v0.26.1/jirac-windows-x86_64.zip'
+$checksum64 = '2a7abde9ab52a0d48938441628a6f66fabb6ddf1049b75025c6528d7091f0548'
 
 $packageArgs = @{
   packageName    = $packageName

--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.26.0
+PackageVersion: 0.26.1
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -9,7 +9,7 @@ NestedInstallerFiles:
 ReleaseDate: 2026-04-30
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.26.0/jirac-windows-x86_64.zip
-    InstallerSha256: 27df97ade9fe1f8b9aad0d32818706cf849095eb5b1a0e65b997e624f70ba0ac
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.26.1/jirac-windows-x86_64.zip
+    InstallerSha256: 2a7abde9ab52a0d48938441628a6f66fabb6ddf1049b75025c6528d7091f0548
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.26.0
+PackageVersion: 0.26.1
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.26.0
+PackageVersion: 0.26.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for v0.26.1
- refresh in-repo Chocolatey package source for v0.26.1
- update Windows installer URL and SHA256 from the published release

## Notes

- recreated from the previously stale manifest refresh change on top of current `main`
- Winget community submission remains a separate follow-up workflow
- Chocolatey publish uses the refreshed source package metadata
