### PR TITLE
docs: update crate READMEs for MCP helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ plugin/
 ### Crate responsibilities
 
 - **`jira-core`** — public API: `JiraClient`, model types (split under `model/`), ADF parser, auth (Cloud + Data Center multi-profile), `FieldCache` for custom-field resolution, error types. Library dependency.
-- **`jira/`** — clap commands (`cli/{api,auth,issue,plan}.rs`), modular TUI (ratatui + crossterm, 10 submodules under `tui/`), interactive prompts (inquire), datetime helpers. Binary: `jirac`.
+- **`jira/`** — clap commands (`cli/{api,auth,issue,mcp,plan}.rs`), modular TUI (ratatui + crossterm, 10 submodules under `tui/`), interactive prompts (inquire), datetime helpers. Binary: `jirac`. `mcp` subcommand: `jirac mcp doctor` + `jirac mcp install --client <target>` to register `jirac-mcp` into supported clients (claude-code, claude-desktop, cursor, gemini-cli, codex, generic-json).
 - **`jira-mcp/`** — MCP server via `rmcp`, split into `app.rs` (wiring) + `server.rs` (impl) + `models.rs` (I/O types). Exposes `jira-core` as MCP tools for LLM clients. Binary: `jirac-mcp`.
 
 ---

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -65,6 +65,25 @@ The MCP server includes tools for:
 - Destructive operations require `confirm: true`.
 - Attachment uploads support local file paths or inline base64 payloads.
 
+## Client install helper
+
+If you already have both `jirac` and `jirac-mcp` installed, you can register the MCP server into supported clients with:
+
+```bash
+jirac mcp doctor
+jirac mcp install --client claude-code
+jirac mcp install --client claude-desktop
+jirac mcp install --client cursor
+jirac mcp install --client gemini-cli
+jirac mcp install --client codex
+jirac mcp install --client generic-json
+```
+
+Notes:
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
+- `generic-json` prints a portable JSON snippet instead of writing a file
+- `cursor` remains provisional until verified in a real Cursor install
+
 ## More docs
 
-See the root README for example client configuration and workspace-level context.
+See the root README and `INSTALL.md` for client-specific install notes, helper target details, and workspace-level context.

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -40,6 +40,8 @@ jirac issue view MYPROJ-123
 jirac issue create -p MYPROJ
 jirac issue render --input desc.md
 jirac tui -p MYPROJ
+jirac mcp doctor
+jirac mcp install --client claude-code
 ```
 
 ## Config and auth
@@ -91,6 +93,25 @@ Useful skills include:
 - `/jira:jql`
 - `/jira:api`
 
+## MCP helper
+
+If you also installed `jirac-mcp`, `jirac` can register the MCP server into supported clients for you:
+
+```bash
+jirac mcp doctor
+jirac mcp install --client claude-code
+jirac mcp install --client claude-desktop
+jirac mcp install --client cursor
+jirac mcp install --client gemini-cli
+jirac mcp install --client codex
+jirac mcp install --client generic-json
+```
+
+Notes:
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
+- `generic-json` prints a portable JSON snippet instead of writing a file
+- `cursor` remains provisional until verified in a real Cursor install
+
 ## More docs
 
-See the root README for full installation, TUI shortcuts, MCP usage, release artifacts, and examples.
+See the root README and `INSTALL.md` for full installation, TUI shortcuts, MCP usage, release artifacts, and examples.


### PR DESCRIPTION
## Summary
- update crates/jira/README.md with MCP helper quick start and notes
- update crates/jira-mcp/README.md with client install helper guidance
- point readers to INSTALL.md for detailed target-specific install notes

## Testing
- docs only