### PR TITLE
fix(zed-jira): use jirac-mcp-server extension id

### DIFF
--- a/crates/zed-jira/extension.toml
+++ b/crates/zed-jira/extension.toml
@@ -1,4 +1,4 @@
-id = "jira"
+id = "jirac-mcp-server"
 name = "Jira"
 version = "0.1.0"
 schema_version = 1
@@ -6,5 +6,5 @@ authors = ["Mulham <mulhamna@gmail.com>"]
 description = "Jira MCP server for Zed — browse issues, run JQL, transition, create, and more via the Agent Panel."
 repository = "https://github.com/mulhamna/jira-commands"
 
-[context_servers.jira]
+[context_servers.jirac-mcp-server]
 name = "Jira"

--- a/crates/zed-jira/src/lib.rs
+++ b/crates/zed-jira/src/lib.rs
@@ -4,7 +4,7 @@ use zed::serde_json::Value;
 use zed::settings::ContextServerSettings;
 use zed_extension_api as zed;
 
-const CONTEXT_SERVER_ID: &str = "jira";
+const CONTEXT_SERVER_ID: &str = "jirac-mcp-server";
 const REPO: &str = "mulhamna/jira-commands";
 
 struct JiraExtension;
@@ -145,7 +145,7 @@ const INSTALLATION_INSTRUCTIONS: &str = r#"Install the Jira extension from the Z
 ```json
 {
   \"context_servers\": {
-    \"jira\": {
+    \"jirac-mcp-server\": {
       \"settings\": {
         \"jira_url\": \"https://yourcompany.atlassian.net\",
         \"jira_email\": \"you@example.com\",


### PR DESCRIPTION
## Summary
- change the Zed extension id to `jirac-mcp-server`
- align the context server key with the published extension id

## Why
Zed review requested a more explicit, unique extension id for publishing.