### PR TITLE
fix: write opencode MCP config directly

### DIFF
--- a/.github/scripts/refresh_release_readme.py
+++ b/.github/scripts/refresh_release_readme.py
@@ -15,6 +15,7 @@ README = Path("README.md")
 INSTALL = Path("INSTALL.md")
 START = "<!-- contributors:start -->"
 END = "<!-- contributors:end -->"
+HOMEBREW_FORMULA = "https://raw.githubusercontent.com/mulhamna/homebrew-tap/main/Formula/jira-commands.rb"
 
 
 def fetch_json(url: str):
@@ -45,6 +46,20 @@ def fetch_contributors(limit: int = 18):
         contributors.append({"login": login, "avatar": avatar, "html": html})
     return contributors
 
+
+
+def refresh_homebrew_badge(text: str) -> str:
+    formula = urllib.request.urlopen(HOMEBREW_FORMULA, timeout=30).read().decode()
+    match = re.search(r'version "([^"]+)"', formula)
+    if not match:
+        raise SystemExit('could not extract Homebrew formula version')
+    version = match.group(1)
+    return re.sub(
+        r"\[!\[Homebrew\]\(https://img\.shields\.io/badge/homebrew-v[^)]+\)\]\(https://github\.com/mulhamna/homebrew-tap\)",
+        f"[![Homebrew](https://img.shields.io/badge/homebrew-v{version}-orange)](https://github.com/mulhamna/homebrew-tap)",
+        text,
+        count=1,
+    )
 
 def replace_install_block(text: str) -> str:
     start = text.find("## Install\n")
@@ -134,6 +149,7 @@ def main() -> int:
     readme = README.read_text()
     install = INSTALL.read_text()
     contributors = fetch_contributors()
+    readme = refresh_homebrew_badge(readme)
     readme = replace_install_block(readme)
     readme = replace_footer(readme, contributors)
     install = refresh_install_md(install)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,7 +165,7 @@ Supported targets now:
 - `cursor` (`~/.cursor/mcp.json`, provisional path until verified in a real Cursor install)
 - `gemini-cli` (delegates to `gemini mcp add -s user ...`)
 - `codex` (delegates to `codex mcp add ...`)
-- `opencode` (delegates to `opencode mcp add ...`)
+- `opencode` (`~/.config/opencode/opencode.jsonc`, direct JSONC write)
 - `generic-json` (prints a portable JSON snippet instead of writing a file)
 - `zed` (`~/.config/zed/settings.json` on Linux, `~/Library/Application Support/Zed/settings.json` on macOS, `%APPDATA%/Zed/settings.json` on Windows; seeds `context_servers.jira.settings` for the official Zed marketplace extension published from <https://github.com/mulhamna/jirac-ext>)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jira on the command line.
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![npm](https://img.shields.io/npm/v/%40mulham28%2Fjirac)](https://www.npmjs.com/package/@mulham28/jirac)
 
-[![Homebrew](https://img.shields.io/badge/homebrew-v0.35.0-orange)](https://github.com/mulhamna/homebrew-tap)
+[![Homebrew](https://img.shields.io/badge/homebrew-v0.38.1-orange)](https://github.com/mulhamna/homebrew-tap)
 [![Winget](https://img.shields.io/winget/v/mulhamna.jirac)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac)
 [![Chocolatey](https://img.shields.io/chocolatey/v/jirac)](https://community.chocolatey.org/packages/jirac)
 [![Scoop](https://img.shields.io/badge/dynamic/json?label=scoop&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac.json&color=00b4ff)](https://github.com/mulhamna/scoop-bucket)

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -84,7 +84,7 @@ jirac mcp install --client zed
 ```
 
 Notes:
-- `gemini-cli`, `codex`, and `opencode` delegate to their native CLI `mcp add` flows
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows; `opencode` writes `~/.config/opencode/opencode.jsonc` directly
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install
 - `zed` writes `context_servers.jira.settings` for the official Zed marketplace extension

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -114,7 +114,7 @@ jirac mcp install --client zed
 ```
 
 Notes:
-- `gemini-cli`, `codex`, and `opencode` delegate to their native CLI `mcp add` flows
+- `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows; `opencode` writes `~/.config/opencode/opencode.jsonc` directly
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install
 - `zed` writes `context_servers.jira.settings` for the official Zed marketplace extension

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -77,7 +77,7 @@ fn install_client(
     }
 
     let resolved_command = resolve_command_for_client(&client, command, dry_run)?;
-    let spec = server_spec(name, &resolved_command, transport);
+    let spec = server_spec(&client, name, &resolved_command, transport);
 
     if matches!(client, McpClient::GenericJson) {
         print_snippet(&spec.json_snippet)?;
@@ -263,19 +263,39 @@ enum ClientDescriptor {
     },
 }
 
-fn server_spec(name: &str, command: &str, transport: &str) -> ServerSpec {
-    let file_entry = json!({
-        "command": command,
-        "args": ["serve", "--transport", transport]
-    });
-    let json_snippet = json!({
-        "mcpServers": {
-            name: file_entry.clone()
+fn server_spec(client: &McpClient, name: &str, command: &str, transport: &str) -> ServerSpec {
+    match client {
+        McpClient::OpenCode => {
+            let file_entry = json!({
+                "type": "local",
+                "command": [command, "serve", "--transport", transport],
+                "enabled": true,
+            });
+            let json_snippet = json!({
+                "mcp": {
+                    name: file_entry.clone()
+                }
+            });
+            ServerSpec {
+                file_entry,
+                json_snippet,
+            }
         }
-    });
-    ServerSpec {
-        file_entry,
-        json_snippet,
+        _ => {
+            let file_entry = json!({
+                "command": command,
+                "args": ["serve", "--transport", transport]
+            });
+            let json_snippet = json!({
+                "mcpServers": {
+                    name: file_entry.clone()
+                }
+            });
+            ServerSpec {
+                file_entry,
+                json_snippet,
+            }
+        }
     }
 }
 
@@ -298,9 +318,8 @@ fn install_target(client: &McpClient) -> Result<InstallTarget> {
             config_path_from_env_or_default("CURSOR_CONFIG", home.join(".cursor/mcp.json")),
             "mcpServers",
         ),
-        McpClient::GeminiCli | McpClient::Codex | McpClient::OpenCode | McpClient::GenericJson => {
-            unreachable!()
-        }
+        McpClient::OpenCode => ("opencode", opencode_settings_path(&home), "mcp"),
+        McpClient::GeminiCli | McpClient::Codex | McpClient::GenericJson => unreachable!(),
         McpClient::Zed => ("zed", zed_settings_path(&home), "context_servers"),
     };
 
@@ -334,6 +353,13 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
                 .unwrap_or_else(|_| PathBuf::from("~/.cursor/mcp.json")),
             note: "Provisional path until verified in a real Cursor install.",
         },
+        McpClient::OpenCode => ClientDescriptor::FileTarget {
+            label: "opencode",
+            path: install_target(client)
+                .map(|t| t.path)
+                .unwrap_or_else(|_| PathBuf::from("~/.config/opencode/opencode.jsonc")),
+            note: "Writes JSONC at ~/.config/opencode/opencode.jsonc by default.",
+        },
         McpClient::GeminiCli => ClientDescriptor::Delegated {
             label: "gemini-cli",
             program: "gemini",
@@ -343,11 +369,6 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
             label: "codex",
             program: "codex",
             note: "Delegates to `codex mcp add ...`.",
-        },
-        McpClient::OpenCode => ClientDescriptor::Delegated {
-            label: "opencode",
-            program: "opencode",
-            note: "Delegates to `opencode mcp add ...`.",
         },
         McpClient::GenericJson => ClientDescriptor::SnippetOnly {
             label: "generic-json",
@@ -373,11 +394,6 @@ fn client_adapter(client: &McpClient) -> Option<ClientAdapter> {
         McpClient::Codex => Some(ClientAdapter {
             label: "codex",
             program: "codex",
-            build_steps: codex_steps,
-        }),
-        McpClient::OpenCode => Some(ClientAdapter {
-            label: "opencode",
-            program: "opencode",
             build_steps: codex_steps,
         }),
         _ => None,
@@ -576,11 +592,28 @@ fn zed_settings_path(home: &Path) -> PathBuf {
     }
 }
 
+fn opencode_settings_path(home: &Path) -> PathBuf {
+    if let Some(path) = env::var_os("OPENCODE_CONFIG") {
+        return PathBuf::from(path);
+    }
+
+    if cfg!(target_os = "macos") {
+        home.join(".config/opencode/opencode.jsonc")
+    } else if cfg!(target_os = "windows") {
+        env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("AppData/Roaming"))
+            .join("opencode/opencode.jsonc")
+    } else {
+        env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"))
+            .join("opencode/opencode.jsonc")
+    }
+}
+
 fn resolve_command_for_client(client: &McpClient, command: &str, dry_run: bool) -> Result<String> {
-    if !matches!(
-        client,
-        McpClient::GeminiCli | McpClient::Codex | McpClient::OpenCode
-    ) {
+    if !matches!(client, McpClient::GeminiCli | McpClient::Codex) {
         return Ok(command.to_string());
     }
 
@@ -628,8 +661,9 @@ fn load_json_object(path: &Path) -> Result<Map<String, Value>> {
         return Ok(Map::new());
     }
 
-    let value: Value = serde_json::from_str(&raw)
-        .with_context(|| format!("Config file {} is not valid JSON", path.display()))?;
+    let sanitized = strip_json_comments(&raw);
+    let value: Value = serde_json::from_str(&sanitized)
+        .with_context(|| format!("Config file {} is not valid JSON/JSONC", path.display()))?;
 
     match value {
         Value::Object(map) => Ok(map),
@@ -638,6 +672,59 @@ fn load_json_object(path: &Path) -> Result<Map<String, Value>> {
             path.display()
         ),
     }
+}
+
+fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                out.push(ch);
+            }
+            '/' if matches!(chars.peek(), Some('/')) => {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if matches!(chars.peek(), Some('*')) => {
+                chars.next();
+                let mut prev = '\0';
+                for next in chars.by_ref() {
+                    if prev == '*' && next == '/' {
+                        break;
+                    }
+                    if next == '\n' {
+                        out.push('\n');
+                    }
+                    prev = next;
+                }
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    out
 }
 
 fn ensure_object_field<'a>(
@@ -717,7 +804,8 @@ mod tests {
 
     #[test]
     fn generic_json_snippet_contains_server_name() {
-        let snippet = server_spec("jira", "jirac-mcp", "stdio").json_snippet;
+        let snippet =
+            server_spec(&McpClient::GenericJson, "jira", "jirac-mcp", "stdio").json_snippet;
         let rendered = serde_json::to_string_pretty(&snippet).unwrap();
         assert!(rendered.contains("\"mcpServers\""));
         assert!(rendered.contains("\"jira\""));
@@ -747,10 +835,23 @@ mod tests {
     }
 
     #[test]
-    fn opencode_preview_matches_cli_shape() {
-        let adapter = client_adapter(&McpClient::OpenCode).unwrap();
-        let preview = adapter.preview_command("jira", "jirac-mcp", "stdio", false);
-        assert!(preview.contains("opencode mcp add jira -- jirac-mcp serve --transport stdio"));
+    fn opencode_snippet_uses_local_command_array() {
+        let snippet =
+            server_spec(&McpClient::OpenCode, "jira", "/tmp/jirac-mcp", "stdio").json_snippet;
+        let rendered = serde_json::to_string_pretty(&snippet).unwrap();
+        assert!(rendered.contains("\"mcp\""));
+        assert!(rendered.contains("\"type\": \"local\""));
+        assert!(rendered.contains("/tmp/jirac-mcp"));
+    }
+
+    #[test]
+    fn load_json_object_accepts_jsonc_comments() {
+        let path =
+            std::env::temp_dir().join(format!("jirac-opencode-test-{}.jsonc", std::process::id()));
+        fs::write(&path, "// top-level comment\n{\n  /* block */\n  \"mcp\": {\n    \"jira\": {\"enabled\": true}\n  }\n}\n").unwrap();
+        let parsed = load_json_object(&path).unwrap();
+        fs::remove_file(&path).ok();
+        assert!(parsed.contains_key("mcp"));
     }
 
     #[test]

--- a/docs/index.html
+++ b/docs/index.html
@@ -499,7 +499,8 @@ jirac mcp install --client zed</code></pre>
             </div>
             <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-600 dark:text-slate-400">
               <li><code>generic-json</code> prints a portable JSON snippet instead of writing a file.</li>
-              <li><code>gemini-cli</code>, <code>codex</code>, and <code>opencode</code> delegate to their native <code>mcp add</code> commands.</li>
+              <li><code>gemini-cli</code> and <code>codex</code> delegate to their native <code>mcp add</code> commands.</li>
+              <li><code>opencode</code> writes <code>~/.config/opencode/opencode.jsonc</code> directly because its CLI flow is interactive.</li>
               <li>Use <code>--print</code> to show the JSON snippet or delegated client command first.</li>
               <li>Use <code>--dry-run</code> to preview without writing.</li>
               <li>Use <code>--force</code> to overwrite an existing entry with the same name.</li>


### PR DESCRIPTION
## Description

This fixes two user-facing release regressions:

1. `jirac mcp install --client opencode` should not delegate to `opencode mcp add`, because that CLI path is interactive and does not accept the expected non-interactive arguments. This PR writes `~/.config/opencode/opencode.jsonc` directly instead.
2. The README Homebrew badge was stale at `v0.35.0`. This PR refreshes it to the current version and updates the release README refresh script so future releases keep it current automatically.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- Added tests for the OpenCode JSON snippet shape and JSONC comment parsing.
- Verified the new dry-run output for `--client opencode` now prints the direct config snippet and target path instead of a delegated CLI command.
- I did not run `cargo audit` again in this PR because the change is scoped to CLI install behavior + docs and introduces no dependencies.

