### PR TITLE
chore(packaging): refresh release docs and manifests for v0.33.0

### DIFF
--- a/packaging/chocolatey/jirac.nuspec
+++ b/packaging/chocolatey/jirac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jirac</id>
-    <version>0.32.0</version>
+    <version>0.33.0</version>
     <packageSourceUrl>https://github.com/mulhamna/jira-commands</packageSourceUrl>
     <owners>mulhamna</owners>
     <title>jirac</title>
@@ -16,7 +16,7 @@
     <tags>jira atlassian cli tui rust mcp</tags>
     <summary>Jira terminal client with TUI, MCP support, and native release archives.</summary>
     <description>jirac is a fast Jira CLI and TUI built in Rust. It supports interactive issue browsing, transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.</description>
-    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v0.32.0</releaseNotes>
+    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v0.33.0</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'jirac'
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v0.32.0/jirac-windows-x86_64.zip'
-$checksum64 = '4256890317e8e4a2b25bcabe8d8fd433b7c4d5b13b7021d5ebb25acf73f69948'
+$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v0.33.0/jirac-windows-x86_64.zip'
+$checksum64 = 'ba52ab15e0f76ed13859185d3fc8f467617f9379b131fc965c55e89f2945e8a7'
 
 $packageArgs = @{
   packageName    = $packageName

--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.32.0
+PackageVersion: 0.33.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
-ReleaseDate: 2026-05-05
+ReleaseDate: 2026-05-07
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.32.0/jirac-windows-x86_64.zip
-    InstallerSha256: 4256890317e8e4a2b25bcabe8d8fd433b7c4d5b13b7021d5ebb25acf73f69948
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.33.0/jirac-windows-x86_64.zip
+    InstallerSha256: ba52ab15e0f76ed13859185d3fc8f467617f9379b131fc965c55e89f2945e8a7
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.32.0
+PackageVersion: 0.33.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.32.0
+PackageVersion: 0.33.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh root README.md and INSTALL.md for the released version
- refresh contributor avatars in the README footer
- refresh in-repo Winget source manifests for v0.33.0
- refresh in-repo Chocolatey package source for v0.33.0
- update Windows installer URL and SHA256 from the published release

## Notes

- generated by the release workflow after publishing GitHub release assets
- Winget community submission remains a separate follow-up workflow
- Chocolatey publish uses the refreshed source package metadata