### PR TITLE
feat(tui): improve notifications and scorecard refresh

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,9 +86,10 @@ jobs:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only run on push to main — scorecard needs write access not available to
-    # fork PRs, and the results are repo-level, not per-PR.
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # Only run on trusted repo events — scorecard needs write access not available to
+    # fork PRs, and the results are repo-level, not per-PR. Include manual
+    # workflow_dispatch so maintainers can refresh Scorecard after settings changes.
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       security-events: write  # upload SARIF to Security tab

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/jira/src/notifications.rs
+++ b/crates/jira/src/notifications.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs,
     path::PathBuf,
+    sync::Arc,
 };
 
 use anyhow::{Context, Result};
@@ -123,6 +124,9 @@ pub async fn scan_mention_notifications(
     let mut entries = Vec::new();
     let mut comment_errors = 0usize;
     let scanned_issues = result.issues.len();
+    let base_url = client.base_url().to_string();
+    let mut comment_tasks = tokio::task::JoinSet::new();
+    let comment_scan_limit = Arc::new(tokio::sync::Semaphore::new(8));
 
     for issue in result.issues {
         if let Some(description) = issue.description.as_ref() {
@@ -138,13 +142,31 @@ pub async fn scan_mention_notifications(
                     author: issue.reporter.clone(),
                     created: issue.updated.clone(),
                     excerpt: notification_excerpt(&adf_to_text(description)),
-                    url: format!("{}/browse/{}", client.base_url(), issue.key),
+                    url: format!("{base_url}/browse/{}", issue.key),
                     read: read_state.read_ids.contains(&id),
                 });
             }
         }
 
-        match client.get_comments(&issue.key).await {
+        let issue_for_comments = issue.clone();
+        let client_for_comments = client.clone();
+        let comment_scan_limit = Arc::clone(&comment_scan_limit);
+        comment_tasks.spawn(async move {
+            let _permit = comment_scan_limit.acquire_owned().await.ok();
+            let comments = client_for_comments
+                .get_comments(&issue_for_comments.key)
+                .await;
+            (issue_for_comments, comments)
+        });
+    }
+
+    while let Some(joined) = comment_tasks.join_next().await {
+        let Ok((issue, comments)) = joined else {
+            comment_errors += 1;
+            continue;
+        };
+
+        match comments {
             Ok(comments) => {
                 for comment in comments {
                     if comment.author_account_id.as_deref() == Some(account_id.as_str()) {
@@ -164,7 +186,7 @@ pub async fn scan_mention_notifications(
                             author: comment.author.clone(),
                             created: comment.created.clone(),
                             excerpt: notification_excerpt(comment.body.as_deref().unwrap_or("")),
-                            url: format!("{}/browse/{}", client.base_url(), issue.key),
+                            url: format!("{base_url}/browse/{}", issue.key),
                             read: read_state.read_ids.contains(&id),
                         });
                     }

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -160,6 +160,7 @@ pub(super) enum AppAction {
     ExecuteTransition(String, String),
     OpenBrowser,
     OpenNotifications,
+    MarkNotificationsRead,
     CreateIssue,
     EditIssue(String),
     AssignIssue(String),
@@ -424,19 +425,28 @@ impl App {
         }
     }
 
+    pub(super) fn mark_selected_notifications_read(&mut self) -> Result<usize> {
+        let Some(key) = self.selected_issue_key() else {
+            return Ok(0);
+        };
+        if self.notification_entries.is_empty() {
+            return Ok(0);
+        }
+
+        let changed = mark_notifications_read(&mut self.notification_entries, &key)?;
+        if changed > 0 {
+            self.set_issue_list(notification_issues(&self.notification_entries));
+        }
+        Ok(changed)
+    }
+
     pub(super) fn open_detail(&mut self) {
-        if let Some(key) = self.selected_issue_key() {
-            if !self.notification_entries.is_empty() {
-                match mark_notifications_read(&mut self.notification_entries, &key) {
-                    Ok(changed) if changed > 0 => {
-                        self.set_issue_list(notification_issues(&self.notification_entries));
-                    }
-                    Ok(_) => {}
-                    Err(err) => {
-                        self.set_status(format!("Failed to mark notifications read: {err}"), true)
-                    }
-                }
+        match self.mark_selected_notifications_read() {
+            Ok(changed) if changed > 0 => {
+                self.set_status(format!("✓ Marked {changed} notification(s) read"), false);
             }
+            Ok(_) => {}
+            Err(err) => self.set_status(format!("Failed to mark notifications read: {err}"), true),
         }
         self.focus = Focus::Detail;
         self.ensure_detail_context();
@@ -804,6 +814,16 @@ pub async fn run_tui(
                 }
             }
 
+            AppAction::MarkNotificationsRead => match app.mark_selected_notifications_read() {
+                Ok(changed) if changed > 0 => {
+                    app.set_status(format!("✓ Marked {changed} notification(s) read"), false)
+                }
+                Ok(_) => app.set_status("No unread notifications on selected issue", false),
+                Err(err) => {
+                    app.set_status(format!("Failed to mark notifications read: {err}"), true)
+                }
+            },
+
             AppAction::OpenNotifications => {
                 let fallback_jql = build_notifications_jql(app.default_project.as_deref(), "7d");
                 app.set_status("Scanning Jira mentions...", false);
@@ -882,9 +902,20 @@ pub async fn run_tui(
 
             AppAction::OpenBrowser => {
                 if let Some(issue) = app.selected_issue() {
-                    let url = format!("{}/browse/{}", app.base_url, issue.key);
+                    let issue_key = issue.key.clone();
+                    let url = format!("{}/browse/{}", app.base_url, issue_key);
                     let _ = open::that(&url);
-                    app.set_status(format!("Opened {}", issue.key), false);
+                    match app.mark_selected_notifications_read() {
+                        Ok(changed) if changed > 0 => app.set_status(
+                            format!("Opened {issue_key}; marked {changed} notification(s) read"),
+                            false,
+                        ),
+                        Ok(_) => app.set_status(format!("Opened {issue_key}"), false),
+                        Err(err) => app.set_status(
+                            format!("Opened {issue_key}; failed to mark read: {err}"),
+                            true,
+                        ),
+                    }
                 }
             }
 

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -75,6 +75,7 @@ fn handle_browse_key(app: &mut App, code: KeyCode) -> AppAction {
         KeyCode::Char('r') => AppAction::Refresh,
         KeyCode::Char('t') => AppAction::FetchTransitions,
         KeyCode::Char('n') => AppAction::OpenNotifications,
+        KeyCode::Char('R') => AppAction::MarkNotificationsRead,
         KeyCode::Char('o') => AppAction::OpenBrowser,
         KeyCode::Char('/') => {
             app.search_input = app.jql.clone();
@@ -200,6 +201,7 @@ fn handle_view_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Char('t') => AppAction::FetchTransitions,
+        KeyCode::Char('R') => AppAction::MarkNotificationsRead,
         KeyCode::Char('o') => AppAction::OpenBrowser,
         KeyCode::Char('?') => {
             app.mode = Mode::Help;

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -133,7 +133,7 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
                 .to_string()
         }
         Mode::Browse => {
-            " j/k:move  Enter:detail  p:queries  n:mentions  T:theme  S:server  g:config  t:transition  C:columns  c:create  e:edit  y:type  M:move  a:assign  ;:comment  w:worklog  b:bulk-log  l:labels  m:comps  v:versions  u:upload  o:browser  r:refresh  /:search  ?:help  q:quit"
+            " j/k:move  Enter:detail  p:queries  n:mentions  R:mark-read  T:theme  S:server  g:config  t:transition  C:columns  c:create  e:edit  y:type  M:move  a:assign  ;:comment  w:worklog  b:bulk-log  l:labels  m:comps  v:versions  u:upload  o:browser  r:refresh  /:search  ?:help  q:quit"
                 .to_string()
         }
         Mode::Search => " Type JQL  Enter:search  Esc:cancel".to_string(),
@@ -1166,6 +1166,7 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) {
         Line::from("  o         Open issue in browser"),
         Line::from("  r         Refresh list"),
         Line::from("  n         Scan and open Jira mention notifications"),
+        Line::from("  R         Mark selected notification issue as read"),
         Line::from("  /         Search with JQL"),
         Line::from("  ?         Show help"),
         Line::from("  q         Quit the TUI"),

--- a/crates/jira/src/tui/theme.rs
+++ b/crates/jira/src/tui/theme.rs
@@ -14,6 +14,7 @@ pub(super) enum ThemeName {
     Monokai,
     Ayu,
     RosePine,
+    Kanagawa,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -43,10 +44,11 @@ impl ThemeName {
             ThemeName::Monokai => "Monokai",
             ThemeName::Ayu => "Ayu Dark",
             ThemeName::RosePine => "Rosé Pine",
+            ThemeName::Kanagawa => "Kanagawa Wave",
         }
     }
 
-    pub(super) const ALL: [ThemeName; 11] = [
+    pub(super) const ALL: [ThemeName; 12] = [
         ThemeName::Default,
         ThemeName::Dracula,
         ThemeName::Nord,
@@ -58,6 +60,7 @@ impl ThemeName {
         ThemeName::Monokai,
         ThemeName::Ayu,
         ThemeName::RosePine,
+        ThemeName::Kanagawa,
     ];
 
     pub(super) fn palette(self) -> Palette {
@@ -182,6 +185,17 @@ impl ThemeName {
                 highlight: Color::Rgb(38, 35, 58),
                 tab_active: Color::Rgb(246, 193, 119),
                 tab_inactive: Color::Rgb(110, 106, 134),
+            },
+            ThemeName::Kanagawa => Palette {
+                header_fg: Color::Rgb(220, 215, 186),
+                header_bg: Color::Rgb(31, 31, 40),
+                accent: Color::Rgb(126, 156, 216),
+                muted: Color::Rgb(114, 115, 126),
+                focus_border: Color::Rgb(149, 127, 184),
+                blur_border: Color::Rgb(54, 54, 68),
+                highlight: Color::Rgb(42, 42, 55),
+                tab_active: Color::Rgb(230, 195, 132),
+                tab_inactive: Color::Rgb(114, 115, 126),
             },
         }
     }


### PR DESCRIPTION
## Summary

- allow manual `workflow_dispatch` runs to refresh OpenSSF Scorecard SARIF after repo settings changes
- add Kanagawa Wave as a TUI theme option
- speed up Jira mention notification scans by fetching issue comments concurrently with a bounded limit
- automatically mark notification issues read when opened in detail or browser
- add `R` shortcut to manually mark the selected notification issue as read
- sync stale workspace crate versions in `Cargo.lock` to the current `0.32.0` manifests

## Notes

The open code scanning alerts are Scorecard alerts, not Rust source SAST findings:

- `BranchProtectionID`: repo settings/ruleset-driven; manual workflow runs previously skipped Scorecard, so this PR makes manual refreshes effective after merge
- `SASTID` and `CITestsID`: Scorecard ratio checks over recent commits/merged PRs; these may improve after more PRs run through the protected flow
- `MaintainedID`: age-based because the repo is under 90 days old; no code fix needed

## Verification

- `git diff --check`
- `cargo fmt --all`
- `cargo test -p jira-commands notifications -- --nocapture`
- `cargo check -p jira-commands`
