### PR TITLE
feat(tui): allow attachment upload from comment modal

### DIFF
--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1438,14 +1438,31 @@ pub async fn run_tui(
                     }
                     ModalKind::AddComment { key } => {
                         let body = modal.field_text(0);
+                        let attachment_raw = modal.field_text(1);
                         let mention_map = modal.mention_map.clone();
                         let body_trim = body.trim().to_string();
+                        let attachment_trim = attachment_raw.trim().to_string();
                         if body_trim.is_empty() {
                             if let Some(m) = app.modal.as_mut() {
                                 m.set_error("Comment cannot be empty");
                             }
                             continue;
                         }
+
+                        let attachment_path = if attachment_trim.is_empty() {
+                            None
+                        } else {
+                            let expanded = shellexpand_tilde(&attachment_trim);
+                            let path = std::path::PathBuf::from(expanded.as_ref());
+                            if !path.exists() {
+                                if let Some(m) = app.modal.as_mut() {
+                                    m.set_error(format!("File not found: {attachment_trim}"));
+                                }
+                                continue;
+                            }
+                            Some(path)
+                        };
+
                         if let Some(m) = app.modal.as_mut() {
                             m.busy = true;
                         }
@@ -1454,10 +1471,32 @@ pub async fn run_tui(
                         inject_mentions(&mut adf, &mention_map);
                         match client.add_comment_adf(&key, adf).await {
                             Ok(_) => {
-                                app.close_modal();
-                                app.detail.comments = None;
-                                app.warm_active_tab(&client).await;
-                                app.set_status(format!("✓ Comment added to {key}"), false);
+                                if let Some(path) = attachment_path {
+                                    match client.upload_attachment(&key, &path).await {
+                                        Ok(_) => {
+                                            app.close_modal();
+                                            app.detail.comments = None;
+                                            app.warm_active_tab(&client).await;
+                                            app.set_status(
+                                                format!("✓ Comment and attachment added to {key}"),
+                                                false,
+                                            );
+                                        }
+                                        Err(e) => {
+                                            if let Some(m) = app.modal.as_mut() {
+                                                m.busy = false;
+                                                m.set_error(format!(
+                                                    "Comment added, but upload failed: {e}"
+                                                ));
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    app.close_modal();
+                                    app.detail.comments = None;
+                                    app.warm_active_tab(&client).await;
+                                    app.set_status(format!("✓ Comment added to {key}"), false);
+                                }
                             }
                             Err(e) => {
                                 if let Some(m) = app.modal.as_mut() {

--- a/crates/jira/src/tui/modal.rs
+++ b/crates/jira/src/tui/modal.rs
@@ -55,7 +55,7 @@ impl ModalKind {
     pub(super) fn hint(&self) -> &'static str {
         match self {
             ModalKind::EditIssue { .. } => " Tab: next field   Ctrl+S: save   Esc: cancel ",
-            ModalKind::AddComment { .. } => " Ctrl+S: send   Esc: cancel ",
+            ModalKind::AddComment { .. } => " Tab: next field   Ctrl+S: send   Esc: cancel ",
             ModalKind::UploadAttachment { .. } => " Enter/Ctrl+S: upload   Esc: cancel ",
             ModalKind::AddWorklog { .. } => " Tab: next field   Ctrl+S: log   Esc: cancel ",
             ModalKind::AddBulkWorklog { .. } => {
@@ -132,15 +132,27 @@ impl Modal {
     }
 
     pub(super) fn add_comment(key: String) -> Self {
-        let mut area = TextArea::default();
-        area.set_cursor_line_style(Style::default());
+        let mut comment_area = TextArea::default();
+        comment_area.set_cursor_line_style(Style::default());
+
+        let mut attachment_area = TextArea::default();
+        attachment_area.set_cursor_line_style(Style::default());
+        attachment_area.set_placeholder_text("optional path, e.g. ./screenshot.png");
+
         Self {
             kind: ModalKind::AddComment { key },
-            fields: vec![ModalField {
-                label: "Comment",
-                area,
-                multiline: true,
-            }],
+            fields: vec![
+                ModalField {
+                    label: "Comment",
+                    area: comment_area,
+                    multiline: true,
+                },
+                ModalField {
+                    label: "Attachment path  (optional)",
+                    area: attachment_area,
+                    multiline: false,
+                },
+            ],
             focus: 0,
             error: None,
             notice: None,


### PR DESCRIPTION
## Summary
- add an optional attachment path field to the TUI comment modal
- submit the comment first, then upload the attachment when a path is provided
- keep the existing standalone upload flow intact while making comment-driven uploads faster

## Testing
- cargo fmt --all
- cargo test -p jira-commands tui -- --nocapture
