### PR TITLE
chore(tui): extract shared picker key and render helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Jira on the command line.
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT + Apache-2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 `jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It supports Jira Cloud and Jira Data Center, stores multiple login profiles, and discovers custom fields at runtime so there is little to configure beyond your credentials.
 

--- a/crates/jira-core/README.md
+++ b/crates/jira-core/README.md
@@ -10,6 +10,7 @@ This crate is versioned and released from the `mulhamna/jira-commands` workspace
 [![Crates.io](https://img.shields.io/crates/v/jira-core.svg)](https://crates.io/crates/jira-core)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 ## Install
 

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -7,6 +7,7 @@
 
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 ## Install
 

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -9,6 +9,7 @@
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 ## Install
 

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -1,4 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::widgets::ListState;
 
 use super::app::{App, AppAction};
 use super::column::default_column_ids;
@@ -632,53 +633,27 @@ fn handle_component_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Down => {
-            let i = app
-                .component_state
-                .selected()
-                .map(|i| (i + 1).min(app.component_options.len().saturating_sub(1)))
-                .unwrap_or(0);
-            app.component_state.select(Some(i));
+            picker_nav_down(&mut app.component_state, app.component_options.len());
             AppAction::None
         }
         KeyCode::Up => {
-            let i = app
-                .component_state
-                .selected()
-                .map(|i| i.saturating_sub(1))
-                .unwrap_or(0);
-            app.component_state.select(Some(i));
+            picker_nav_up(&mut app.component_state);
             AppAction::None
         }
         KeyCode::Left => {
-            if app.component_cursor > 0 {
-                app.component_cursor -= 1;
-            }
+            picker_cursor_left(&mut app.component_cursor);
             AppAction::None
         }
         KeyCode::Right => {
-            if app.component_cursor < app.component_query.chars().count() {
-                app.component_cursor += 1;
-            }
+            picker_cursor_right(&mut app.component_cursor, &app.component_query);
             AppAction::None
         }
         KeyCode::Backspace => {
-            if app.component_cursor > 0 {
-                app.component_cursor -= 1;
-                let byte_pos = app
-                    .component_query
-                    .char_indices()
-                    .nth(app.component_cursor)
-                    .map(|(i, _)| i)
-                    .unwrap_or(app.component_query.len());
-                let char_len = app.component_query[byte_pos..]
-                    .chars()
-                    .next()
-                    .map(|c| c.len_utf8())
-                    .unwrap_or(0);
-                app.component_query.drain(byte_pos..byte_pos + char_len);
-                return AppAction::RefreshComponentOptions;
+            if picker_backspace(&mut app.component_query, &mut app.component_cursor) {
+                AppAction::RefreshComponentOptions
+            } else {
+                AppAction::None
             }
-            AppAction::None
         }
         KeyCode::Char(' ') => {
             if let Some(idx) = app.component_state.selected() {
@@ -693,14 +668,7 @@ fn handle_component_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Char(c) => {
-            let byte_pos = app
-                .component_query
-                .char_indices()
-                .nth(app.component_cursor)
-                .map(|(i, _)| i)
-                .unwrap_or(app.component_query.len());
-            app.component_query.insert(byte_pos, c);
-            app.component_cursor += 1;
+            picker_type_char(&mut app.component_query, &mut app.component_cursor, c);
             AppAction::RefreshComponentOptions
         }
         KeyCode::Enter => {
@@ -718,53 +686,27 @@ fn handle_fix_version_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Down => {
-            let i = app
-                .fix_version_state
-                .selected()
-                .map(|i| (i + 1).min(app.fix_version_options.len().saturating_sub(1)))
-                .unwrap_or(0);
-            app.fix_version_state.select(Some(i));
+            picker_nav_down(&mut app.fix_version_state, app.fix_version_options.len());
             AppAction::None
         }
         KeyCode::Up => {
-            let i = app
-                .fix_version_state
-                .selected()
-                .map(|i| i.saturating_sub(1))
-                .unwrap_or(0);
-            app.fix_version_state.select(Some(i));
+            picker_nav_up(&mut app.fix_version_state);
             AppAction::None
         }
         KeyCode::Left => {
-            if app.fix_version_cursor > 0 {
-                app.fix_version_cursor -= 1;
-            }
+            picker_cursor_left(&mut app.fix_version_cursor);
             AppAction::None
         }
         KeyCode::Right => {
-            if app.fix_version_cursor < app.fix_version_query.chars().count() {
-                app.fix_version_cursor += 1;
-            }
+            picker_cursor_right(&mut app.fix_version_cursor, &app.fix_version_query);
             AppAction::None
         }
         KeyCode::Backspace => {
-            if app.fix_version_cursor > 0 {
-                app.fix_version_cursor -= 1;
-                let byte_pos = app
-                    .fix_version_query
-                    .char_indices()
-                    .nth(app.fix_version_cursor)
-                    .map(|(i, _)| i)
-                    .unwrap_or(app.fix_version_query.len());
-                let char_len = app.fix_version_query[byte_pos..]
-                    .chars()
-                    .next()
-                    .map(|c| c.len_utf8())
-                    .unwrap_or(0);
-                app.fix_version_query.drain(byte_pos..byte_pos + char_len);
-                return AppAction::RefreshFixVersionOptions;
+            if picker_backspace(&mut app.fix_version_query, &mut app.fix_version_cursor) {
+                AppAction::RefreshFixVersionOptions
+            } else {
+                AppAction::None
             }
-            AppAction::None
         }
         KeyCode::Char(' ') => {
             if let Some(idx) = app.fix_version_state.selected() {
@@ -779,14 +721,7 @@ fn handle_fix_version_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Char(c) => {
-            let byte_pos = app
-                .fix_version_query
-                .char_indices()
-                .nth(app.fix_version_cursor)
-                .map(|(i, _)| i)
-                .unwrap_or(app.fix_version_query.len());
-            app.fix_version_query.insert(byte_pos, c);
-            app.fix_version_cursor += 1;
+            picker_type_char(&mut app.fix_version_query, &mut app.fix_version_cursor, c);
             AppAction::RefreshFixVersionOptions
         }
         KeyCode::Enter => {
@@ -804,66 +739,88 @@ fn handle_sprint_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Down => {
-            let i = app
-                .sprint_state
-                .selected()
-                .map(|i| (i + 1).min(app.sprint_options.len().saturating_sub(1)))
-                .unwrap_or(0);
-            app.sprint_state.select(Some(i));
+            picker_nav_down(&mut app.sprint_state, app.sprint_options.len());
             AppAction::None
         }
         KeyCode::Up => {
-            let i = app
-                .sprint_state
-                .selected()
-                .map(|i| i.saturating_sub(1))
-                .unwrap_or(0);
-            app.sprint_state.select(Some(i));
+            picker_nav_up(&mut app.sprint_state);
             AppAction::None
         }
         KeyCode::Left => {
-            if app.sprint_cursor > 0 {
-                app.sprint_cursor -= 1;
-            }
+            picker_cursor_left(&mut app.sprint_cursor);
             AppAction::None
         }
         KeyCode::Right => {
-            if app.sprint_cursor < app.sprint_query.chars().count() {
-                app.sprint_cursor += 1;
-            }
+            picker_cursor_right(&mut app.sprint_cursor, &app.sprint_query);
             AppAction::None
         }
         KeyCode::Backspace => {
-            if app.sprint_cursor > 0 {
-                app.sprint_cursor -= 1;
-                let byte_pos = app
-                    .sprint_query
-                    .char_indices()
-                    .nth(app.sprint_cursor)
-                    .map(|(i, _)| i)
-                    .unwrap_or(app.sprint_query.len());
-                let char_len = app.sprint_query[byte_pos..]
-                    .chars()
-                    .next()
-                    .map(|c| c.len_utf8())
-                    .unwrap_or(0);
-                app.sprint_query.drain(byte_pos..byte_pos + char_len);
-                return AppAction::RefreshSprintOptions;
+            if picker_backspace(&mut app.sprint_query, &mut app.sprint_cursor) {
+                AppAction::RefreshSprintOptions
+            } else {
+                AppAction::None
             }
-            AppAction::None
         }
         KeyCode::Char(c) => {
-            let byte_pos = app
-                .sprint_query
-                .char_indices()
-                .nth(app.sprint_cursor)
-                .map(|(i, _)| i)
-                .unwrap_or(app.sprint_query.len());
-            app.sprint_query.insert(byte_pos, c);
-            app.sprint_cursor += 1;
+            picker_type_char(&mut app.sprint_query, &mut app.sprint_cursor, c);
             AppAction::RefreshSprintOptions
         }
         KeyCode::Enter => AppAction::ApplySprintSelection(app.sprint_issue_key.clone()),
         _ => AppAction::None,
     }
+}
+
+fn picker_nav_down(state: &mut ListState, len: usize) {
+    let i = state
+        .selected()
+        .map(|i| (i + 1).min(len.saturating_sub(1)))
+        .unwrap_or(0);
+    state.select(Some(i));
+}
+
+fn picker_nav_up(state: &mut ListState) {
+    let i = state.selected().map(|i| i.saturating_sub(1)).unwrap_or(0);
+    state.select(Some(i));
+}
+
+fn picker_cursor_left(cursor: &mut usize) {
+    if *cursor > 0 {
+        *cursor -= 1;
+    }
+}
+
+fn picker_cursor_right(cursor: &mut usize, query: &str) {
+    if *cursor < query.chars().count() {
+        *cursor += 1;
+    }
+}
+
+fn picker_backspace(query: &mut String, cursor: &mut usize) -> bool {
+    if *cursor > 0 {
+        *cursor -= 1;
+        let byte_pos = query
+            .char_indices()
+            .nth(*cursor)
+            .map(|(i, _)| i)
+            .unwrap_or(query.len());
+        let char_len = query[byte_pos..]
+            .chars()
+            .next()
+            .map(|c| c.len_utf8())
+            .unwrap_or(0);
+        query.drain(byte_pos..byte_pos + char_len);
+        true
+    } else {
+        false
+    }
+}
+
+fn picker_type_char(query: &mut String, cursor: &mut usize, c: char) {
+    let byte_pos = query
+        .char_indices()
+        .nth(*cursor)
+        .map(|(i, _)| i)
+        .unwrap_or(query.len());
+    query.insert(byte_pos, c);
+    *cursor += 1;
 }

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -1,8 +1,12 @@
+use std::collections::HashSet;
+
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Clear, List, ListItem, Paragraph, Row, Table, Wrap},
+    widgets::{
+        Block, Borders, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, Wrap,
+    },
     Frame,
 };
 
@@ -11,6 +15,7 @@ use super::column::format_column_summary;
 use super::modal::render_modal;
 use super::mode::Mode;
 use super::panel::{DetailTab, Focus};
+use super::picker::PickerOption;
 use super::theme::{Palette, ThemeName};
 
 pub(super) fn ui(f: &mut Frame, app: &mut App) {
@@ -739,87 +744,82 @@ fn render_assignee_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palett
 }
 
 fn render_component_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
-    let popup_area = side_panel_rect(area);
-    let [input_area, list_area, hint_area] = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3),
-            Constraint::Min(8),
-            Constraint::Length(4),
-        ])
-        .areas(popup_area);
-
-    let input = Paragraph::new(app.component_query.as_str())
-        .block(
-            Block::default()
-                .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
-                .border_style(Style::default().fg(palette.focus_border))
-                .title(format!(
-                    " Components: {} ({}) ",
-                    app.component_issue_key, app.component_project_key
-                ))
-                .style(Style::default().bg(Color::Black)),
-        )
-        .style(Style::default().fg(palette.header_fg));
-
-    let items: Vec<ListItem> = app
-        .component_options
-        .iter()
-        .map(|option| {
-            let checked = if app.component_selected.contains(&option.value) {
-                "[x]"
-            } else {
-                "[ ]"
-            };
-            ListItem::new(format!("{checked} {}", option.label))
-        })
-        .collect();
-
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::LEFT | Borders::RIGHT)
-                .border_style(Style::default().fg(palette.focus_border))
-                .style(Style::default().bg(Color::Black)),
-        )
-        .highlight_style(
-            Style::default()
-                .bg(palette.highlight)
-                .fg(palette.header_fg)
-                .add_modifier(Modifier::BOLD),
-        )
-        .highlight_symbol("> ");
-
-    let hints = Paragraph::new(vec![
-        Line::from("Type to filter project components"),
-        Line::from("↑/↓ move   Space toggle   Enter save"),
-        Line::from("Esc cancel"),
-    ])
-    .block(
-        Block::default()
-            .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(palette.focus_border))
-            .style(Style::default().bg(Color::Black)),
-    )
-    .style(Style::default().fg(palette.muted));
-
-    f.render_widget(Clear, popup_area);
-    f.render_widget(input, input_area);
-    f.render_stateful_widget(list, list_area, &mut app.component_state);
-    f.render_widget(hints, hint_area);
-
-    let before_cursor: String = app
-        .component_query
-        .chars()
-        .take(app.component_cursor)
-        .collect();
-    f.set_cursor_position((
-        input_area.x + 1 + before_cursor.len() as u16,
-        input_area.y + 1,
-    ));
+    let title = format!(
+        " Components: {} ({}) ",
+        app.component_issue_key, app.component_project_key
+    );
+    render_multi_select_picker_popup(
+        f,
+        area,
+        palette,
+        &app.component_query,
+        app.component_cursor,
+        &app.component_options.clone(),
+        &app.component_selected,
+        &mut app.component_state,
+        &title,
+        &[
+            "Type to filter project components",
+            "↑/↓ move   Space toggle   Enter save",
+            "Esc cancel",
+        ],
+    );
 }
 
 fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
+    let title = format!(
+        " Fix Versions: {} ({}) ",
+        app.fix_version_issue_key, app.fix_version_project_key
+    );
+    render_multi_select_picker_popup(
+        f,
+        area,
+        palette,
+        &app.fix_version_query,
+        app.fix_version_cursor,
+        &app.fix_version_options.clone(),
+        &app.fix_version_selected,
+        &mut app.fix_version_state,
+        &title,
+        &[
+            "Type to filter project fix versions",
+            "↑/↓ move   Space toggle   Enter save",
+            "Esc cancel",
+        ],
+    );
+}
+
+fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
+    let title = format!(" Sprint: {} ", app.sprint_issue_key);
+    render_single_select_picker_popup(
+        f,
+        area,
+        palette,
+        &app.sprint_query,
+        app.sprint_cursor,
+        &app.sprint_options.clone(),
+        &mut app.sprint_state,
+        &title,
+        &[
+            "Type to filter sprints",
+            "↑/↓ move   Enter assign   Esc cancel",
+        ],
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_multi_select_picker_popup(
+    f: &mut Frame,
+    area: Rect,
+    palette: Palette,
+    query: &str,
+    cursor: usize,
+    options: &[PickerOption],
+    selected: &HashSet<String>,
+    state: &mut ListState,
+    title: &str,
+    hint_lines: &[&str],
+) {
     let popup_area = side_panel_rect(area);
     let [input_area, list_area, hint_area] = Layout::default()
         .direction(Direction::Vertical)
@@ -830,24 +830,20 @@ fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, pal
         ])
         .areas(popup_area);
 
-    let input = Paragraph::new(app.fix_version_query.as_str())
+    let input = Paragraph::new(query)
         .block(
             Block::default()
                 .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
                 .border_style(Style::default().fg(palette.focus_border))
-                .title(format!(
-                    " Fix Versions: {} ({}) ",
-                    app.fix_version_issue_key, app.fix_version_project_key
-                ))
+                .title(title.to_string())
                 .style(Style::default().bg(Color::Black)),
         )
         .style(Style::default().fg(palette.header_fg));
 
-    let items: Vec<ListItem> = app
-        .fix_version_options
+    let items: Vec<ListItem> = options
         .iter()
         .map(|option| {
-            let checked = if app.fix_version_selected.contains(&option.value) {
+            let checked = if selected.contains(&option.value) {
                 "[x]"
             } else {
                 "[ ]"
@@ -871,36 +867,40 @@ fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, pal
         )
         .highlight_symbol("> ");
 
-    let hints = Paragraph::new(vec![
-        Line::from("Type to filter project fix versions"),
-        Line::from("↑/↓ move   Space toggle   Enter save"),
-        Line::from("Esc cancel"),
-    ])
-    .block(
-        Block::default()
-            .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(palette.focus_border))
-            .style(Style::default().bg(Color::Black)),
-    )
-    .style(Style::default().fg(palette.muted));
+    let hint_text: Vec<Line> = hint_lines.iter().map(|l| Line::from(*l)).collect();
+    let hints = Paragraph::new(hint_text)
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                .border_style(Style::default().fg(palette.focus_border))
+                .style(Style::default().bg(Color::Black)),
+        )
+        .style(Style::default().fg(palette.muted));
 
     f.render_widget(Clear, popup_area);
     f.render_widget(input, input_area);
-    f.render_stateful_widget(list, list_area, &mut app.fix_version_state);
+    f.render_stateful_widget(list, list_area, state);
     f.render_widget(hints, hint_area);
 
-    let before_cursor: String = app
-        .fix_version_query
-        .chars()
-        .take(app.fix_version_cursor)
-        .collect();
+    let before_cursor: String = query.chars().take(cursor).collect();
     f.set_cursor_position((
         input_area.x + 1 + before_cursor.len() as u16,
         input_area.y + 1,
     ));
 }
 
-fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
+#[allow(clippy::too_many_arguments)]
+fn render_single_select_picker_popup(
+    f: &mut Frame,
+    area: Rect,
+    palette: Palette,
+    query: &str,
+    cursor: usize,
+    options: &[PickerOption],
+    state: &mut ListState,
+    title: &str,
+    hint_lines: &[&str],
+) {
     let popup_area = side_panel_rect(area);
     let [input_area, list_area, hint_area] = Layout::default()
         .direction(Direction::Vertical)
@@ -911,18 +911,17 @@ fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette:
         ])
         .areas(popup_area);
 
-    let input = Paragraph::new(app.sprint_query.as_str())
+    let input = Paragraph::new(query)
         .block(
             Block::default()
                 .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
                 .border_style(Style::default().fg(palette.focus_border))
-                .title(format!(" Sprint: {} ", app.sprint_issue_key))
+                .title(title.to_string())
                 .style(Style::default().bg(Color::Black)),
         )
         .style(Style::default().fg(palette.header_fg));
 
-    let items: Vec<ListItem> = app
-        .sprint_options
+    let items: Vec<ListItem> = options
         .iter()
         .map(|option| ListItem::new(option.label.clone()))
         .collect();
@@ -942,24 +941,22 @@ fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette:
         )
         .highlight_symbol("> ");
 
-    let hints = Paragraph::new(vec![
-        Line::from("Type to filter sprints"),
-        Line::from("↑/↓ move   Enter assign   Esc cancel"),
-    ])
-    .block(
-        Block::default()
-            .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(palette.focus_border))
-            .style(Style::default().bg(Color::Black)),
-    )
-    .style(Style::default().fg(palette.muted));
+    let hint_text: Vec<Line> = hint_lines.iter().map(|l| Line::from(*l)).collect();
+    let hints = Paragraph::new(hint_text)
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                .border_style(Style::default().fg(palette.focus_border))
+                .style(Style::default().bg(Color::Black)),
+        )
+        .style(Style::default().fg(palette.muted));
 
     f.render_widget(Clear, popup_area);
     f.render_widget(input, input_area);
-    f.render_stateful_widget(list, list_area, &mut app.sprint_state);
+    f.render_stateful_widget(list, list_area, state);
     f.render_widget(hints, hint_area);
 
-    let before_cursor: String = app.sprint_query.chars().take(app.sprint_cursor).collect();
+    let before_cursor: String = query.chars().take(cursor).collect();
     f.set_cursor_position((
         input_area.x + 1 + before_cursor.len() as u16,
         input_area.y + 1,

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -7,6 +7,7 @@ A fast, polished Jira CLI and TUI built in Rust.
 [![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
 [![License: MIT%20OR%20Apache--2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 `jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports custom fields discovered at runtime, native attachment uploads, cursor-based pagination, Jira Cloud, and Jira Data Center.
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,5 +1,6 @@
 # @mulham28/jirac npm package
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 Install `jirac` from GitHub Releases using npm.
 


### PR DESCRIPTION
## Summary
  - Extract 6 shared helpers in `keys.rs` (`picker_nav_down/up`,
  `picker_cursor_left/right`, `picker_backspace`, `picker_type_char`) — eliminates ~180
  lines of duplicated text-editing and navigation logic across component, fix-version,
  and sprint picker key handlers
  - Extract `render_multi_select_picker_popup` and `render_single_select_picker_popup`
  in `render.rs` — eliminates ~160 lines of duplicated ratatui layout/widget boilerplate
  - No behavior change — all picker functionality identical

  ## Test plan
  - [x] `cargo fmt --all -- --check` passes
  - [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
  - [x] `cargo test --all` passes
  - [x] `cargo build --all` passes