### PR TITLE
feat: add Zed MCP extension wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       rust_core: ${{ steps.filter.outputs.rust_core }}
       rust_cli: ${{ steps.filter.outputs.rust_cli }}
       rust_mcp: ${{ steps.filter.outputs.rust_mcp }}
+      rust_zed: ${{ steps.filter.outputs.rust_zed }}
       plugin: ${{ steps.filter.outputs.plugin }}
       plugin_release: ${{ steps.filter.outputs.plugin_release }}
       clawhub: ${{ steps.filter.outputs.clawhub }}
@@ -61,6 +62,10 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'crates/jira-mcp/**'
+            rust_zed:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/zed-jira/**'
             plugin:
               - 'plugin/**'
               - '.claude-plugin/**'
@@ -80,6 +85,7 @@ jobs:
               - 'crates/jira/README.md'
               - 'crates/jira-core/README.md'
               - 'crates/jira-mcp/README.md'
+              - 'crates/zed-jira/README.md'
               - 'packaging/winget/**'
               - 'packaging/scoop/**'
               - 'packaging/npm/**'
@@ -326,6 +332,27 @@ jobs:
 
       - name: Run jira-mcp tests
         run: cargo test -p jira-mcp
+
+  test-zed:
+    name: Zed extension smoke build
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust_zed == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build zed-jira for wasm32-wasip1
+        run: cargo build -p zed-jira --target wasm32-wasip1 --release
 
   plugin-check:
     name: Plugin structure check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +123,18 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
 
 [[package]]
 name = "autocfg"
@@ -493,6 +511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +891,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1479,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1502,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1522,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1777,6 +1814,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2796,6 +2843,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2976,6 +3027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +3068,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spdx"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -3427,6 +3493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,12 +3878,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.227.1",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
+dependencies = [
+ "anyhow",
+ "auditable-serde",
+ "flate2",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.227.1",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -3822,8 +3923,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -3837,6 +3938,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4313,11 +4426,21 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de"
+dependencies = [
+ "wit-bindgen-rt",
+ "wit-bindgen-rust-macro 0.41.0",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
@@ -4328,13 +4451,51 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.227.1",
+]
+
+[[package]]
+name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"
+dependencies = [
+ "bitflags 2.11.1",
+ "futures",
+ "once_cell",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata 0.227.1",
+ "wit-bindgen-core 0.41.0",
+ "wit-component 0.227.1",
 ]
 
 [[package]]
@@ -4348,9 +4509,24 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad19eec017904e04c60719592a803ee5da76cb51c81e3f6fbf9457f59db49799"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core 0.41.0",
+ "wit-bindgen-rust 0.41.0",
 ]
 
 [[package]]
@@ -4364,8 +4540,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.227.1",
+ "wasm-metadata 0.227.1",
+ "wasmparser 0.227.1",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
@@ -4381,10 +4576,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -4402,7 +4615,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4438,6 +4651,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zed-jira"
+version = "0.1.0"
+dependencies = [
+ "zed_extension_api",
+]
+
+[[package]]
+name = "zed_extension_api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen 0.41.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/jira-core", "crates/jira", "crates/jira-mcp"]
+members = ["crates/jira-core", "crates/jira", "crates/jira-mcp", "crates/zed-jira"]
 resolver = "2"
 
 [workspace.package]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,6 +155,7 @@ jirac mcp install --client cursor
 jirac mcp install --client gemini-cli
 jirac mcp install --client codex
 jirac mcp install --client generic-json
+jirac mcp install --client zed
 ```
 
 Supported targets now:
@@ -164,12 +165,13 @@ Supported targets now:
 - `gemini-cli` (delegates to `gemini mcp add -s user ...`)
 - `codex` (delegates to `codex mcp add ...`)
 - `generic-json` (prints a portable JSON snippet instead of writing a file)
+- `zed` (`~/.config/zed/settings.json` on Linux, `~/Library/Application Support/Zed/settings.json` on macOS, `%APPDATA%/Zed/settings.json` on Windows; seeds `context_servers.jira.settings` for the official Zed marketplace extension)
 
 Helpful flags:
 - `--print` prints the JSON snippet or delegated client command first
 - `--dry-run` previews without writing
 - `--force` overwrites an existing MCP entry with the same name, or runs remove+add for delegated clients
-- `--name jira` changes the MCP server name
+- `--name jira` changes the MCP server name (except `zed`, which uses the fixed `jira` context server id)
 - `--command jirac-mcp` changes the launched binary
 - `--transport stdio` changes the transport args
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ export JIRA_TOKEN=your_api_token
 
 Use `jirac mcp install --client <target>` to register `jirac-mcp` with supported clients, or `jirac mcp doctor` to check prerequisites.
 
+Supported helpers include Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, generic JSON snippets, and Zed. Zed uses the official `Jira` marketplace extension and `jirac mcp install --client zed` seeds `context_servers.jira.settings` in `settings.json`.
+
 See [INSTALL.md](INSTALL.md) for the supported target matrix, client-specific notes, and recommended install flow.
 
 ## Using jira-core as a library
@@ -317,6 +319,7 @@ crates/
   jira-core/   # shared client, models, config, auth
   jira/        # CLI app
   jira-mcp/    # MCP server
+  zed-jira/    # Zed extension wrapper for jirac-mcp
 assets/        # screenshots and images
 packaging/     # release/install packaging
 ```

--- a/crates/jira-core/src/config.rs
+++ b/crates/jira-core/src/config.rs
@@ -470,6 +470,27 @@ timeout_secs = 55
     }
 
     #[test]
+    fn loads_from_env_without_config_file() {
+        let _guard = env_lock().lock().expect("env lock");
+        let temp_dir = TempDir::new().expect("tempdir");
+        clear_config_home();
+        set_config_home(&temp_dir);
+
+        std::env::set_var("JIRA_URL", "https://env-only.atlassian.net");
+        std::env::set_var("JIRA_EMAIL", "env@example.com");
+        std::env::set_var("JIRA_TOKEN", "env-secret");
+        std::env::set_var("JIRA_PROJECT", "ENV");
+
+        let config = JiraConfig::load().expect("load env-only");
+        assert_eq!(config.base_url, "https://env-only.atlassian.net");
+        assert_eq!(config.email, "env@example.com");
+        assert_eq!(config.token.as_deref(), Some("env-secret"));
+        assert_eq!(config.project.as_deref(), Some("ENV"));
+
+        clear_config_home();
+    }
+
+    #[test]
     fn loads_named_profile_and_applies_env_overrides() {
         let _guard = env_lock().lock().expect("env lock");
         let temp_dir = TempDir::new().expect("tempdir");

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -79,12 +79,14 @@ jirac mcp install --client cursor
 jirac mcp install --client gemini-cli
 jirac mcp install --client codex
 jirac mcp install --client generic-json
+jirac mcp install --client zed
 ```
 
 Notes:
 - `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install
+- `zed` writes `context_servers.jira.settings` for the official Zed marketplace extension
 
 ## More docs
 

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -107,12 +107,14 @@ jirac mcp install --client cursor
 jirac mcp install --client gemini-cli
 jirac mcp install --client codex
 jirac mcp install --client generic-json
+jirac mcp install --client zed
 ```
 
 Notes:
 - `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install
+- `zed` writes `context_servers.jira.settings` for the official Zed marketplace extension
 
 ## More docs
 

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -43,6 +43,7 @@ pub enum McpClient {
     GeminiCli,
     Codex,
     GenericJson,
+    Zed,
 }
 
 pub fn handle(command: McpCommand) -> Result<()> {
@@ -69,6 +70,10 @@ fn install_client(
     dry_run: bool,
     force: bool,
 ) -> Result<()> {
+    if matches!(client, McpClient::Zed) {
+        return install_zed_client(name, print, dry_run, force);
+    }
+
     let resolved_command = resolve_command_for_client(&client, command, dry_run)?;
     let spec = server_spec(name, &resolved_command, transport);
 
@@ -175,6 +180,7 @@ fn doctor(client: Option<McpClient>, command: &str) -> Result<()> {
             McpClient::GeminiCli,
             McpClient::Codex,
             McpClient::GenericJson,
+            McpClient::Zed,
         ],
     };
 
@@ -273,26 +279,30 @@ fn server_spec(name: &str, command: &str, transport: &str) -> ServerSpec {
 fn install_target(client: &McpClient) -> Result<InstallTarget> {
     let home = home_dir().context("Could not determine home directory")?;
 
-    let (label, path) = match client {
+    let (label, path, top_level_key) = match client {
         McpClient::ClaudeCode => (
             "claude-code",
             config_path_from_env_or_default("CLAUDE_CODE_CONFIG", home.join(".mcp.json")),
+            "mcpServers",
         ),
         McpClient::ClaudeDesktop => (
             "claude-desktop",
             config_path_from_env_or_default("CLAUDE_DESKTOP_CONFIG", home.join(".claude.json")),
+            "mcpServers",
         ),
         McpClient::Cursor => (
             "cursor",
             config_path_from_env_or_default("CURSOR_CONFIG", home.join(".cursor/mcp.json")),
+            "mcpServers",
         ),
         McpClient::GeminiCli | McpClient::Codex | McpClient::GenericJson => unreachable!(),
+        McpClient::Zed => ("zed", zed_settings_path(&home), "context_servers"),
     };
 
     Ok(InstallTarget {
         label,
         path,
-        top_level_key: "mcpServers".to_string(),
+        top_level_key: top_level_key.to_string(),
     })
 }
 
@@ -333,6 +343,13 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
             label: "generic-json",
             note: "Prints a portable JSON snippet instead of writing a file.",
         },
+        McpClient::Zed => ClientDescriptor::FileTarget {
+            label: "zed",
+            path: install_target(client)
+                .map(|t| t.path)
+                .unwrap_or_else(|_| PathBuf::from("~/.config/zed/settings.json")),
+            note: "Writes context_servers.jira.settings for the Zed marketplace extension.",
+        },
     }
 }
 
@@ -350,6 +367,104 @@ fn client_adapter(client: &McpClient) -> Option<ClientAdapter> {
         }),
         _ => None,
     }
+}
+
+fn install_zed_client(name: &str, print: bool, dry_run: bool, force: bool) -> Result<()> {
+    if name != "jira" {
+        bail!("Zed uses the fixed context server id `jira`; omit --name or pass --name jira.");
+    }
+
+    let target = install_target(&McpClient::Zed)?;
+    let mut root = load_json_object(&target.path)?;
+    let context_servers = ensure_object_field(&mut root, &target.top_level_key)?;
+    let entry = context_servers
+        .entry("jira".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+
+    let entry_map = match entry {
+        Value::Object(map) => map,
+        _ => bail!(
+            "Zed context_servers.jira entry at {} must be a JSON object",
+            target.path.display()
+        ),
+    };
+
+    let settings_map = ensure_object_field(entry_map, "settings")?;
+    let desired = zed_settings_from_jira_config(JiraConfig::load().unwrap_or_default());
+    let changed = merge_string_values(settings_map, &desired, force);
+    let snippet = zed_json_snippet(&desired);
+
+    if print || dry_run {
+        print_snippet(&snippet)?;
+    }
+
+    if dry_run {
+        println!(
+            "Dry run, no file written. Target: {}",
+            target.path.display()
+        );
+        return Ok(());
+    }
+
+    if !changed {
+        println!(
+            "Zed context server settings already up to date at {}",
+            target.path.display()
+        );
+        return Ok(());
+    }
+
+    backup_if_exists(&target.path)?;
+    write_json_object(&target.path, &root)?;
+    println!("Updated Zed Jira MCP settings at {}", target.path.display());
+    println!("Install the Jira extension from the Zed marketplace if it is not installed yet.");
+    Ok(())
+}
+
+fn zed_settings_from_jira_config(config: JiraConfig) -> Map<String, Value> {
+    let mut settings = Map::new();
+
+    if !config.base_url.trim().is_empty() {
+        settings.insert("jira_url".into(), Value::String(config.base_url));
+    }
+    if !config.email.trim().is_empty() {
+        settings.insert("jira_email".into(), Value::String(config.email));
+    }
+    if let Some(token) = config.token.filter(|token| !token.trim().is_empty()) {
+        settings.insert("jira_token".into(), Value::String(token));
+    }
+    if let Some(project) = config.project.filter(|project| !project.trim().is_empty()) {
+        settings.insert("default_project".into(), Value::String(project));
+    }
+
+    settings
+}
+
+fn zed_json_snippet(settings: &Map<String, Value>) -> Value {
+    json!({
+        "context_servers": {
+            "jira": {
+                "settings": settings
+            }
+        }
+    })
+}
+
+fn merge_string_values(
+    target: &mut Map<String, Value>,
+    desired: &Map<String, Value>,
+    force: bool,
+) -> bool {
+    let mut changed = false;
+
+    for (key, value) in desired {
+        if force || target.get(key) != Some(value) {
+            target.insert(key.clone(), value.clone());
+            changed = true;
+        }
+    }
+
+    changed
 }
 
 struct ClientAdapter {
@@ -424,6 +539,26 @@ fn config_path_from_env_or_default(env_key: &str, default: PathBuf) -> PathBuf {
 
 fn home_dir() -> Option<PathBuf> {
     env::var_os("HOME").map(PathBuf::from)
+}
+
+fn zed_settings_path(home: &Path) -> PathBuf {
+    if let Some(path) = env::var_os("ZED_SETTINGS_PATH") {
+        return PathBuf::from(path);
+    }
+
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Zed/settings.json")
+    } else if cfg!(target_os = "windows") {
+        env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("AppData/Roaming"))
+            .join("Zed/settings.json")
+    } else {
+        env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"))
+            .join("zed/settings.json")
+    }
 }
 
 fn resolve_command_for_client(client: &McpClient, command: &str, dry_run: bool) -> Result<String> {
@@ -597,6 +732,45 @@ mod tests {
     fn resolve_command_path_finds_absolute_path() {
         let path = resolve_command_path("/bin/sh").unwrap();
         assert_eq!(path, PathBuf::from("/bin/sh"));
+    }
+
+    #[test]
+    fn zed_install_snippet_uses_context_servers() {
+        let settings = zed_settings_from_jira_config(JiraConfig {
+            base_url: "https://example.atlassian.net".into(),
+            email: "dev@example.com".into(),
+            token: Some("secret".into()),
+            project: Some("PROJ".into()),
+            ..JiraConfig::default()
+        });
+        let snippet = zed_json_snippet(&settings);
+        let rendered = serde_json::to_string_pretty(&snippet).unwrap();
+        assert!(rendered.contains("\"context_servers\""));
+        assert!(rendered.contains("\"jira_url\""));
+        assert!(rendered.contains("PROJ"));
+    }
+
+    #[test]
+    fn merge_string_values_only_overwrites_requested_keys() {
+        let mut target = Map::new();
+        target.insert(
+            "jira_url".into(),
+            Value::String("https://old.example".into()),
+        );
+        target.insert("other".into(), Value::String("keep".into()));
+
+        let mut desired = Map::new();
+        desired.insert(
+            "jira_url".into(),
+            Value::String("https://new.example".into()),
+        );
+
+        assert!(merge_string_values(&mut target, &desired, false));
+        assert_eq!(
+            target.get("jira_url").and_then(Value::as_str),
+            Some("https://new.example")
+        );
+        assert_eq!(target.get("other").and_then(Value::as_str), Some("keep"));
     }
 
     #[test]

--- a/crates/zed-jira/Cargo.toml
+++ b/crates/zed-jira/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zed-jira"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.7.0"

--- a/crates/zed-jira/LICENSE
+++ b/crates/zed-jira/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mulham
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/zed-jira/README.md
+++ b/crates/zed-jira/README.md
@@ -1,0 +1,27 @@
+# zed-jira
+
+Official Zed extension wrapper for `jirac-mcp`.
+
+This crate compiles to a Zed extension WASM module. It does not implement Jira logic itself; it downloads the matching `jirac-mcp` release artifact for the current platform, exposes Zed context-server settings, and launches the MCP server over stdio.
+
+## Local smoke build
+
+```bash
+rustup target add wasm32-wasip1
+cargo build -p zed-jira --target wasm32-wasip1 --release
+```
+
+## Settings
+
+The extension maps these Zed settings into `jirac-mcp` environment variables:
+
+- `jira_url` -> `JIRA_URL`
+- `jira_email` -> `JIRA_EMAIL`
+- `jira_token` -> `JIRA_TOKEN`
+- `default_project` -> `JIRA_PROJECT`
+
+You can seed the same settings from an existing `jirac` auth profile with:
+
+```bash
+jirac mcp install --client zed
+```

--- a/crates/zed-jira/configuration/default-settings.json
+++ b/crates/zed-jira/configuration/default-settings.json
@@ -1,0 +1,6 @@
+{
+  "jira_url": "https://yourcompany.atlassian.net",
+  "jira_email": "you@example.com",
+  "jira_token": "<JIRA_API_TOKEN>",
+  "default_project": "MYPROJ"
+}

--- a/crates/zed-jira/configuration/schema.json
+++ b/crates/zed-jira/configuration/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "jira_url": {
+      "type": "string",
+      "description": "Your Jira base URL, e.g. https://yourcompany.atlassian.net"
+    },
+    "jira_email": {
+      "type": "string",
+      "description": "Email or username for your Jira account"
+    },
+    "jira_token": {
+      "type": "string",
+      "description": "Atlassian API token or Data Center PAT/password"
+    },
+    "default_project": {
+      "type": "string",
+      "description": "Optional default Jira project key, e.g. MYPROJ"
+    }
+  },
+  "required": ["jira_url", "jira_email", "jira_token"]
+}

--- a/crates/zed-jira/extension.toml
+++ b/crates/zed-jira/extension.toml
@@ -1,0 +1,10 @@
+id = "jira"
+name = "Jira"
+version = "0.1.0"
+schema_version = 1
+authors = ["Mulham <mulhamna@gmail.com>"]
+description = "Jira MCP server for Zed — browse issues, run JQL, transition, create, and more via the Agent Panel."
+repository = "https://github.com/mulhamna/jira-commands"
+
+[context_servers.jira]
+name = "Jira"

--- a/crates/zed-jira/src/lib.rs
+++ b/crates/zed-jira/src/lib.rs
@@ -1,0 +1,167 @@
+use std::path::Path;
+
+use zed::serde_json::Value;
+use zed::settings::ContextServerSettings;
+use zed_extension_api as zed;
+
+const CONTEXT_SERVER_ID: &str = "jira";
+const REPO: &str = "mulhamna/jira-commands";
+
+struct JiraExtension;
+
+impl zed::Extension for JiraExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn context_server_configuration(
+        &mut self,
+        _context_server_id: &zed::ContextServerId,
+        _project: &zed::Project,
+    ) -> zed::Result<Option<zed::ContextServerConfiguration>> {
+        Ok(Some(zed::ContextServerConfiguration {
+            installation_instructions: INSTALLATION_INSTRUCTIONS.to_string(),
+            settings_schema: include_str!("../configuration/schema.json").to_string(),
+            default_settings: include_str!("../configuration/default-settings.json").to_string(),
+        }))
+    }
+
+    fn context_server_command(
+        &mut self,
+        _context_server_id: &zed::ContextServerId,
+        project: &zed::Project,
+    ) -> zed::Result<zed::Command> {
+        let settings = ContextServerSettings::for_project(CONTEXT_SERVER_ID, project)?;
+        let binary = settings
+            .command
+            .as_ref()
+            .and_then(|command| command.path.clone())
+            .unwrap_or(ensure_binary()?);
+
+        let args = settings
+            .command
+            .as_ref()
+            .and_then(|command| command.arguments.clone())
+            .unwrap_or_else(default_args);
+
+        let mut env = env_from_settings(settings.settings.as_ref())?;
+        if let Some(extra_env) = settings.command.and_then(|command| command.env) {
+            env.extend(extra_env);
+        }
+
+        Ok(zed::Command {
+            command: binary,
+            args,
+            env,
+        })
+    }
+}
+
+fn ensure_binary() -> zed::Result<String> {
+    let release = zed::latest_github_release(
+        REPO,
+        zed::GithubReleaseOptions {
+            require_assets: true,
+            pre_release: false,
+        },
+    )?;
+
+    let asset_name = asset_name_for_platform()?;
+    let asset = release
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| format!("No release asset found for {asset_name}"))?;
+
+    let relative_path = format!("jirac-mcp/{}/{}", release.version, asset.name);
+    if !Path::new(&relative_path).exists() {
+        zed::download_file(
+            &asset.download_url,
+            &relative_path,
+            zed::DownloadedFileType::Uncompressed,
+        )?;
+        if !relative_path.ends_with(".exe") {
+            zed::make_file_executable(&relative_path)?;
+        }
+    }
+
+    Ok(relative_path)
+}
+
+fn asset_name_for_platform() -> zed::Result<&'static str> {
+    let (os, arch) = zed::current_platform();
+
+    match (os, arch) {
+        (zed::Os::Linux, zed::Architecture::X8664) => Ok("jirac-mcp-linux-x86_64"),
+        (zed::Os::Linux, zed::Architecture::Aarch64) => Ok("jirac-mcp-linux-aarch64"),
+        (zed::Os::Mac, zed::Architecture::X8664) => Ok("jirac-mcp-macos-x86_64"),
+        (zed::Os::Mac, zed::Architecture::Aarch64) => Ok("jirac-mcp-macos-aarch64"),
+        (zed::Os::Windows, zed::Architecture::X8664) => Ok("jirac-mcp-windows-x86_64.exe"),
+        _ => Err(format!("Unsupported platform: {os:?} {arch:?}")),
+    }
+}
+
+fn default_args() -> Vec<String> {
+    vec!["serve".into(), "--transport".into(), "stdio".into()]
+}
+
+fn env_from_settings(settings: Option<&Value>) -> zed::Result<Vec<(String, String)>> {
+    let Some(Value::Object(settings)) = settings else {
+        return Ok(vec![]);
+    };
+
+    let mut env = Vec::new();
+    push_string(&mut env, settings.get("jira_url"), "JIRA_URL")?;
+    push_string(&mut env, settings.get("jira_email"), "JIRA_EMAIL")?;
+    push_string(&mut env, settings.get("jira_token"), "JIRA_TOKEN")?;
+    push_string(&mut env, settings.get("default_project"), "JIRA_PROJECT")?;
+    Ok(env)
+}
+
+fn push_string(
+    env: &mut Vec<(String, String)>,
+    value: Option<&Value>,
+    key: &str,
+) -> zed::Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+
+    let string = value
+        .as_str()
+        .ok_or_else(|| format!("{key} must be a string"))?
+        .trim()
+        .to_string();
+
+    if !string.is_empty() {
+        env.push((key.to_string(), string));
+    }
+
+    Ok(())
+}
+
+const INSTALLATION_INSTRUCTIONS: &str = r#"Install the Jira extension from the Zed marketplace, then add your Jira credentials in Zed settings:
+
+```json
+{
+  \"context_servers\": {
+    \"jira\": {
+      \"settings\": {
+        \"jira_url\": \"https://yourcompany.atlassian.net\",
+        \"jira_email\": \"you@example.com\",
+        \"jira_token\": \"<JIRA_API_TOKEN>\",
+        \"default_project\": \"MYPROJ\"
+      }
+    }
+  }
+}
+```
+
+You can also seed the same settings from your saved `jirac` auth profile with:
+
+```bash
+jirac mcp install --client zed
+```
+"#;
+
+zed::register_extension!(JiraExtension);


### PR DESCRIPTION
## Summary
- add a dedicated `zed-jira` Zed extension crate that downloads and launches `jirac-mcp`
- add `jirac mcp install --client zed` plus Zed settings seeding from existing jirac auth config
- document the new Zed flow and add CI smoke coverage for the wasm32-wasip1 extension build

## Testing
- cargo test -p jira-core
- cargo test -p jira-commands
- cargo test -p jira-mcp
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build -p zed-jira --target wasm32-wasip1 --release
