### PR TITLE
docs: add OpenSSF badge to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Jira on the command line.
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT + Apache-2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-blue.svg)](LICENSE-MIT)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 `jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It supports Jira Cloud and Jira Data Center, stores multiple login profiles, and discovers custom fields at runtime so there is little to configure beyond your credentials.
 

--- a/crates/jira-core/README.md
+++ b/crates/jira-core/README.md
@@ -9,6 +9,7 @@ This crate is versioned and released from the `mulhamna/jira-commands` workspace
 
 [![Crates.io](https://img.shields.io/crates/v/jira-core.svg)](https://crates.io/crates/jira-core)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 ## Install
 

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -6,6 +6,7 @@
 `jira-mcp` is the MCP server crate in the `mulhamna/jira-commands` workspace. It reuses `jira-core` and exposes typed Jira tools for editors, assistants, and remote MCP clients.
 
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 ## Install
 

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -65,6 +65,25 @@ The MCP server includes tools for:
 - Destructive operations require `confirm: true`.
 - Attachment uploads support local file paths or inline base64 payloads.
 
+## Client install helper
+
+If you already have both `jirac` and `jirac-mcp` installed, you can register the MCP server into supported clients with:
+
+```bash
+jirac mcp doctor
+jirac mcp install --client claude-code
+jirac mcp install --client claude-desktop
+jirac mcp install --client cursor
+jirac mcp install --client gemini-cli
+jirac mcp install --client codex
+jirac mcp install --client generic-json
+```
+
+Notes:
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
+- `generic-json` prints a portable JSON snippet instead of writing a file
+- `cursor` remains provisional until verified in a real Cursor install
+
 ## More docs
 
-See the root README for example client configuration and workspace-level context.
+See the root README and `INSTALL.md` for client-specific install notes, helper target details, and workspace-level context.

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -8,6 +8,7 @@
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 ## Install
 

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -40,6 +40,8 @@ jirac issue view MYPROJ-123
 jirac issue create -p MYPROJ
 jirac issue render --input desc.md
 jirac tui -p MYPROJ
+jirac mcp doctor
+jirac mcp install --client claude-code
 ```
 
 ## Config and auth
@@ -91,6 +93,25 @@ Useful skills include:
 - `/jira:jql`
 - `/jira:api`
 
+## MCP helper
+
+If you also installed `jirac-mcp`, `jirac` can register the MCP server into supported clients for you:
+
+```bash
+jirac mcp doctor
+jirac mcp install --client claude-code
+jirac mcp install --client claude-desktop
+jirac mcp install --client cursor
+jirac mcp install --client gemini-cli
+jirac mcp install --client codex
+jirac mcp install --client generic-json
+```
+
+Notes:
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
+- `generic-json` prints a portable JSON snippet instead of writing a file
+- `cursor` remains provisional until verified in a real Cursor install
+
 ## More docs
 
-See the root README for full installation, TUI shortcuts, MCP usage, release artifacts, and examples.
+See the root README and `INSTALL.md` for full installation, TUI shortcuts, MCP usage, release artifacts, and examples.

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -6,6 +6,7 @@ A fast, polished Jira CLI and TUI built in Rust.
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 `jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports custom fields discovered at runtime, native attachment uploads, cursor-based pagination, Jira Cloud, and Jira Data Center.
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,4 +1,5 @@
 # @mulham28/jirac npm package
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 Install `jirac` from GitHub Releases using npm.
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,4 +1,5 @@
 # jira — Claude Code Plugin
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 
 Manage Jira issues directly from Claude Code. Create, list, view, transition, comment, log time, and run bulk operations without leaving your editor.
 


### PR DESCRIPTION
## Summary
- add the OpenSSF Best Practices badge to the main workspace README
- add the badge to crate and integration readmes that are user-facing
- keep internal packaging note docs unchanged

## Testing
- docs only
