### PR TITLE
feat(tui): add project fix-version browser

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build fuzzers (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run fuzzers (${{ matrix.sanitizer }})
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             workflows:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
 
   # ── 1. CVE scan (rustsec advisory database) ───────────────────────────────
   # Uses plain shell commands instead of rustsec/audit-check action to avoid
@@ -111,6 +111,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+      - uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           sarif_file: scorecard-results.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3352,9 +3352,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Jira on the command line.
 
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
-[![Homebrew](https://img.shields.io/badge/homebrew-mulhamna%2Ftap-orange)](https://github.com/mulhamna/homebrew-tap)
+[![npm](https://img.shields.io/npm/v/%40mulham28%2Fjirac)](https://www.npmjs.com/package/@mulham28/jirac)
+[![Homebrew](https://img.shields.io/homebrew/v/mulhamna/tap/jira-commands)](https://github.com/mulhamna/homebrew-tap)
+[![Winget](https://img.shields.io/winget/v/mulhamna.jirac)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac)
+[![Chocolatey](https://img.shields.io/chocolatey/v/jirac)](https://community.chocolatey.org/packages/jirac)
+[![Scoop](https://img.shields.io/scoop/v/mulhamna/jirac)](https://github.com/mulhamna/scoop-bucket)
 [![License: MIT + Apache-2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ Jira on the command line.
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![npm](https://img.shields.io/npm/v/%40mulham28%2Fjirac)](https://www.npmjs.com/package/@mulham28/jirac)
-[![Homebrew](https://img.shields.io/homebrew/v/mulhamna/tap/jira-commands)](https://github.com/mulhamna/homebrew-tap)
+
+[![Homebrew](https://img.shields.io/badge/homebrew-v0.35.0-orange)](https://github.com/mulhamna/homebrew-tap)
 [![Winget](https://img.shields.io/winget/v/mulhamna.jirac)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac)
 [![Chocolatey](https://img.shields.io/chocolatey/v/jirac)](https://community.chocolatey.org/packages/jirac)
-[![Scoop](https://img.shields.io/scoop/v/mulhamna/jirac)](https://github.com/mulhamna/scoop-bucket)
+[![Scoop](https://img.shields.io/badge/dynamic/json?label=scoop&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac.json&color=00b4ff)](https://github.com/mulhamna/scoop-bucket)
+
 [![License: MIT + Apache-2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ jirac auth use client-dc
 
 ## Interactive TUI
 
-The TUI is a full-screen terminal interface for browsing and managing issues. Recent builds include a split master-detail layout, saved JQL picker, theme picker, server summary, config summary overlays, in-TUI modals for native issue type changes and project moves, and both single (`w`) and bulk (`b`) worklog flows. Press `?` inside the TUI for a complete shortcut reference.
+The TUI is a full-screen terminal interface for browsing and managing issues. Recent builds include a split master-detail layout, a project-level fix-version browser (`V`) with backlog preview, saved JQL picker, theme picker, server summary, config summary overlays, in-TUI modals for native issue type changes and project moves, and both single (`w`) and bulk (`b`) worklog flows. Press `?` inside the TUI for a complete shortcut reference.
 
 ```bash
 jirac tui -p PROJ

--- a/TUI.md
+++ b/TUI.md
@@ -19,6 +19,7 @@ The TUI provides a full-screen terminal interface for browsing and managing Jira
 | `j` / `k`   | Navigate up / down                                            |
 | `Enter`     | Open split detail view                                        |
 | `p`         | Open saved JQL queries                                        |
+| `V`         | Browse project fix versions and preview one version backlog   |
 | `T`         | Open theme picker                                             |
 | `S`         | Show server summary                                           |
 | `g`         | Show config summary                                           |
@@ -49,7 +50,6 @@ The TUI provides a full-screen terminal interface for browsing and managing Jira
 
 Detail tabs:
 - Summary
-- Versions (project fix versions + backlog preview for the selected issue's fix version)
 - Comments
 - Worklog
 - Attachments

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -41,7 +41,9 @@ use super::prompts::{
 use super::render::ui;
 use super::theme::ThemeName;
 use crate::version_check::{self, UpdateNotice};
-use crate::version_insights::load_issue_version_insight;
+use crate::version_insights::{
+    load_project_versions, load_version_backlog_preview, VersionBacklogPreview,
+};
 
 pub(super) fn looks_like_jql(input: &str) -> bool {
     let lower = input.trim().to_lowercase();
@@ -111,6 +113,13 @@ pub(super) struct App {
     pub(super) column_picker_state: ListState,
     pub(super) column_picker_filter: String,
     pub(super) available_fields: Vec<Field>,
+    pub(super) project_version_query: String,
+    pub(super) project_version_cursor: usize,
+    pub(super) project_version_options: Vec<PickerOption>,
+    pub(super) project_version_state: ListState,
+    pub(super) project_version_project_key: String,
+    pub(super) project_version_catalog: Vec<jira_core::model::ProjectVersion>,
+    pub(super) project_version_preview: Option<VersionBacklogPreview>,
     pub(super) assignee_query: String,
     pub(super) assignee_cursor: usize,
     pub(super) assignee_options: Vec<PickerOption>,
@@ -163,6 +172,9 @@ pub(super) enum AppAction {
     OpenNotifications,
     MarkNotificationsRead,
     CreateIssue,
+    OpenProjectVersionBrowser,
+    RefreshProjectVersionBrowser,
+    RefreshProjectVersionPreview,
     EditIssue(String),
     AssignIssue(String),
     OpenAssigneePicker(String),
@@ -207,16 +219,6 @@ impl App {
         self.detail.reset_for(&key);
 
         match self.active_tab {
-            DetailTab::Versions => {
-                if self.detail.version_insight.is_none() {
-                    match load_issue_version_insight(client, &key, 8).await {
-                        Ok(insight) => self.detail.version_insight = Some(insight),
-                        Err(e) => {
-                            self.set_status(format!("Version insight load failed: {e}"), true)
-                        }
-                    }
-                }
-            }
             DetailTab::Comments => {
                 if self.detail.comments.is_none() {
                     match client.get_comments(&key).await {
@@ -278,6 +280,13 @@ impl App {
             column_picker_state,
             column_picker_filter: String::new(),
             available_fields: Vec::new(),
+            project_version_query: String::new(),
+            project_version_cursor: 0,
+            project_version_options: Vec::new(),
+            project_version_state: ListState::default(),
+            project_version_project_key: String::new(),
+            project_version_catalog: Vec::new(),
+            project_version_preview: None,
             assignee_query: String::new(),
             assignee_cursor: 0,
             assignee_options: Vec::new(),
@@ -368,6 +377,32 @@ impl App {
 
     pub(super) fn selected_issue_key(&self) -> Option<String> {
         self.selected_issue().map(|i| i.key.clone())
+    }
+
+    pub(super) fn active_project_key(&self) -> Option<String> {
+        self.default_project.clone().or_else(|| {
+            self.selected_issue().map(|issue| {
+                issue
+                    .key
+                    .split_once('-')
+                    .map(|(project, _)| project.to_string())
+                    .unwrap_or_else(|| issue.project_key.clone())
+            })
+        })
+    }
+
+    pub(super) fn selected_project_version_name(&self) -> Option<&str> {
+        let idx = self.project_version_state.selected()?;
+        self.project_version_options
+            .get(idx)
+            .map(|option| option.value.as_str())
+    }
+
+    pub(super) fn selected_project_version(&self) -> Option<&jira_core::model::ProjectVersion> {
+        let name = self.selected_project_version_name()?;
+        self.project_version_catalog
+            .iter()
+            .find(|version| version.name == name)
     }
 
     pub(super) fn next_issue(&mut self) {
@@ -821,6 +856,157 @@ pub async fn run_tui(
                     }
                     Err(e) => {
                         app.set_status(format!("JQL error: {e}"), true);
+                    }
+                }
+            }
+
+            AppAction::OpenProjectVersionBrowser => {
+                let Some(project_key) = app.active_project_key() else {
+                    app.set_status(
+                        "Open a project-scoped TUI (`jirac tui -p PROJ`) or select an issue first",
+                        true,
+                    );
+                    continue;
+                };
+
+                app.project_version_project_key = project_key.clone();
+                app.project_version_query.clear();
+                app.project_version_cursor = 0;
+                app.project_version_options.clear();
+                app.project_version_catalog.clear();
+                app.project_version_preview = None;
+                app.project_version_state = ListState::default();
+                app.mode = Mode::ProjectVersionBrowser;
+                app.focus = Focus::List;
+                app.set_status(format!("Loading fix versions for {project_key}..."), false);
+                terminal.draw(|f| ui(f, &mut app))?;
+
+                match load_project_versions(&client, &project_key).await {
+                    Ok(versions) => {
+                        app.project_version_catalog = versions
+                            .into_iter()
+                            .filter(|version| !version.name.trim().is_empty())
+                            .collect();
+                        app.project_version_options = app
+                            .project_version_catalog
+                            .iter()
+                            .map(|version| PickerOption {
+                                value: version.name.clone(),
+                                label: version.name.clone(),
+                            })
+                            .collect();
+
+                        if !app.project_version_options.is_empty() {
+                            app.project_version_state.select(Some(0));
+                            if let Some(version) = app.selected_project_version().cloned() {
+                                app.set_status(
+                                    format!("Loading backlog preview for {}...", version.name),
+                                    false,
+                                );
+                                match load_version_backlog_preview(
+                                    &client,
+                                    &project_key,
+                                    version,
+                                    25,
+                                )
+                                .await
+                                {
+                                    Ok(preview) => {
+                                        app.project_version_preview = Some(preview);
+                                        app.clear_status();
+                                    }
+                                    Err(e) => app.set_status(
+                                        format!("Version backlog lookup failed: {e}"),
+                                        true,
+                                    ),
+                                }
+                            } else {
+                                app.clear_status();
+                            }
+                        } else {
+                            app.set_status(
+                                format!("No fix versions found for {project_key}"),
+                                false,
+                            );
+                        }
+                    }
+                    Err(e) => app.set_status(format!("Fix version lookup failed: {e}"), true),
+                }
+            }
+
+            AppAction::RefreshProjectVersionBrowser => {
+                let query = app.project_version_query.to_lowercase();
+                app.project_version_options = app
+                    .project_version_catalog
+                    .iter()
+                    .filter(|version| {
+                        query.is_empty() || version.name.to_lowercase().contains(&query)
+                    })
+                    .map(|version| PickerOption {
+                        value: version.name.clone(),
+                        label: version.name.clone(),
+                    })
+                    .collect();
+                app.project_version_state
+                    .select(if app.project_version_options.is_empty() {
+                        None
+                    } else {
+                        Some(0)
+                    });
+                app.project_version_preview = None;
+
+                if app.project_version_options.is_empty() {
+                    app.set_status("No matching fix versions", false);
+                } else {
+                    app.clear_status();
+                }
+
+                if let Some(version) = app.selected_project_version().cloned() {
+                    app.set_status(
+                        format!("Loading backlog preview for {}...", version.name),
+                        false,
+                    );
+                    match load_version_backlog_preview(
+                        &client,
+                        &app.project_version_project_key,
+                        version,
+                        25,
+                    )
+                    .await
+                    {
+                        Ok(preview) => {
+                            app.project_version_preview = Some(preview);
+                            app.clear_status();
+                        }
+                        Err(e) => {
+                            app.set_status(format!("Version backlog lookup failed: {e}"), true)
+                        }
+                    }
+                }
+            }
+
+            AppAction::RefreshProjectVersionPreview => {
+                app.project_version_preview = None;
+                if let Some(version) = app.selected_project_version().cloned() {
+                    app.set_status(
+                        format!("Loading backlog preview for {}...", version.name),
+                        false,
+                    );
+                    match load_version_backlog_preview(
+                        &client,
+                        &app.project_version_project_key,
+                        version,
+                        25,
+                    )
+                    .await
+                    {
+                        Ok(preview) => {
+                            app.project_version_preview = Some(preview);
+                            app.clear_status();
+                        }
+                        Err(e) => {
+                            app.set_status(format!("Version backlog lookup failed: {e}"), true)
+                        }
                     }
                 }
             }

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -33,6 +33,7 @@ pub(super) fn handle_key(app: &mut App, event: KeyEvent) -> AppAction {
         }
         Mode::Search => handle_search_key(app, code),
         Mode::Transition => handle_transition_key(app, code),
+        Mode::ProjectVersionBrowser => handle_project_version_browser_key(app, code),
         Mode::ColumnPicker => handle_column_picker_key(app, code),
         Mode::AssigneePicker => handle_assignee_picker_key(app, code),
         Mode::ComponentPicker => handle_component_picker_key(app, code),
@@ -103,6 +104,7 @@ fn handle_browse_key(app: &mut App, code: KeyCode) -> AppAction {
             app.mode = Mode::ThemePicker;
             AppAction::None
         }
+        KeyCode::Char('V') => AppAction::OpenProjectVersionBrowser,
         KeyCode::Char('S') => {
             app.mode = Mode::ServerInfo;
             AppAction::LoadServerInfo
@@ -203,6 +205,7 @@ fn handle_view_key(app: &mut App, code: KeyCode) -> AppAction {
         KeyCode::Char('t') => AppAction::FetchTransitions,
         KeyCode::Char('R') => AppAction::MarkNotificationsRead,
         KeyCode::Char('o') => AppAction::OpenBrowser,
+        KeyCode::Char('V') => AppAction::OpenProjectVersionBrowser,
         KeyCode::Char('?') => {
             app.mode = Mode::Help;
             AppAction::None
@@ -528,6 +531,53 @@ fn handle_assignee_picker_key(app: &mut App, code: KeyCode) -> AppAction {
                 }
             }
             AppAction::None
+        }
+        _ => AppAction::None,
+    }
+}
+
+fn handle_project_version_browser_key(app: &mut App, code: KeyCode) -> AppAction {
+    match code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.mode = Mode::Browse;
+            AppAction::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            picker_nav_down(
+                &mut app.project_version_state,
+                app.project_version_options.len(),
+            );
+            AppAction::RefreshProjectVersionPreview
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            picker_nav_up(&mut app.project_version_state);
+            AppAction::RefreshProjectVersionPreview
+        }
+        KeyCode::Left => {
+            picker_cursor_left(&mut app.project_version_cursor);
+            AppAction::None
+        }
+        KeyCode::Right => {
+            picker_cursor_right(&mut app.project_version_cursor, &app.project_version_query);
+            AppAction::None
+        }
+        KeyCode::Backspace => {
+            if picker_backspace(
+                &mut app.project_version_query,
+                &mut app.project_version_cursor,
+            ) {
+                AppAction::RefreshProjectVersionBrowser
+            } else {
+                AppAction::None
+            }
+        }
+        KeyCode::Char(c) => {
+            picker_type_char(
+                &mut app.project_version_query,
+                &mut app.project_version_cursor,
+                c,
+            );
+            AppAction::RefreshProjectVersionBrowser
         }
         _ => AppAction::None,
     }

--- a/crates/jira/src/tui/mode.rs
+++ b/crates/jira/src/tui/mode.rs
@@ -4,6 +4,7 @@ pub(super) enum Mode {
     Search,
     Transition,
     Help,
+    ProjectVersionBrowser,
     ColumnPicker,
     AssigneePicker,
     ComponentPicker,

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -1,11 +1,9 @@
-use crate::version_insights::IssueVersionInsight;
 use jira_core::model::{Comment, Worklog};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DetailTab {
     Summary,
-    Versions,
     Comments,
     Worklog,
     Attachments,
@@ -14,9 +12,8 @@ pub(super) enum DetailTab {
 }
 
 impl DetailTab {
-    pub(super) const ALL: [DetailTab; 7] = [
+    pub(super) const ALL: [DetailTab; 6] = [
         DetailTab::Summary,
-        DetailTab::Versions,
         DetailTab::Comments,
         DetailTab::Worklog,
         DetailTab::Attachments,
@@ -27,7 +24,6 @@ impl DetailTab {
     pub(super) fn label(self) -> &'static str {
         match self {
             DetailTab::Summary => "Summary",
-            DetailTab::Versions => "Versions",
             DetailTab::Comments => "Comments",
             DetailTab::Worklog => "Worklog",
             DetailTab::Attachments => "Attachments",
@@ -54,7 +50,6 @@ impl DetailTab {
 #[derive(Debug, Default)]
 pub(super) struct DetailData {
     pub(super) issue_key: String,
-    pub(super) version_insight: Option<IssueVersionInsight>,
     pub(super) comments: Option<Vec<Comment>>,
     pub(super) worklogs: Option<Vec<Worklog>>,
     pub(super) remote_links: Option<Vec<Value>>,

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -17,7 +17,7 @@ use super::mode::Mode;
 use super::panel::{DetailTab, Focus};
 use super::picker::PickerOption;
 use super::theme::{Palette, ThemeName};
-use super::version_format::{backlog_preview_lines, project_versions_preview};
+use super::version_format::{backlog_preview_lines, version_status_badges};
 
 pub(super) fn ui(f: &mut Frame, app: &mut App) {
     let size = f.area();
@@ -47,6 +47,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         Mode::Search => " Jira CLI — Search ".to_string(),
         Mode::Transition => " Jira CLI — Select Transition ".to_string(),
         Mode::Help => " Jira CLI — Help ".to_string(),
+        Mode::ProjectVersionBrowser => " Jira CLI — Project Versions ".to_string(),
         Mode::ColumnPicker => " Jira CLI — Columns ".to_string(),
         Mode::AssigneePicker => " Jira CLI — Assignee Picker ".to_string(),
         Mode::ComponentPicker => " Jira CLI — Component Picker ".to_string(),
@@ -81,6 +82,10 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         Mode::Help => {
             render_browse(f, app, chunks[1], palette);
             render_help_popup(f, size, palette);
+        }
+        Mode::ProjectVersionBrowser => {
+            render_browse(f, app, chunks[1], palette);
+            render_project_version_browser_popup(f, app, size, palette);
         }
         Mode::ColumnPicker => {
             render_browse(f, app, chunks[1], palette);
@@ -140,6 +145,7 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
         Mode::Search => " Type JQL  Enter:search  Esc:cancel".to_string(),
         Mode::Transition => " j/k:move  Enter:execute  Esc:cancel".to_string(),
         Mode::Help => " Any key: close".to_string(),
+        Mode::ProjectVersionBrowser => " type:filter  j/k:move  Esc:close".to_string(),
         Mode::ColumnPicker => " ↑/↓:move  Space:toggle  type:filter  Tab:clear  Enter:save  Esc:cancel".to_string(),
         Mode::AssigneePicker => " type:search  j/k:move  Enter:assign  Esc:cancel".to_string(),
         Mode::ComponentPicker => " type:search  j/k:move  Space:toggle  Enter:save  Esc:cancel".to_string(),
@@ -281,7 +287,6 @@ fn render_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
 
     let body = match app.active_tab {
         DetailTab::Summary => build_summary_lines(issue, palette),
-        DetailTab::Versions => build_version_lines(app, palette),
         DetailTab::Comments => build_comment_lines(app, palette),
         DetailTab::Worklog => build_worklog_lines(app, palette),
         DetailTab::Attachments => build_attachment_lines(issue),
@@ -350,70 +355,6 @@ fn build_summary_lines(issue: &jira_core::model::Issue, palette: Palette) -> Vec
                 lines.push(Line::from(format!("  {line}")));
             }
         }
-    }
-
-    lines
-}
-
-fn build_version_lines(app: &App, palette: Palette) -> Vec<Line<'static>> {
-    let Some(insight) = &app.detail.version_insight else {
-        return build_placeholder_lines("Versions", "Loading fix version insight...");
-    };
-
-    let mut lines: Vec<Line<'static>> = vec![
-        owned_field_line("Issue", insight.issue_key.clone(), palette),
-        owned_field_line("Project", insight.project_key.clone(), palette),
-    ];
-
-    let current = if insight.issue_fix_versions.is_empty() {
-        "—".to_string()
-    } else {
-        insight.issue_fix_versions.join(", ")
-    };
-    lines.push(owned_field_line("Current", current, palette));
-
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "Project versions:",
-        Style::default().add_modifier(Modifier::UNDERLINED),
-    )));
-    lines.push(Line::from(""));
-    for line in project_versions_preview(insight, 12) {
-        lines.push(Line::from(format!("  {line}")));
-    }
-    if insight.project_versions.len() > 12 {
-        lines.push(Line::from(format!(
-            "  … {} more version(s)",
-            insight.project_versions.len() - 12
-        )));
-    }
-
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "Open backlog preview:",
-        Style::default().add_modifier(Modifier::UNDERLINED),
-    )));
-    lines.push(Line::from(""));
-
-    if insight.previews.is_empty() {
-        if insight.issue_fix_versions.is_empty() {
-            lines.push(Line::from("  No fix version is set on this issue yet."));
-        } else {
-            lines.push(Line::from(
-                "  No open backlog items found for this issue's fix version(s).",
-            ));
-        }
-        return lines;
-    }
-
-    for preview in &insight.previews {
-        for line in backlog_preview_lines(preview, 6) {
-            lines.push(Line::from(format!("  {line}")));
-        }
-        lines.push(Line::from(""));
-    }
-    if matches!(lines.last(), Some(line) if line.spans.is_empty()) {
-        lines.pop();
     }
 
     lines
@@ -853,6 +794,125 @@ fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, pal
             "Esc cancel",
         ],
     );
+}
+
+fn render_project_version_browser_popup(
+    f: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    palette: Palette,
+) {
+    let popup_area = centered_rect(86, 82, area);
+    let [left_area, right_area] = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+        .areas(popup_area);
+
+    let left_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(left_area);
+
+    let query = Paragraph::new(app.project_version_query.clone())
+        .block(
+            Block::default()
+                .title(format!(
+                    " Fix Versions — {} ",
+                    if app.project_version_project_key.is_empty() {
+                        "project"
+                    } else {
+                        &app.project_version_project_key
+                    }
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(palette.focus_border)),
+        )
+        .style(Style::default().fg(palette.header_fg));
+
+    let version_items: Vec<ListItem> = if app.project_version_options.is_empty() {
+        vec![ListItem::new("No fix versions")]
+    } else {
+        app.project_version_options
+            .iter()
+            .map(|option| ListItem::new(option.label.clone()))
+            .collect()
+    };
+
+    let versions = List::new(version_items)
+        .block(
+            Block::default()
+                .title(" Versions ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(palette.focus_border)),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(palette.header_fg)
+                .bg(palette.highlight)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut right_lines: Vec<Line<'static>> = Vec::new();
+    if let Some(version) = app.selected_project_version() {
+        right_lines.push(Line::from(Span::styled(
+            version.name.clone(),
+            Style::default()
+                .fg(palette.tab_active)
+                .add_modifier(Modifier::BOLD),
+        )));
+        let badges = version_status_badges(version);
+        if !badges.is_empty() {
+            right_lines.push(Line::from(badges));
+        }
+        if let Some(description) = version.description.as_deref() {
+            let trimmed = description.trim();
+            if !trimmed.is_empty() {
+                right_lines.push(Line::from(""));
+                right_lines.push(Line::from(trimmed.to_string()));
+            }
+        }
+        right_lines.push(Line::from(""));
+        right_lines.push(Line::from(Span::styled(
+            "Open backlog:",
+            Style::default().add_modifier(Modifier::UNDERLINED),
+        )));
+        right_lines.push(Line::from(""));
+
+        match &app.project_version_preview {
+            Some(preview) if preview.version.name == version.name => {
+                for line in backlog_preview_lines(preview, 25) {
+                    right_lines.push(Line::from(line));
+                }
+            }
+            _ => right_lines.push(Line::from("Loading backlog preview...")),
+        }
+    } else {
+        right_lines.push(Line::from("Select a fix version to preview its backlog."));
+    }
+
+    let detail = Paragraph::new(right_lines)
+        .block(
+            Block::default()
+                .title(" Backlog Preview ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(palette.focus_border)),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(Clear, popup_area);
+    f.render_widget(query, left_chunks[0]);
+    f.render_stateful_widget(versions, left_chunks[1], &mut app.project_version_state);
+    f.render_widget(detail, right_area);
+
+    let before_cursor: String = app
+        .project_version_query
+        .chars()
+        .take(app.project_version_cursor)
+        .collect();
+    let cursor_x = left_chunks[0].x + 1 + before_cursor.len() as u16;
+    let cursor_y = left_chunks[0].y + 1;
+    f.set_cursor_position((cursor_x, cursor_y));
 }
 
 fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {

--- a/crates/jira/src/tui/version_format.rs
+++ b/crates/jira/src/tui/version_format.rs
@@ -1,6 +1,6 @@
 use jira_core::model::{Issue, ProjectVersion};
 
-use crate::version_insights::{IssueVersionInsight, VersionBacklogPreview};
+use crate::version_insights::VersionBacklogPreview;
 
 pub(super) fn version_status_badges(version: &ProjectVersion) -> String {
     let mut parts: Vec<String> = Vec::new();
@@ -20,31 +20,6 @@ pub(super) fn version_status_badges(version: &ProjectVersion) -> String {
 
 pub(super) fn preview_issue_line(issue: &Issue) -> String {
     format!("{} [{}] {}", issue.key, issue.status, issue.summary)
-}
-
-pub(super) fn project_versions_preview(insight: &IssueVersionInsight, limit: usize) -> Vec<String> {
-    insight
-        .project_versions
-        .iter()
-        .take(limit)
-        .map(|version| {
-            let marker = if insight
-                .issue_fix_versions
-                .iter()
-                .any(|name| name == &version.name)
-            {
-                "*"
-            } else {
-                "•"
-            };
-            let badges = version_status_badges(version);
-            if badges.is_empty() {
-                format!("{marker} {}", version.name)
-            } else {
-                format!("{marker} {} ({badges})", version.name)
-            }
-        })
-        .collect()
 }
 
 pub(super) fn backlog_preview_lines(preview: &VersionBacklogPreview, limit: usize) -> Vec<String> {

--- a/crates/jira/src/version_insights.rs
+++ b/crates/jira/src/version_insights.rs
@@ -35,7 +35,7 @@ pub async fn load_issue_version_insight(
     let issue_fix_versions = extract_fix_versions(&issue.fields);
 
     let mut project_versions = client.get_project_versions(&project_key).await?;
-    project_versions.sort_by_key(version_sort_key);
+    sort_project_versions(&mut project_versions);
 
     let mut previews = Vec::new();
     for version_name in &issue_fix_versions {
@@ -71,6 +71,36 @@ pub async fn load_issue_version_insight(
     })
 }
 
+pub async fn load_project_versions(
+    client: &JiraClient,
+    project_key: &str,
+) -> Result<Vec<ProjectVersion>> {
+    let mut versions = client.get_project_versions(project_key).await?;
+    sort_project_versions(&mut versions);
+    Ok(versions)
+}
+
+pub async fn load_version_backlog_preview(
+    client: &JiraClient,
+    project_key: &str,
+    version: ProjectVersion,
+    preview_limit: u32,
+) -> Result<VersionBacklogPreview> {
+    let jql = format!(
+        "project = \"{}\" AND fixVersion = \"{}\" AND statusCategory != Done ORDER BY updated DESC",
+        escape_jql(project_key),
+        escape_jql(&version.name),
+    );
+    let result = client
+        .search_issues(&jql, None, Some(preview_limit))
+        .await?;
+    Ok(VersionBacklogPreview {
+        version,
+        total_open: result.total.unwrap_or(result.issues.len() as u64),
+        issues: result.issues,
+    })
+}
+
 pub fn extract_fix_versions(fields: &Value) -> Vec<String> {
     fields
         .get("fixVersions")
@@ -89,6 +119,10 @@ pub fn extract_fix_versions(fields: &Value) -> Vec<String> {
 
 fn escape_jql(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+pub fn sort_project_versions(versions: &mut [ProjectVersion]) {
+    versions.sort_by_key(version_sort_key);
 }
 
 fn version_sort_key(version: &ProjectVersion) -> (u8, String, String) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -382,7 +382,7 @@ $ jirac issue transition CORE-183 --to Done
 
     <section id="tui" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
       <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Interactive TUI</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard-driven issue management, including a Versions detail tab for project fix versions and backlog preview, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, themes, single worklog entry via <code>w</code>, and bulk date-range worklogs via <code>b</code> with confirmation.</p>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard-driven issue management, including a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, themes, single worklog entry via <code>w</code>, and bulk date-range worklogs via <code>b</code> with confirmation.</p>
       <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
         <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
           <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
@@ -394,7 +394,7 @@ $ jirac issue transition CORE-183 --to Done
           <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
             <tr><td class="px-4 py-3"><span class="keycap">↑ / k</span></td><td class="px-4 py-3">Move to the issue above.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">↓ / j</span></td><td class="px-4 py-3">Move to the issue below.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">Enter</span></td><td class="px-4 py-3">Open details for the selected issue, including the Versions tab.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">Enter</span></td><td class="px-4 py-3">Open details for the selected issue.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">n</span></td><td class="px-4 py-3">Scan and open Jira mention notifications.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">R</span></td><td class="px-4 py-3">Mark the selected notification issue as read.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">c</span></td><td class="px-4 py-3">Create a new issue.</td></tr>
@@ -405,6 +405,7 @@ $ jirac issue transition CORE-183 --to Done
             <tr><td class="px-4 py-3"><span class="keycap">C</span></td><td class="px-4 py-3">Choose which table columns stay visible and persist that preference.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">T</span></td><td class="px-4 py-3">Open the theme picker, including Kanagawa Wave.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">p</span></td><td class="px-4 py-3">Open saved JQL queries.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">V</span></td><td class="px-4 py-3">Browse project fix versions and preview backlog for the selected version.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">w</span></td><td class="px-4 py-3">Add a single worklog to the issue.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">b</span></td><td class="px-4 py-3">Add bulk worklogs across a date range, with confirmation before submit.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">v</span></td><td class="px-4 py-3">Edit fix versions.</td></tr>


### PR DESCRIPTION
## Summary
- add a project-scoped fix-version browser in the TUI via `V`
- show backlog preview for the selected fix version from within the browser
- remove the redundant issue-detail Versions tab so version browsing has one clear path
- fold in the currently open dependabot bumps for tokio, codeql-action, dorny/paths-filter, and clusterfuzzlite

## UX
- `V` opens project fix versions from the main TUI list/detail context
- moving selection updates the backlog preview for that version
- issue detail stays focused on the issue itself

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build --all`

## Supersedes
- #231
- #232
- #233
- #234
