### PR TITLE
chore(jira-core,tui): SDK polish + mouse support for 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.37.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,9 +1539,10 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.37.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "comrak",
  "dirs",
  "figment",
@@ -1559,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.37.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Jira on the command line.
 ## Highlights
 
 - **Interactive TUI** — browse, search, create, edit, change type, move between projects, transition, assign, comment, bulk-comment, worklog, upload, and inspect issues without leaving the terminal
+- **Mouse-driven TUI** — click rows, tabs, picker options, and outside-popup; scroll wheel navigates lists; double-click opens detail
 - **Split master-detail UI** — keep the issue list visible while opening summary, comments, worklog, attachments, subtasks, and links
 - **Saved query and theme preferences** — reuse saved JQLs, persist visible columns, and switch TUI themes (including GitHub Light)
 - **Multi-profile auth** — store and switch between multiple Jira accounts or deployments
@@ -246,11 +247,13 @@ jirac auth use client-dc
 
 The TUI is a full-screen terminal interface for browsing and managing issues. Recent builds include a split master-detail layout, a project-level fix-version browser (`V`) with backlog preview plus in-place version creation (`n`) and metadata editing (`e`), saved JQL picker, theme picker, server summary, config summary overlays, in-TUI modals for native issue type changes and project moves, and both single (`w`) and bulk (`b`) worklog flows. Press `?` inside the TUI for a complete shortcut reference.
 
+The TUI also accepts full mouse input: click any issue row to select, double-click (or click a tab) to open the detail view, click picker options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only so in-flight input isn't lost.
+
 ```bash
 jirac tui -p PROJ
 ```
 
-Full keybinding reference: [TUI.md](TUI.md)
+Full keybinding and mouse reference: [TUI.md](TUI.md)
 
 ## Configuration
 

--- a/TUI.md
+++ b/TUI.md
@@ -162,3 +162,23 @@ Available presets include dark themes plus **GitHub Light** for a brighter, ligh
 | Key         | Action      |
 | ----------- | ----------- |
 | `Esc` / `q` | Close popup |
+
+## Mouse support
+
+The TUI is fully keyboard-driven, but every pointer-friendly interaction is also wired up. Mouse capture is enabled automatically while the TUI is running; to copy text out of the terminal hold `Shift` (iTerm2 / most Linux terminals) or `Option` (Terminal.app) while selecting.
+
+| Action                  | Result                                                                  |
+| ----------------------- | ----------------------------------------------------------------------- |
+| Click issue row         | Select that row                                                         |
+| Double-click issue row  | Open split detail view (same as `Enter`)                                |
+| Click detail tab        | Switch to that tab; lazy-fetches comments/worklog/links as needed       |
+| Click detail pane       | Switch focus to detail when currently focused on the list               |
+| Click picker option     | Apply for single-select pickers (transition, assignee, sprint, saved JQL, theme, project versions browser); toggle for multi-select pickers (components, fix versions, columns) |
+| Click outside a popup   | Close popup (equivalent to `Esc`)                                       |
+| Scroll wheel on list    | Previous / next issue                                                   |
+| Scroll wheel on picker  | Move picker selection up / down                                         |
+
+Notes:
+- Modal forms (create / edit / bulk-comment) intentionally ignore outside clicks so partially filled forms aren't discarded. Use `Esc` to cancel.
+- Double-click window is 400 ms on the same cell. Slower clicks count as two separate selects.
+- Under tmux make sure `set -g mouse on` is set in `~/.tmux.conf` so mouse events are forwarded to the TUI.

--- a/crates/jira-core/Cargo.toml
+++ b/crates/jira-core/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1"
 tracing = "0.1"
 comrak = { version = "0.28", default-features = false }
 mime_guess = "2"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jira-core/README.md
+++ b/crates/jira-core/README.md
@@ -27,6 +27,10 @@ jira-core = "0.12"
 - field metadata discovery and reuse
 - issue, worklog, transition, attachment, and bulk-operation helpers
 - Atlassian Document Format helpers for text and Markdown conversion
+- typed `model::` structs for every public response: `Issue`, `Comment`,
+  `Worklog`, `Attachment`, `Field`, `IssueLink`, `IssueType`,
+  `RemoteLink`, `Component`, `Transition`, `JiraUser`, `Sprint`,
+  `ProjectVersion` — no more walking raw `serde_json::Value`
 
 ## Example
 

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -178,37 +178,45 @@ impl JiraClient {
             })
     }
 
+    /// Send a request, retrying on HTTP 429 according to the `Retry-After` header.
+    /// Returns the first non-429 response, or `RateLimit` after `MAX_RETRIES` attempts.
+    async fn execute_with_retry(
+        &self,
+        builder_fn: impl Fn() -> reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response> {
+        let mut attempt = 0u32;
+        loop {
+            attempt += 1;
+            let response = builder_fn().send().await?;
+
+            if response.status() != StatusCode::TOO_MANY_REQUESTS {
+                return Ok(response);
+            }
+
+            let retry_after = response
+                .headers()
+                .get("Retry-After")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(60);
+
+            warn!("Rate limited. Retrying after {}s", retry_after);
+
+            if attempt >= MAX_RETRIES {
+                return Err(JiraError::RateLimit { retry_after });
+            }
+
+            tokio::time::sleep(Duration::from_secs(retry_after)).await;
+        }
+    }
+
     /// Core request method with rate-limit retry logic.
     async fn request<T>(&self, builder_fn: impl Fn() -> reqwest::RequestBuilder) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        let mut attempt = 0u32;
-        loop {
-            attempt += 1;
-            let req = builder_fn();
-            let response = req.send().await?;
-
-            if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                let retry_after = response
-                    .headers()
-                    .get("Retry-After")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60);
-
-                warn!("Rate limited. Retrying after {}s", retry_after);
-
-                if attempt >= MAX_RETRIES {
-                    return Err(JiraError::RateLimit { retry_after });
-                }
-
-                tokio::time::sleep(Duration::from_secs(retry_after)).await;
-                continue;
-            }
-
-            return handle_response(response).await;
-        }
+        let response = self.execute_with_retry(builder_fn).await?;
+        handle_response(response).await
     }
 
     /// Core request method for responses with no body (204 No Content).
@@ -216,44 +224,19 @@ impl JiraClient {
         &self,
         builder_fn: impl Fn() -> reqwest::RequestBuilder,
     ) -> Result<()> {
-        let mut attempt = 0u32;
-        loop {
-            attempt += 1;
-            let req = builder_fn();
-            let response = req.send().await?;
-
-            if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                let retry_after = response
-                    .headers()
-                    .get("Retry-After")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60);
-
-                warn!("Rate limited. Retrying after {}s", retry_after);
-
-                if attempt >= MAX_RETRIES {
-                    return Err(JiraError::RateLimit { retry_after });
-                }
-
-                tokio::time::sleep(Duration::from_secs(retry_after)).await;
-                continue;
-            }
-
-            let status = response.status();
-            if status.is_success() {
-                return Ok(());
-            }
-
-            let body = response.text().await.unwrap_or_default();
-            if status == StatusCode::NOT_FOUND {
-                return Err(JiraError::NotFound(body));
-            }
-            return Err(JiraError::Api {
-                status: status.as_u16(),
-                message: body,
-            });
+        let response = self.execute_with_retry(builder_fn).await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
         }
+        let body = response.text().await.unwrap_or_default();
+        if status == StatusCode::NOT_FOUND {
+            return Err(JiraError::NotFound(body));
+        }
+        Err(JiraError::Api {
+            status: status.as_u16(),
+            message: body,
+        })
     }
 
     /// Multipart request with rate-limit retry (for attachment uploads).
@@ -264,32 +247,8 @@ impl JiraClient {
     where
         T: serde::de::DeserializeOwned,
     {
-        let mut attempt = 0u32;
-        loop {
-            attempt += 1;
-            let req = builder_fn();
-            let response = req.send().await?;
-
-            if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                let retry_after = response
-                    .headers()
-                    .get("Retry-After")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60);
-
-                warn!("Rate limited. Retrying after {}s", retry_after);
-
-                if attempt >= MAX_RETRIES {
-                    return Err(JiraError::RateLimit { retry_after });
-                }
-
-                tokio::time::sleep(Duration::from_secs(retry_after)).await;
-                continue;
-            }
-
-            return handle_response(response).await;
-        }
+        let response = self.execute_with_retry(builder_fn).await?;
+        handle_response(response).await
     }
 
     /// Search issues using JQL with cursor-based pagination.
@@ -1384,65 +1343,48 @@ impl JiraClient {
         let url = format!("{}{}", self.config.base_url.trim_end_matches('/'), path);
 
         let http = &self.http;
-        let mut attempt = 0u32;
-        loop {
-            attempt += 1;
-            let req = match method.to_uppercase().as_str() {
-                "GET" => http.get(&url),
-                "POST" => http.post(&url),
-                "PUT" => http.put(&url),
-                "DELETE" => http.delete(&url),
-                "PATCH" => http.patch(&url),
-                _ => http.get(&url),
-            };
-            let req = req.headers(headers.clone());
-            let req = if let Some(b) = &body {
-                req.json(b)
-            } else {
-                req
-            };
-
-            let response = req.send().await?;
-
-            if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                let retry_after = response
-                    .headers()
-                    .get("Retry-After")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60);
-                warn!("Rate limited. Retrying after {}s", retry_after);
-                if attempt >= MAX_RETRIES {
-                    return Err(JiraError::RateLimit { retry_after });
+        let response = self
+            .execute_with_retry(|| {
+                let req = match method.to_uppercase().as_str() {
+                    "GET" => http.get(&url),
+                    "POST" => http.post(&url),
+                    "PUT" => http.put(&url),
+                    "DELETE" => http.delete(&url),
+                    "PATCH" => http.patch(&url),
+                    _ => http.get(&url),
+                };
+                let req = req.headers(headers.clone());
+                if let Some(b) = &body {
+                    req.json(b)
+                } else {
+                    req
                 }
-                tokio::time::sleep(Duration::from_secs(retry_after)).await;
-                continue;
-            }
+            })
+            .await?;
 
-            let status = response.status();
+        let status = response.status();
 
-            // 204 No Content — success with empty body
-            if status == StatusCode::NO_CONTENT {
-                return Ok(None);
-            }
-
-            if status.is_success() {
-                let value: Value = response.json().await?;
-                return Ok(Some(value));
-            }
-
-            let body_text = response.text().await.unwrap_or_default();
-            return Err(match status {
-                StatusCode::NOT_FOUND => JiraError::NotFound(body_text),
-                StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                    JiraError::Auth(format!("HTTP {status}: {body_text}"))
-                }
-                _ => JiraError::Api {
-                    status: status.as_u16(),
-                    message: body_text,
-                },
-            });
+        // 204 No Content — success with empty body
+        if status == StatusCode::NO_CONTENT {
+            return Ok(None);
         }
+
+        if status.is_success() {
+            let value: Value = response.json().await?;
+            return Ok(Some(value));
+        }
+
+        let body_text = response.text().await.unwrap_or_default();
+        Err(match status {
+            StatusCode::NOT_FOUND => JiraError::NotFound(body_text),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                JiraError::Auth(format!("HTTP {status}: {body_text}"))
+            }
+            _ => JiraError::Api {
+                status: status.as_u16(),
+                message: body_text,
+            },
+        })
     }
 
     // ── Plans API (Jira Premium) ──────────────────────────────────────────────

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -14,6 +14,7 @@ use crate::{
     model::{
         attachment::Attachment,
         comment::Comment,
+        component::Component,
         field::Field,
         issue::{
             CreateIssueRequest, CreateIssueRequestV2, Issue, RawIssue, RawSearchResponse,
@@ -21,6 +22,7 @@ use crate::{
         },
         issue_type::IssueType,
         link::{IssueLink, IssueLinkType},
+        remote_link::RemoteLink,
         sprint::Sprint,
         version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest},
         worklog::Worklog,
@@ -353,6 +355,15 @@ impl JiraClient {
     }
 
     /// Create a new issue.
+    ///
+    /// Deprecated in favor of [`JiraClient::create_issue_v2`], which supports
+    /// custom fields, labels, components, parent, fix versions, and ADF
+    /// descriptions. This method is retained for backward compatibility and
+    /// will be removed in a future release.
+    #[deprecated(
+        since = "0.40.0",
+        note = "Use `create_issue_v2` — supports custom fields, labels, components, parent, fix versions"
+    )]
     pub async fn create_issue(&self, req: CreateIssueRequest) -> Result<Issue> {
         let headers = self.auth_headers()?;
         let url = self.platform_url("/issue");
@@ -718,16 +729,13 @@ impl JiraClient {
     }
 
     /// List components available within a project.
-    pub async fn get_project_components(&self, project_key: &str) -> Result<Vec<Value>> {
+    pub async fn get_project_components(&self, project_key: &str) -> Result<Vec<Component>> {
         let headers = self.auth_headers()?;
         let url = self.platform_url(&format!("/project/{project_key}/components"));
 
         let http = &self.http;
-        let components: Vec<Value> = self
-            .request(|| http.get(&url).headers(headers.clone()))
-            .await?;
-
-        Ok(components)
+        self.request(|| http.get(&url).headers(headers.clone()))
+            .await
     }
 
     /// List fix versions available within a project.
@@ -1147,7 +1155,7 @@ impl JiraClient {
     }
 
     /// List remote links on an issue.
-    pub async fn get_remote_links(&self, issue_key: &str) -> Result<Vec<Value>> {
+    pub async fn get_remote_links(&self, issue_key: &str) -> Result<Vec<RemoteLink>> {
         let headers = self.auth_headers()?;
         let url = self.platform_url(&format!("/issue/{issue_key}/remotelink"));
 

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -69,31 +69,15 @@ impl JiraClient {
     }
 
     fn auth_headers(&self) -> Result<HeaderMap> {
-        let token = self.config.token.as_deref().ok_or_else(|| {
-            JiraError::Auth("No token configured. Run `jirac auth login` first.".into())
-        })?;
-
-        let auth_value = match self.config.auth_type {
-            JiraAuthType::CloudApiToken | JiraAuthType::DataCenterBasic => {
-                let credentials = base64_encode(&format!("{}:{}", self.config.email, token));
-                format!("Basic {credentials}")
-            }
-            JiraAuthType::DataCenterPat => format!("Bearer {token}"),
-        };
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&auth_value)
-                .map_err(|e| JiraError::Auth(format!("Invalid auth header: {e}")))?,
-        );
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
-        Ok(headers)
+        self.build_auth_headers(true)
     }
 
     /// Auth headers without Content-Type — required for multipart uploads.
     fn auth_headers_no_content_type(&self) -> Result<HeaderMap> {
+        self.build_auth_headers(false)
+    }
+
+    fn build_auth_headers(&self, include_content_type: bool) -> Result<HeaderMap> {
         let token = self.config.token.as_deref().ok_or_else(|| {
             JiraError::Auth("No token configured. Run `jirac auth login` first.".into())
         })?;
@@ -112,6 +96,9 @@ impl JiraClient {
             HeaderValue::from_str(&auth_value)
                 .map_err(|e| JiraError::Auth(format!("Invalid auth header: {e}")))?,
         );
+        if include_content_type {
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        }
         Ok(headers)
     }
 

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -24,6 +24,7 @@ use crate::{
         link::{IssueLink, IssueLinkType},
         remote_link::RemoteLink,
         sprint::Sprint,
+        transition::Transition,
         version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest},
         worklog::Worklog,
     },
@@ -550,13 +551,13 @@ impl JiraClient {
     }
 
     /// Get available transitions for an issue.
-    pub async fn get_transitions(&self, key: &str) -> Result<Vec<Value>> {
+    pub async fn get_transitions(&self, key: &str) -> Result<Vec<Transition>> {
         let headers = self.auth_headers()?;
         let url = self.platform_url(&format!("/issue/{key}/transitions"));
 
         #[derive(serde::Deserialize)]
         struct TransitionsResponse {
-            transitions: Vec<Value>,
+            transitions: Vec<Transition>,
         }
 
         let http = &self.http;

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -2572,4 +2572,186 @@ mod tests {
             "Blocked Issue"
         );
     }
+
+    #[tokio::test]
+    async fn get_remote_links_parses_object_title_and_url() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1/remotelink"))
+            .and(header("authorization", cloud_auth().as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "id": 10001,
+                    "self": "https://jira.example.com/rest/api/3/issue/TEST-1/remotelink/10001",
+                    "globalId": "system=https://docs.example.com&id=42",
+                    "relationship": "Wiki Page",
+                    "object": {
+                        "title": "Design Doc",
+                        "url": "https://docs.example.com/design",
+                        "summary": "Architecture overview"
+                    }
+                },
+                {
+                    "id": 10002,
+                    "object": {
+                        "title": "Tracking ticket",
+                        "url": "https://tracker.example.com/4242"
+                    }
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let links = client
+            .get_remote_links("TEST-1")
+            .await
+            .expect("remote links should parse");
+
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].id, 10001);
+        assert_eq!(
+            links[0].global_id.as_deref(),
+            Some("system=https://docs.example.com&id=42")
+        );
+        assert_eq!(links[0].object.title, "Design Doc");
+        assert_eq!(links[0].object.url, "https://docs.example.com/design");
+        assert_eq!(
+            links[0].object.summary.as_deref(),
+            Some("Architecture overview")
+        );
+        assert_eq!(links[1].id, 10002);
+        assert!(links[1].global_id.is_none());
+        assert!(links[1].object.summary.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_remote_links_returns_empty_when_no_links() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1/remotelink"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let links = client.get_remote_links("TEST-1").await.expect("parse");
+        assert!(links.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_project_components_parses_id_and_name() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/project/PROJ/components"))
+            .and(header("authorization", cloud_auth().as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {
+                    "id": "10100",
+                    "name": "Backend",
+                    "description": "Server-side code",
+                    "self": "https://jira.example.com/rest/api/3/component/10100"
+                },
+                {
+                    "id": "10101",
+                    "name": "Frontend"
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let components = client
+            .get_project_components("PROJ")
+            .await
+            .expect("components should parse");
+
+        assert_eq!(components.len(), 2);
+        assert_eq!(components[0].id, "10100");
+        assert_eq!(components[0].name, "Backend");
+        assert_eq!(
+            components[0].description.as_deref(),
+            Some("Server-side code")
+        );
+        assert!(components[0].self_url.is_some());
+        assert_eq!(components[1].name, "Frontend");
+        assert!(components[1].description.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_transitions_parses_id_name_and_preserves_extra_fields() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1/transitions"))
+            .and(header("authorization", cloud_auth().as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "expand": "transitions",
+                "transitions": [
+                    {
+                        "id": "21",
+                        "name": "In Progress",
+                        "hasScreen": false,
+                        "isGlobal": false,
+                        "isInitial": false,
+                        "isAvailable": true,
+                        "to": {
+                            "id": "3",
+                            "name": "In Progress",
+                            "statusCategory": { "key": "indeterminate" }
+                        }
+                    },
+                    {
+                        "id": "31",
+                        "name": "Done",
+                        "to": { "id": "10001", "name": "Done" }
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let transitions = client
+            .get_transitions("TEST-1")
+            .await
+            .expect("transitions should parse");
+
+        assert_eq!(transitions.len(), 2);
+        assert_eq!(transitions[0].id, "21");
+        assert_eq!(transitions[0].name, "In Progress");
+        assert_eq!(
+            transitions[0].to.as_ref().and_then(|t| t.name.as_deref()),
+            Some("In Progress")
+        );
+
+        // Extra Jira fields (hasScreen, isGlobal, ...) must round-trip via #[serde(flatten)]
+        // so MCP consumers re-serializing the struct keep the full payload shape.
+        let reserialized = serde_json::to_value(&transitions[0]).expect("serialize");
+        assert_eq!(reserialized["hasScreen"], json!(false));
+        assert_eq!(reserialized["isAvailable"], json!(true));
+
+        assert_eq!(transitions[1].id, "31");
+        assert!(transitions[1].to.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_transitions_returns_empty_when_no_transitions_available() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1/transitions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "transitions": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let transitions = client.get_transitions("TEST-1").await.expect("parse");
+        assert!(transitions.is_empty());
+    }
 }

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -1606,33 +1606,9 @@ where
 
 /// Returns current UTC time in Jira worklog format: "2006-01-02T15:04:05.000+0000"
 fn current_jira_timestamp() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    // Manual conversion: secs since epoch → date/time components
-    let s = secs % 60;
-    let m = (secs / 60) % 60;
-    let h = (secs / 3600) % 24;
-    // Days since epoch
-    let days = secs / 86400;
-    // Simplified: use a rough date calculation
-    // For worklog "started", accuracy to the day is sufficient
-    let year_approx = 1970 + days / 365;
-    let day_of_year = days % 365;
-    let month = (day_of_year / 30) + 1;
-    let day = (day_of_year % 30) + 1;
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.000+0000",
-        year_approx,
-        month.min(12),
-        day.min(28),
-        h,
-        m,
-        s
-    )
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3f%z")
+        .to_string()
 }
 
 fn base64_encode(input: &str) -> String {

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -25,6 +25,7 @@ use crate::{
         remote_link::RemoteLink,
         sprint::Sprint,
         transition::Transition,
+        user::JiraUser,
         version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest},
         worklog::Worklog,
     },
@@ -154,15 +155,13 @@ impl JiraClient {
         users
             .iter()
             .find(|u| {
-                u.get("emailAddress")
-                    .and_then(|v| v.as_str())
+                u.email_address
+                    .as_deref()
                     .map(|e| e.eq_ignore_ascii_case(s))
                     .unwrap_or(false)
             })
             .or_else(|| users.first())
-            .and_then(|u| u.get("accountId"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+            .map(|u| u.account_id.clone())
             .ok_or_else(|| JiraError::Api {
                 status: 0,
                 message: format!("User not found: {s}"),
@@ -713,20 +712,17 @@ impl JiraClient {
     }
 
     /// Search Jira users by query string (for User field autocomplete).
-    pub async fn search_users(&self, query: &str) -> Result<Vec<Value>> {
+    pub async fn search_users(&self, query: &str) -> Result<Vec<JiraUser>> {
         let headers = self.auth_headers()?;
         let url = self.platform_url("/user/search");
 
         let http = &self.http;
-        let users: Vec<Value> = self
-            .request(|| {
-                http.get(&url)
-                    .headers(headers.clone())
-                    .query(&[("query", query), ("maxResults", "20")])
-            })
-            .await?;
-
-        Ok(users)
+        self.request(|| {
+            http.get(&url)
+                .headers(headers.clone())
+                .query(&[("query", query), ("maxResults", "20")])
+        })
+        .await
     }
 
     /// List components available within a project.
@@ -1822,9 +1818,9 @@ mod tests {
             .expect("search should parse");
 
         assert_eq!(users.len(), 1);
-        assert_eq!(users[0]["accountId"], "acct-1");
-        assert_eq!(users[0]["displayName"], "Alice Example");
-        assert!(users[0].get("emailAddress").is_none());
+        assert_eq!(users[0].account_id, "acct-1");
+        assert_eq!(users[0].display_name.as_deref(), Some("Alice Example"));
+        assert!(users[0].email_address.is_none());
     }
 
     #[tokio::test]
@@ -2333,7 +2329,7 @@ mod tests {
             .expect("request should retry and succeed");
 
         assert_eq!(users.len(), 1);
-        assert_eq!(users[0]["accountId"], "acct-1");
+        assert_eq!(users[0].account_id, "acct-1");
     }
 
     #[tokio::test]

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -30,6 +30,14 @@ use crate::{
 const AGILE_BASE: &str = "/rest/agile/1.0";
 const MAX_RETRIES: u32 = 3;
 
+#[derive(serde::Deserialize)]
+struct MyselfResponse {
+    #[serde(rename = "accountId")]
+    account_id: Option<String>,
+    #[serde(rename = "timeZone")]
+    time_zone: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct JiraClient {
     http: Client,
@@ -103,7 +111,7 @@ impl JiraClient {
         Ok(headers)
     }
 
-    async fn get_myself_value(&self) -> Result<Value> {
+    async fn get_myself_info(&self) -> Result<MyselfResponse> {
         let headers = self.auth_headers()?;
         let url = self.platform_url("/myself");
 
@@ -114,24 +122,16 @@ impl JiraClient {
 
     /// Get the current authenticated user's accountId.
     pub async fn get_myself(&self) -> Result<String> {
-        let user = self.get_myself_value().await?;
-
-        user.get("accountId")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| JiraError::Api {
-                status: 0,
-                message: "Could not get accountId from /myself".into(),
-            })
+        let me = self.get_myself_info().await?;
+        me.account_id.ok_or_else(|| JiraError::Api {
+            status: 0,
+            message: "Could not get accountId from /myself".into(),
+        })
     }
 
     /// Get the current authenticated user's Jira timezone (IANA name), if available.
     pub async fn get_myself_timezone(&self) -> Result<Option<String>> {
-        let user = self.get_myself_value().await?;
-        Ok(user
-            .get("timeZone")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()))
+        Ok(self.get_myself_info().await?.time_zone)
     }
 
     /// Resolve an assignee string to a Jira accountId.

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -19,6 +19,7 @@ use crate::{
             CreateIssueRequest, CreateIssueRequestV2, Issue, RawIssue, RawSearchResponse,
             SearchResult, UpdateIssueRequest,
         },
+        issue_type::IssueType,
         link::{IssueLink, IssueLinkType},
         sprint::Sprint,
         version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest},
@@ -1491,13 +1492,6 @@ impl JiraClient {
         self.request_no_body(|| http.delete(&url).headers(headers.clone()))
             .await
     }
-}
-
-/// Issue type metadata (id + name) returned by createmeta.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct IssueType {
-    pub id: String,
-    pub name: String,
 }
 
 async fn handle_response<T>(response: Response) -> Result<T>

--- a/crates/jira-core/src/lib.rs
+++ b/crates/jira-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod field_cache;
 pub mod model;
 
-pub use client::{IssueType, JiraClient};
+pub use client::JiraClient;
 pub use error::{JiraError, Result};
 pub use field_cache::FieldCache;
+pub use model::IssueType;

--- a/crates/jira-core/src/model/component.rs
+++ b/crates/jira-core/src/model/component.rs
@@ -1,0 +1,11 @@
+/// A project component, returned by `GET /rest/api/3/project/{key}/components`.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Component {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default, rename = "self")]
+    pub self_url: Option<String>,
+}

--- a/crates/jira-core/src/model/issue_type.rs
+++ b/crates/jira-core/src/model/issue_type.rs
@@ -1,0 +1,6 @@
+/// Issue type metadata (id + name) returned by createmeta.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct IssueType {
+    pub id: String,
+    pub name: String,
+}

--- a/crates/jira-core/src/model/mod.rs
+++ b/crates/jira-core/src/model/mod.rs
@@ -7,6 +7,7 @@ pub mod issue_type;
 pub mod link;
 pub mod remote_link;
 pub mod sprint;
+pub mod transition;
 pub mod version;
 pub mod worklog;
 
@@ -21,5 +22,6 @@ pub use issue_type::IssueType;
 pub use link::{IssueLink, IssueLinkType};
 pub use remote_link::{RemoteLink, RemoteLinkObject};
 pub use sprint::Sprint;
+pub use transition::{Transition, TransitionStatus};
 pub use version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest};
 pub use worklog::Worklog;

--- a/crates/jira-core/src/model/mod.rs
+++ b/crates/jira-core/src/model/mod.rs
@@ -8,6 +8,7 @@ pub mod link;
 pub mod remote_link;
 pub mod sprint;
 pub mod transition;
+pub mod user;
 pub mod version;
 pub mod worklog;
 
@@ -23,5 +24,6 @@ pub use link::{IssueLink, IssueLinkType};
 pub use remote_link::{RemoteLink, RemoteLinkObject};
 pub use sprint::Sprint;
 pub use transition::{Transition, TransitionStatus};
+pub use user::JiraUser;
 pub use version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest};
 pub use worklog::Worklog;

--- a/crates/jira-core/src/model/mod.rs
+++ b/crates/jira-core/src/model/mod.rs
@@ -2,6 +2,7 @@ pub mod attachment;
 pub mod comment;
 pub mod field;
 pub mod issue;
+pub mod issue_type;
 pub mod link;
 pub mod sprint;
 pub mod version;
@@ -13,6 +14,7 @@ pub use field::{Field, FieldKind, FieldValue};
 pub use issue::{
     CreateIssueRequest, CreateIssueRequestV2, Issue, SearchResult, UpdateIssueRequest,
 };
+pub use issue_type::IssueType;
 pub use link::{IssueLink, IssueLinkType};
 pub use sprint::Sprint;
 pub use version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest};

--- a/crates/jira-core/src/model/mod.rs
+++ b/crates/jira-core/src/model/mod.rs
@@ -1,21 +1,25 @@
 pub mod attachment;
 pub mod comment;
+pub mod component;
 pub mod field;
 pub mod issue;
 pub mod issue_type;
 pub mod link;
+pub mod remote_link;
 pub mod sprint;
 pub mod version;
 pub mod worklog;
 
 pub use attachment::Attachment;
 pub use comment::Comment;
+pub use component::Component;
 pub use field::{Field, FieldKind, FieldValue};
 pub use issue::{
     CreateIssueRequest, CreateIssueRequestV2, Issue, SearchResult, UpdateIssueRequest,
 };
 pub use issue_type::IssueType;
 pub use link::{IssueLink, IssueLinkType};
+pub use remote_link::{RemoteLink, RemoteLinkObject};
 pub use sprint::Sprint;
 pub use version::{CreateProjectVersionRequest, ProjectVersion, UpdateProjectVersionRequest};
 pub use worklog::Worklog;

--- a/crates/jira-core/src/model/remote_link.rs
+++ b/crates/jira-core/src/model/remote_link.rs
@@ -1,0 +1,25 @@
+/// A remote link attached to a Jira issue.
+///
+/// Returned by `GET /rest/api/3/issue/{key}/remotelink`. Only the fields
+/// consumed by this crate's callers are typed; the full Jira payload
+/// includes additional optional metadata (icon, status, application).
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteLink {
+    pub id: i64,
+    #[serde(rename = "self", default)]
+    pub self_url: Option<String>,
+    #[serde(default)]
+    pub global_id: Option<String>,
+    #[serde(default)]
+    pub relationship: Option<String>,
+    pub object: RemoteLinkObject,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct RemoteLinkObject {
+    pub title: String,
+    pub url: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+}

--- a/crates/jira-core/src/model/transition.rs
+++ b/crates/jira-core/src/model/transition.rs
@@ -1,0 +1,28 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// An issue workflow transition, returned by `GET /rest/api/3/issue/{key}/transitions`.
+///
+/// Unknown fields from the Jira response are captured in `extra` so that
+/// callers re-serializing the transition (e.g. the MCP server) preserve
+/// the full payload shape.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Transition {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub to: Option<TransitionStatus>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct TransitionStatus {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}

--- a/crates/jira-core/src/model/user.rs
+++ b/crates/jira-core/src/model/user.rs
@@ -1,0 +1,14 @@
+/// A Jira user, returned by `GET /rest/api/3/user/search` and similar endpoints.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraUser {
+    pub account_id: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub email_address: Option<String>,
+    #[serde(default)]
+    pub active: Option<bool>,
+    #[serde(default)]
+    pub account_type: Option<String>,
+}

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -535,14 +535,8 @@ async fn resolve_transition(
 ) -> AppResult<ResolvedTransition> {
     let transitions = client.get_transitions(key).await?;
     let found = transitions
-        .iter()
-        .find(|transition| {
-            transition.get("id").and_then(|value| value.as_str()) == Some(name_or_id)
-                || transition
-                    .get("name")
-                    .and_then(|value| value.as_str())
-                    .is_some_and(|name| name.eq_ignore_ascii_case(name_or_id))
-        })
+        .into_iter()
+        .find(|t| t.id == name_or_id || t.name.eq_ignore_ascii_case(name_or_id))
         .ok_or_else(|| {
             AppError::not_found(
                 format!("Transition '{name_or_id}' not found for {key}"),
@@ -551,16 +545,8 @@ async fn resolve_transition(
         })?;
 
     Ok(ResolvedTransition {
-        id: found
-            .get("id")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default()
-            .to_string(),
-        name: found
-            .get("name")
-            .and_then(|value| value.as_str())
-            .unwrap_or(name_or_id)
-            .to_string(),
+        id: found.id,
+        name: found.name,
     })
 }
 

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -28,7 +28,7 @@ Or use one of the workspace-level install options from the root README:
 - `jirac` primary CLI binary
 - issue listing, viewing, create, update, transition, delete, clone
 - worklog, attachment, bulk-update, bulk-transition, archive, batch, and bulk-create flows
-- interactive TUI flows, including split master-detail, saved JQL picker, theme picker, searchable assignee picker, project-scoped component picker, server summary, config summary, and saved column settings
+- interactive TUI flows, including split master-detail, saved JQL picker, theme picker, searchable assignee picker, project-scoped component picker, server summary, config summary, and saved column settings — fully usable with mouse (click rows, tabs, picker options; scroll wheel; click outside popup to dismiss)
 - raw Jira REST API passthrough
 - shared config with multi-profile auth support
 

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -2172,22 +2172,13 @@ async fn transition_issue(
     let transition_id = if let Some(name_or_id) = transition {
         transitions
             .iter()
-            .find(|t| {
-                t.get("id").and_then(|v| v.as_str()) == Some(&name_or_id)
-                    || t.get("name").and_then(|v| v.as_str()) == Some(&name_or_id)
-            })
-            .and_then(|t| t.get("id"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+            .find(|t| t.id == name_or_id || t.name == name_or_id)
+            .map(|t| t.id.clone())
             .ok_or_else(|| anyhow::anyhow!("Transition '{}' not found", name_or_id))?
     } else {
         let options: Vec<String> = transitions
             .iter()
-            .filter_map(|t| {
-                let id = t.get("id")?.as_str()?;
-                let name = t.get("name")?.as_str()?;
-                Some(format!("{name} [{id}]"))
-            })
+            .map(|t| format!("{} [{}]", t.name, t.id))
             .collect();
 
         let selected = Select::new("Select transition:", options.clone())
@@ -3020,16 +3011,8 @@ async fn bulk_transition(
 
     let transition_id = transitions
         .iter()
-        .find(|t| {
-            t.get("id").and_then(|v| v.as_str()) == Some(&to)
-                || t.get("name")
-                    .and_then(|v| v.as_str())
-                    .map(|n| n.to_lowercase())
-                    == Some(to.to_lowercase())
-        })
-        .and_then(|t| t.get("id"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .find(|t| t.id == to || t.name.eq_ignore_ascii_case(&to))
+        .map(|t| t.id.clone())
         .ok_or_else(|| anyhow::anyhow!("Transition '{}' not found", to))?;
 
     let pb = progress_bar(issues.len() as u64);
@@ -3504,16 +3487,8 @@ async fn batch_manifest(
                         .map_err(|e| anyhow::anyhow!(e))?;
                     let tid = transitions
                         .iter()
-                        .find(|t| {
-                            t.get("id").and_then(|v| v.as_str()) == Some(&to)
-                                || t.get("name")
-                                    .and_then(|v| v.as_str())
-                                    .map(|n| n.to_lowercase())
-                                    == Some(to.to_lowercase())
-                        })
-                        .and_then(|t| t.get("id"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
+                        .find(|t| t.id == to || t.name.eq_ignore_ascii_case(&to))
+                        .map(|t| t.id.clone())
                         .ok_or_else(|| anyhow::anyhow!("Transition '{}' not found", to))?;
                     client
                         .transition_issue(&key, &tid)

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1151,20 +1151,12 @@ pub async fn run_tui(
                     Ok(users) => {
                         for user in users {
                             let display = user
-                                .get("displayName")
-                                .and_then(|v| v.as_str())
+                                .display_name
+                                .as_deref()
                                 .unwrap_or("Unknown user")
                                 .trim();
-                            let email = user
-                                .get("emailAddress")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .trim();
-                            let account_id = user
-                                .get("accountId")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .trim();
+                            let email = user.email_address.as_deref().unwrap_or("").trim();
+                            let account_id = user.account_id.trim();
                             if account_id.is_empty() {
                                 continue;
                             }
@@ -1202,20 +1194,12 @@ pub async fn run_tui(
                         }];
                         for user in users {
                             let display = user
-                                .get("displayName")
-                                .and_then(|v| v.as_str())
+                                .display_name
+                                .as_deref()
                                 .unwrap_or("Unknown user")
                                 .trim();
-                            let email = user
-                                .get("emailAddress")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .trim();
-                            let account_id = user
-                                .get("accountId")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .trim();
+                            let email = user.email_address.as_deref().unwrap_or("").trim();
+                            let account_id = user.account_id.trim();
                             if account_id.is_empty() {
                                 continue;
                             }
@@ -1524,14 +1508,11 @@ pub async fn run_tui(
 
                     if let Ok(users) = client.search_users(&query).await {
                         let options: Vec<PickerOption> = users
-                            .iter()
+                            .into_iter()
                             .filter_map(|u| {
-                                let display =
-                                    u.get("displayName").and_then(|v| v.as_str())?.to_string();
-                                let account_id =
-                                    u.get("accountId").and_then(|v| v.as_str())?.to_string();
+                                let display = u.display_name?;
                                 Some(PickerOption {
-                                    value: account_id,
+                                    value: u.account_id,
                                     label: display,
                                 })
                             })

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1278,8 +1278,7 @@ pub async fn run_tui(
                                 app.component_catalog = components
                                     .into_iter()
                                     .filter_map(|component| {
-                                        let name =
-                                            component.get("name").and_then(|v| v.as_str())?.trim();
+                                        let name = component.name.trim();
                                         if name.is_empty() {
                                             return None;
                                         }

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -10,7 +10,7 @@ use crate::notifications::{
 };
 use anyhow::Result;
 use crossterm::{
-    event::{self, Event, KeyEventKind},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -24,7 +24,7 @@ use jira_core::{
     IssueType, JiraClient,
 };
 
-use super::panel::{DetailData, DetailTab, Focus};
+use super::panel::{DetailData, DetailTab, Focus, HitZones};
 use ratatui::{
     backend::CrosstermBackend,
     widgets::{ListState, TableState},
@@ -35,6 +35,7 @@ use super::column::{format_column_summary, ColumnSpec};
 use super::keys;
 use super::modal::{Modal, ModalKind};
 use super::mode::Mode;
+use super::mouse;
 use super::picker::PickerOption;
 use super::prefs::{SavedJql, TuiPreferences};
 use super::prompts::{
@@ -162,6 +163,7 @@ pub(super) struct App {
     pub(super) modal: Option<Modal>,
     pub(super) prev_mode: Option<Mode>,
     pub(super) notification_entries: Vec<NotificationEntry>,
+    pub(super) hit_zones: HitZones,
 }
 
 pub(super) enum AppAction {
@@ -332,6 +334,7 @@ impl App {
             modal: None,
             prev_mode: None,
             notification_entries: Vec::new(),
+            hit_zones: HitZones::default(),
         }
     }
 
@@ -795,7 +798,7 @@ pub async fn run_tui(
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -825,14 +828,18 @@ pub async fn run_tui(
             continue;
         }
 
-        let Ok(Event::Key(key)) = event::read() else {
-            continue;
+        let action = match event::read() {
+            Ok(Event::Key(key)) => {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                keys::handle_key(&mut app, key)
+            }
+            Ok(Event::Mouse(mouse_event)) => mouse::handle_mouse(&mut app, mouse_event),
+            _ => continue,
         };
-        if key.kind != KeyEventKind::Press {
-            continue;
-        }
 
-        match keys::handle_key(&mut app, key) {
+        match action {
             AppAction::Quit => break,
 
             AppAction::Refresh => {
@@ -2754,7 +2761,11 @@ pub async fn run_tui(
     }
 
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
     terminal.show_cursor()?;
 
     Ok(())

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1078,14 +1078,8 @@ pub async fn run_tui(
                     terminal.draw(|f| ui(f, &mut app))?;
                     match client.get_transitions(&key).await {
                         Ok(raw) => {
-                            let transitions: Vec<(String, String)> = raw
-                                .iter()
-                                .filter_map(|t| {
-                                    let id = t.get("id")?.as_str()?.to_string();
-                                    let name = t.get("name")?.as_str()?.to_string();
-                                    Some((id, name))
-                                })
-                                .collect();
+                            let transitions: Vec<(String, String)> =
+                                raw.into_iter().map(|t| (t.id, t.name)).collect();
 
                             if transitions.is_empty() {
                                 app.set_status("No transitions available", true);

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     io,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crate::notifications::{
@@ -164,6 +164,8 @@ pub(super) struct App {
     pub(super) prev_mode: Option<Mode>,
     pub(super) notification_entries: Vec<NotificationEntry>,
     pub(super) hit_zones: HitZones,
+    /// (when, column, row) of the last left-click. Used to detect double-click.
+    pub(super) last_click: Option<(Instant, u16, u16)>,
 }
 
 pub(super) enum AppAction {
@@ -335,6 +337,7 @@ impl App {
             prev_mode: None,
             notification_entries: Vec::new(),
             hit_zones: HitZones::default(),
+            last_click: None,
         }
     }
 

--- a/crates/jira/src/tui/mod.rs
+++ b/crates/jira/src/tui/mod.rs
@@ -3,6 +3,7 @@ mod column;
 mod keys;
 mod modal;
 mod mode;
+mod mouse;
 mod panel;
 mod picker;
 mod prefs;

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -5,10 +5,20 @@
 //! returns the appropriate `AppAction` (or `None` if the click missed
 //! every registered target).
 
+use std::time::{Duration, Instant};
+
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use super::app::{App, AppAction};
+use super::panel::Focus;
+
+/// Maximum gap between two left-clicks on the same cell to count as a double-click.
+const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(400);
+
+/// Vertical offset from a list/table's top-left corner to the first data row.
+/// Layout is: top border (1) + header row (1) + header bottom_margin (1) = 3.
+const LIST_HEADER_OFFSET: u16 = 3;
 
 fn contains(rect: &Rect, col: u16, row: u16) -> bool {
     col >= rect.x
@@ -17,21 +27,70 @@ fn contains(rect: &Rect, col: u16, row: u16) -> bool {
         && row < rect.y.saturating_add(rect.height)
 }
 
-pub(super) fn handle_mouse(_app: &mut App, event: MouseEvent) -> AppAction {
+/// Translate a pointer row inside the list rect to an issue index, accounting
+/// for table scroll offset. Returns `None` if the click landed on the header,
+/// border, or below the last visible row.
+fn list_row_index(app: &App, rect: &Rect, row: u16) -> Option<usize> {
+    let first_data_row = rect.y.saturating_add(LIST_HEADER_OFFSET);
+    let last_data_row = rect.y.saturating_add(rect.height).saturating_sub(2); // bottom border
+    if row < first_data_row || row >= last_data_row {
+        return None;
+    }
+    let visible_offset = (row - first_data_row) as usize;
+    let scroll_offset = app.table_state.offset();
+    let idx = scroll_offset + visible_offset;
+    (idx < app.issues.len()).then_some(idx)
+}
+
+pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
+    let col = event.column;
+    let row = event.row;
+
     match event.kind {
         MouseEventKind::Down(MouseButton::Left) => {
-            // hit-test wired in follow-up commits
+            let now = Instant::now();
+            let is_double_click = app
+                .last_click
+                .map(|(t, c, r)| {
+                    now.duration_since(t) <= DOUBLE_CLICK_WINDOW && c == col && r == row
+                })
+                .unwrap_or(false);
+            app.last_click = Some((now, col, row));
+
+            // List row click
+            if let Some(list_rect) = app.hit_zones.list {
+                if contains(&list_rect, col, row) {
+                    if let Some(idx) = list_row_index(app, &list_rect, row) {
+                        app.table_state.select(Some(idx));
+                        if is_double_click {
+                            app.focus = Focus::Detail;
+                        }
+                    }
+                    return AppAction::None;
+                }
+            }
+
             AppAction::None
         }
-        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-            // wheel scroll wired in follow-up commits
+        MouseEventKind::ScrollUp => {
+            // Wheel up over the list scrolls selection up.
+            if let Some(list_rect) = app.hit_zones.list {
+                if contains(&list_rect, col, row) {
+                    app.prev_issue();
+                    return AppAction::None;
+                }
+            }
+            AppAction::None
+        }
+        MouseEventKind::ScrollDown => {
+            if let Some(list_rect) = app.hit_zones.list {
+                if contains(&list_rect, col, row) {
+                    app.next_issue();
+                    return AppAction::None;
+                }
+            }
             AppAction::None
         }
         _ => AppAction::None,
     }
-}
-
-#[allow(dead_code)]
-pub(super) fn point_in(rect: Option<&Rect>, col: u16, row: u16) -> bool {
-    rect.is_some_and(|r| contains(r, col, row))
 }

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -7,10 +7,13 @@
 
 use std::time::{Duration, Instant};
 
-use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
+use ratatui::widgets::ListState;
 
 use super::app::{App, AppAction};
+use super::keys;
+use super::mode::Mode;
 use super::panel::Focus;
 
 /// Maximum gap between two left-clicks on the same cell to count as a double-click.
@@ -42,6 +45,23 @@ fn list_row_index(app: &App, rect: &Rect, row: u16) -> Option<usize> {
     (idx < app.issues.len()).then_some(idx)
 }
 
+fn synth_press(app: &mut App, code: KeyCode) -> AppAction {
+    keys::handle_key(app, KeyEvent::new(code, KeyModifiers::NONE))
+}
+
+/// Select an option in a picker list state and then synthesize the keypress
+/// (`Enter` for single-select pickers, `Space` for multi-select) so the
+/// existing keyboard handler runs the apply/toggle logic.
+fn select_and_press(
+    app: &mut App,
+    state_field: fn(&mut App) -> &mut ListState,
+    idx: usize,
+    code: KeyCode,
+) -> AppAction {
+    state_field(app).select(Some(idx));
+    synth_press(app, code)
+}
+
 pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
     let col = event.column;
     let row = event.row;
@@ -56,6 +76,90 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 })
                 .unwrap_or(false);
             app.last_click = Some((now, col, row));
+
+            // Picker option click — dispatch per-mode.
+            if let Some(picker) = app.hit_zones.picker {
+                if let Some(idx) = picker.row_to_index(row) {
+                    if col >= picker.area.x && col < picker.area.x.saturating_add(picker.area.width)
+                    {
+                        match app.mode {
+                            Mode::Transition => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.transition_list_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::AssigneePicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.assignee_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::SprintPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.sprint_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::SavedJqlPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.saved_jql_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::ThemePicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.theme_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::ProjectVersionBrowser => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.project_version_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
+                            Mode::ComponentPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.component_state,
+                                    idx,
+                                    KeyCode::Char(' '),
+                                );
+                            }
+                            Mode::FixVersionPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.fix_version_state,
+                                    idx,
+                                    KeyCode::Char(' '),
+                                );
+                            }
+                            Mode::ColumnPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.column_picker_state,
+                                    idx,
+                                    KeyCode::Char(' '),
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
 
             // Detail tab header click → switch tab + warm async.
             for (tab_rect, tab) in app.hit_zones.detail_tabs.clone() {

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -197,10 +197,26 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 }
             }
 
+            // Click outside an active popup → close (synthesize Esc, which every
+            // popup-mode handler treats as cancel).
+            if is_popup_mode(&app.mode) {
+                if let Some(popup) = app.hit_zones.popup {
+                    if !contains(&popup, col, row) {
+                        return synth_press(app, KeyCode::Esc);
+                    }
+                }
+            }
+
             AppAction::None
         }
         MouseEventKind::ScrollUp => {
-            // Wheel up over the list scrolls selection up.
+            // Wheel over a picker → move selection up.
+            if let Some(picker) = app.hit_zones.picker {
+                if contains(&picker.area, col, row) {
+                    return synth_press(app, KeyCode::Up);
+                }
+            }
+            // Wheel over the issue list → previous issue.
             if let Some(list_rect) = app.hit_zones.list {
                 if contains(&list_rect, col, row) {
                     app.prev_issue();
@@ -210,6 +226,11 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
             AppAction::None
         }
         MouseEventKind::ScrollDown => {
+            if let Some(picker) = app.hit_zones.picker {
+                if contains(&picker.area, col, row) {
+                    return synth_press(app, KeyCode::Down);
+                }
+            }
             if let Some(list_rect) = app.hit_zones.list {
                 if contains(&list_rect, col, row) {
                     app.next_issue();
@@ -220,4 +241,22 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
         }
         _ => AppAction::None,
     }
+}
+
+fn is_popup_mode(mode: &Mode) -> bool {
+    matches!(
+        mode,
+        Mode::Transition
+            | Mode::Help
+            | Mode::ProjectVersionBrowser
+            | Mode::ColumnPicker
+            | Mode::AssigneePicker
+            | Mode::ComponentPicker
+            | Mode::FixVersionPicker
+            | Mode::SprintPicker
+            | Mode::SavedJqlPicker
+            | Mode::ThemePicker
+            | Mode::ServerInfo
+            | Mode::ConfigView
+    )
 }

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -57,14 +57,37 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 .unwrap_or(false);
             app.last_click = Some((now, col, row));
 
-            // List row click
+            // Detail tab header click → switch tab + warm async.
+            for (tab_rect, tab) in app.hit_zones.detail_tabs.clone() {
+                if contains(&tab_rect, col, row) {
+                    app.focus = Focus::Detail;
+                    app.set_active_tab(tab);
+                    return AppAction::WarmActiveTab;
+                }
+            }
+
+            // List row click → select issue. In list-only view a double-click
+            // promotes focus to Detail (matches Enter key behavior).
             if let Some(list_rect) = app.hit_zones.list {
                 if contains(&list_rect, col, row) {
                     if let Some(idx) = list_row_index(app, &list_rect, row) {
                         app.table_state.select(Some(idx));
-                        if is_double_click {
+                        if is_double_click && app.focus == Focus::List {
                             app.focus = Focus::Detail;
+                            return AppAction::WarmActiveTab;
                         }
+                    }
+                    return AppAction::None;
+                }
+            }
+
+            // Click anywhere inside the detail pane but not on a tab → focus
+            // the detail (no-op if focus is already Detail).
+            if let Some(pane) = app.hit_zones.detail_pane {
+                if contains(&pane, col, row) {
+                    if app.focus != Focus::Detail {
+                        app.focus = Focus::Detail;
+                        return AppAction::WarmActiveTab;
                     }
                     return AppAction::None;
                 }

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -1,0 +1,37 @@
+//! Mouse event → AppAction dispatcher.
+//!
+//! Render code records click targets into `App.hit_zones` each frame.
+//! This module hit-tests pointer coordinates against those zones and
+//! returns the appropriate `AppAction` (or `None` if the click missed
+//! every registered target).
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+
+use super::app::{App, AppAction};
+
+fn contains(rect: &Rect, col: u16, row: u16) -> bool {
+    col >= rect.x
+        && col < rect.x.saturating_add(rect.width)
+        && row >= rect.y
+        && row < rect.y.saturating_add(rect.height)
+}
+
+pub(super) fn handle_mouse(_app: &mut App, event: MouseEvent) -> AppAction {
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            // hit-test wired in follow-up commits
+            AppAction::None
+        }
+        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+            // wheel scroll wired in follow-up commits
+            AppAction::None
+        }
+        _ => AppAction::None,
+    }
+}
+
+#[allow(dead_code)]
+pub(super) fn point_in(rect: Option<&Rect>, col: u16, row: u16) -> bool {
+    rect.is_some_and(|r| contains(r, col, row))
+}

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -83,11 +83,22 @@ pub(super) struct HitZones {
     pub(super) detail_pane: Option<Rect>,
     /// One rect per visible detail tab header (Summary, Comments, ...).
     pub(super) detail_tabs: Vec<(Rect, DetailTab)>,
-    /// Visible picker option rects, indexed by option position.
-    pub(super) picker_rows: Vec<Rect>,
+    /// The currently visible picker list (transition, assignee, etc.).
+    /// `area` is the inner content area (no border) where rows are drawn.
+    pub(super) picker: Option<PickerHit>,
     /// The currently visible popup bounding box. Clicks *outside* this
     /// rect while a popup mode is active should close the popup.
     pub(super) popup: Option<Rect>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PickerHit {
+    /// Inner area (excluding borders) where rows are rendered.
+    pub(super) area: Rect,
+    /// The list state's current scroll offset (0 = first option at top).
+    pub(super) offset: usize,
+    /// Total number of options in the picker (bounds-check upper limit).
+    pub(super) count: usize,
 }
 
 impl HitZones {
@@ -95,7 +106,20 @@ impl HitZones {
         self.list = None;
         self.detail_pane = None;
         self.detail_tabs.clear();
-        self.picker_rows.clear();
+        self.picker = None;
         self.popup = None;
+    }
+}
+
+impl PickerHit {
+    /// Translate a pointer row to an option index, or `None` if the row
+    /// lands on a border / past the last option.
+    pub(super) fn row_to_index(&self, row: u16) -> Option<usize> {
+        if row < self.area.y || row >= self.area.y.saturating_add(self.area.height) {
+            return None;
+        }
+        let visible = (row - self.area.y) as usize;
+        let idx = self.offset.saturating_add(visible);
+        (idx < self.count).then_some(idx)
     }
 }

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -1,5 +1,4 @@
-use jira_core::model::{Comment, Worklog};
-use serde_json::Value;
+use jira_core::model::{Comment, RemoteLink, Worklog};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DetailTab {
@@ -52,7 +51,7 @@ pub(super) struct DetailData {
     pub(super) issue_key: String,
     pub(super) comments: Option<Vec<Comment>>,
     pub(super) worklogs: Option<Vec<Worklog>>,
-    pub(super) remote_links: Option<Vec<Value>>,
+    pub(super) remote_links: Option<Vec<RemoteLink>>,
 }
 
 impl DetailData {

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -1,4 +1,5 @@
 use jira_core::model::{Comment, RemoteLink, Worklog};
+use ratatui::layout::Rect;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DetailTab {
@@ -69,4 +70,32 @@ impl DetailData {
 pub(super) enum Focus {
     List,
     Detail,
+}
+
+/// Click targets captured during the previous frame's render pass.
+/// Mouse events are hit-tested against these zones to translate pointer
+/// coordinates into the same `AppAction` variants the keyboard handler emits.
+#[derive(Debug, Default, Clone)]
+pub(super) struct HitZones {
+    /// Issue list table area (full bounding box including header + border).
+    pub(super) list: Option<Rect>,
+    /// Detail pane area (right side in master-detail layout).
+    pub(super) detail_pane: Option<Rect>,
+    /// One rect per visible detail tab header (Summary, Comments, ...).
+    pub(super) detail_tabs: Vec<(Rect, DetailTab)>,
+    /// Visible picker option rects, indexed by option position.
+    pub(super) picker_rows: Vec<Rect>,
+    /// The currently visible popup bounding box. Clicks *outside* this
+    /// rect while a popup mode is active should close the popup.
+    pub(super) popup: Option<Rect>,
+}
+
+impl HitZones {
+    pub(super) fn clear(&mut self) {
+        self.list = None;
+        self.detail_pane = None;
+        self.detail_tabs.clear();
+        self.picker_rows.clear();
+        self.popup = None;
+    }
 }

--- a/crates/jira/src/tui/picker.rs
+++ b/crates/jira/src/tui/picker.rs
@@ -116,20 +116,12 @@ pub(super) async fn prompt_assignee_selection(
 
     for user in users {
         let display = user
-            .get("displayName")
-            .and_then(|v| v.as_str())
+            .display_name
+            .as_deref()
             .unwrap_or("Unknown user")
             .trim();
-        let email = user
-            .get("emailAddress")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim();
-        let account_id = user
-            .get("accountId")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim();
+        let email = user.email_address.as_deref().unwrap_or("").trim();
+        let account_id = user.account_id.trim();
 
         if account_id.is_empty() {
             continue;

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -1455,6 +1455,18 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
         Line::from("  e,y,M,a,;,w,b,m,v,s,u,t,o also work from detail view"),
         Line::from(""),
         Line::from(Span::styled(
+            "Mouse:",
+            Style::default().fg(palette.tab_active),
+        )),
+        Line::from("  Click row             Select issue"),
+        Line::from("  Double-click row      Open detail view"),
+        Line::from("  Click detail tab      Switch tab"),
+        Line::from("  Click detail pane     Focus detail (from list)"),
+        Line::from("  Click picker option   Apply (single-select) / toggle (multi-select)"),
+        Line::from("  Click outside popup   Close popup (same as Esc)"),
+        Line::from("  Scroll wheel          Move selection in list or picker"),
+        Line::from(""),
+        Line::from(Span::styled(
             "Press any key to close",
             Style::default().fg(palette.muted),
         )),

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -253,6 +253,7 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
         );
 
     f.render_stateful_widget(table, area, &mut app.table_state);
+    app.hit_zones.list = Some(area);
 }
 
 fn render_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -14,10 +14,27 @@ use super::app::App;
 use super::column::format_column_summary;
 use super::modal::render_modal;
 use super::mode::Mode;
-use super::panel::{DetailTab, Focus};
+use super::panel::{DetailTab, Focus, PickerHit};
 use super::picker::PickerOption;
 use super::theme::{Palette, ThemeName};
 use super::version_format::{backlog_preview_lines, version_status_badges};
+
+/// Build a `PickerHit` from a bordered list/table widget area.
+/// `area` is the *outer* rect (including borders); the result's `area`
+/// is shrunk by 1 cell on every side, matching where rows are actually drawn.
+fn picker_hit_for_bordered(area: Rect, offset: usize, count: usize) -> PickerHit {
+    let inner = Rect {
+        x: area.x.saturating_add(1),
+        y: area.y.saturating_add(1),
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
+    PickerHit {
+        area: inner,
+        offset,
+        count,
+    }
+}
 
 pub(super) fn ui(f: &mut Frame, app: &mut App) {
     app.hit_zones.clear();
@@ -613,6 +630,12 @@ fn render_transition_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Pa
 
     f.render_widget(Clear, popup_area);
     f.render_stateful_widget(list, popup_area, &mut app.transition_list_state);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        popup_area,
+        app.transition_list_state.offset(),
+        app.transitions.len(),
+    ));
 }
 
 fn render_column_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -709,8 +732,15 @@ fn render_column_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette:
     f.render_widget(Clear, popup_area);
     f.render_widget(selected_summary, header_area);
     f.render_widget(search_bar, search_area);
+    let visible_count = filtered.len();
     f.render_stateful_widget(list, list_area, &mut app.column_picker_state);
     f.render_widget(hints, hint_area);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.column_picker_state.offset(),
+        visible_count,
+    ));
 }
 
 fn render_assignee_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -769,8 +799,15 @@ fn render_assignee_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palett
 
     f.render_widget(Clear, popup_area);
     f.render_widget(input, input_area);
+    let assignee_count = app.assignee_options.len();
     f.render_stateful_widget(list, list_area, &mut app.assignee_state);
     f.render_widget(hints, hint_area);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.assignee_state.offset(),
+        assignee_count,
+    ));
 
     let before_cursor: String = app
         .assignee_query
@@ -788,7 +825,8 @@ fn render_component_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palet
         " Components: {} ({}) ",
         app.component_issue_key, app.component_project_key
     );
-    render_multi_select_picker_popup(
+    let option_count = app.component_options.len();
+    let (popup_area, list_area) = render_multi_select_picker_popup(
         f,
         area,
         palette,
@@ -804,6 +842,12 @@ fn render_component_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palet
             "Esc cancel",
         ],
     );
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.component_state.offset(),
+        option_count,
+    ));
 }
 
 fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -811,7 +855,8 @@ fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, pal
         " Fix Versions: {} ({}) ",
         app.fix_version_issue_key, app.fix_version_project_key
     );
-    render_multi_select_picker_popup(
+    let option_count = app.fix_version_options.len();
+    let (popup_area, list_area) = render_multi_select_picker_popup(
         f,
         area,
         palette,
@@ -827,6 +872,12 @@ fn render_fix_version_picker_popup(f: &mut Frame, app: &mut App, area: Rect, pal
             "Esc cancel",
         ],
     );
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.fix_version_state.offset(),
+        option_count,
+    ));
 }
 
 fn render_project_version_browser_popup(
@@ -953,8 +1004,15 @@ fn render_project_version_browser_popup(
 
     f.render_widget(Clear, popup_area);
     f.render_widget(query, left_chunks[0]);
+    let version_count = app.project_version_options.len();
     f.render_stateful_widget(versions, left_chunks[1], &mut app.project_version_state);
     f.render_widget(detail, right_area);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        left_chunks[1],
+        app.project_version_state.offset(),
+        version_count,
+    ));
 
     let before_cursor: String = app
         .project_version_query
@@ -968,7 +1026,8 @@ fn render_project_version_browser_popup(
 
 fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
     let title = format!(" Sprint: {} ", app.sprint_issue_key);
-    render_single_select_picker_popup(
+    let option_count = app.sprint_options.len();
+    let (popup_area, list_area) = render_single_select_picker_popup(
         f,
         area,
         palette,
@@ -982,6 +1041,12 @@ fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette:
             "↑/↓ move   Enter assign   Esc cancel",
         ],
     );
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.sprint_state.offset(),
+        option_count,
+    ));
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -996,7 +1061,7 @@ fn render_multi_select_picker_popup(
     state: &mut ListState,
     title: &str,
     hint_lines: &[&str],
-) {
+) -> (Rect, Rect) {
     let popup_area = side_panel_rect(area);
     let [input_area, list_area, hint_area] = Layout::default()
         .direction(Direction::Vertical)
@@ -1064,6 +1129,8 @@ fn render_multi_select_picker_popup(
         input_area.x + 1 + before_cursor.len() as u16,
         input_area.y + 1,
     ));
+
+    (popup_area, list_area)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1077,7 +1144,7 @@ fn render_single_select_picker_popup(
     state: &mut ListState,
     title: &str,
     hint_lines: &[&str],
-) {
+) -> (Rect, Rect) {
     let popup_area = side_panel_rect(area);
     let [input_area, list_area, hint_area] = Layout::default()
         .direction(Direction::Vertical)
@@ -1138,6 +1205,8 @@ fn render_single_select_picker_popup(
         input_area.x + 1 + before_cursor.len() as u16,
         input_area.y + 1,
     ));
+
+    (popup_area, list_area)
 }
 
 fn render_saved_jql_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -1240,8 +1309,15 @@ fn render_saved_jql_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Pal
     f.render_widget(Clear, popup_area);
     f.render_widget(selected_summary, summary_area);
     f.render_widget(search_bar, search_area);
+    let saved_count = filtered.len();
     f.render_stateful_widget(list, list_area, &mut app.saved_jql_state);
     f.render_widget(hints, hint_area);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.saved_jql_state.offset(),
+        saved_count,
+    ));
 }
 
 fn render_theme_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -1275,7 +1351,14 @@ fn render_theme_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: 
         .highlight_symbol("> ");
 
     f.render_widget(Clear, popup_area);
+    let theme_count = ThemeName::ALL.len();
     f.render_stateful_widget(list, popup_area, &mut app.theme_state);
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        popup_area,
+        app.theme_state.offset(),
+        theme_count,
+    ));
 }
 
 fn render_text_popup(f: &mut Frame, title: &str, lines: &[String], area: Rect, palette: Palette) {

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -99,7 +99,8 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         }
         Mode::Help => {
             render_browse(f, app, chunks[1], palette);
-            render_help_popup(f, size, palette);
+            let popup = render_help_popup(f, size, palette);
+            app.hit_zones.popup = Some(popup);
         }
         Mode::ProjectVersionBrowser => {
             render_browse(f, app, chunks[1], palette);
@@ -135,11 +136,14 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         }
         Mode::ServerInfo => {
             render_browse(f, app, chunks[1], palette);
-            render_text_popup(f, " Server Info ", &app.server_info_lines, size, palette);
+            let popup =
+                render_text_popup(f, " Server Info ", &app.server_info_lines, size, palette);
+            app.hit_zones.popup = Some(popup);
         }
         Mode::ConfigView => {
             render_browse(f, app, chunks[1], palette);
-            render_text_popup(f, " Config View ", &app.config_lines, size, palette);
+            let popup = render_text_popup(f, " Config View ", &app.config_lines, size, palette);
+            app.hit_zones.popup = Some(popup);
         }
         Mode::Modal => {
             render_browse(f, app, chunks[1], palette);
@@ -1361,7 +1365,13 @@ fn render_theme_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: 
     ));
 }
 
-fn render_text_popup(f: &mut Frame, title: &str, lines: &[String], area: Rect, palette: Palette) {
+fn render_text_popup(
+    f: &mut Frame,
+    title: &str,
+    lines: &[String],
+    area: Rect,
+    palette: Palette,
+) -> Rect {
     let popup_area = centered_rect(72, 85, area);
     let mut content = if lines.is_empty() {
         vec![Line::from("No data")]
@@ -1386,9 +1396,10 @@ fn render_text_popup(f: &mut Frame, title: &str, lines: &[String], area: Rect, p
 
     f.render_widget(Clear, popup_area);
     f.render_widget(paragraph, popup_area);
+    popup_area
 }
 
-fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) {
+fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
     let popup_area = centered_rect(70, 95, area);
 
     let lines = vec![
@@ -1460,6 +1471,7 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) {
         )
         .wrap(Wrap { trim: false });
     f.render_widget(paragraph, popup_area);
+    popup_area
 }
 
 fn owned_field_line(label: &str, value: String, palette: Palette) -> Line<'static> {

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -20,6 +20,7 @@ use super::theme::{Palette, ThemeName};
 use super::version_format::{backlog_preview_lines, version_status_badges};
 
 pub(super) fn ui(f: &mut Frame, app: &mut App) {
+    app.hit_zones.clear();
     let size = f.area();
     let palette = app.prefs.theme.palette();
     let chunks = Layout::default()

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -257,9 +257,11 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
 }
 
 fn render_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
-    let Some(issue) = app.selected_issue() else {
-        return;
+    let issue_key = match app.selected_issue() {
+        Some(issue) => issue.key.clone(),
+        None => return,
     };
+    app.hit_zones.detail_pane = Some(area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -281,20 +283,56 @@ fn render_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
         })
         .collect::<Vec<_>>();
 
+    // Record one Rect per tab header so mouse::handle_mouse can hit-test clicks.
+    // Tabs are rendered on the single content row of a bordered Paragraph at
+    // chunks[0], so the first tab starts at (x + 1, y + 1) and each tab's
+    // width matches its formatted label (" {label} ") in columns.
+    let tab_origin_x = chunks[0].x.saturating_add(1);
+    let tab_origin_y = chunks[0].y.saturating_add(1);
+    let inner_width = chunks[0].width.saturating_sub(2);
+    let mut cursor_x = tab_origin_x;
+    let tab_rects: Vec<(Rect, DetailTab)> = DetailTab::ALL
+        .iter()
+        .filter_map(|tab| {
+            let label_width = (tab.label().chars().count() + 2) as u16;
+            if cursor_x.saturating_add(label_width) > tab_origin_x.saturating_add(inner_width) {
+                return None;
+            }
+            let rect = Rect {
+                x: cursor_x,
+                y: tab_origin_y,
+                width: label_width,
+                height: 1,
+            };
+            cursor_x = cursor_x.saturating_add(label_width);
+            Some((rect, *tab))
+        })
+        .collect();
+    app.hit_zones.detail_tabs = tab_rects;
+
     let tabs = Paragraph::new(Line::from(tab_titles)).block(
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(palette.focus_border))
-            .title(format!(" {} ", issue.key)),
+            .title(format!(" {issue_key} ")),
     );
     f.render_widget(tabs, chunks[0]);
 
     let body = match app.active_tab {
-        DetailTab::Summary => build_summary_lines(issue, palette),
+        DetailTab::Summary => {
+            let issue = app.selected_issue().expect("issue exists");
+            build_summary_lines(issue, palette)
+        }
         DetailTab::Comments => build_comment_lines(app, palette),
         DetailTab::Worklog => build_worklog_lines(app, palette),
-        DetailTab::Attachments => build_attachment_lines(issue),
-        DetailTab::Subtasks => build_subtask_lines(issue),
+        DetailTab::Attachments => {
+            let issue = app.selected_issue().expect("issue exists");
+            build_attachment_lines(issue)
+        }
+        DetailTab::Subtasks => {
+            let issue = app.selected_issue().expect("issue exists");
+            build_subtask_lines(issue)
+        }
         DetailTab::Links => build_link_lines(app),
     };
 

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -449,20 +449,11 @@ fn build_link_lines(app: &App) -> Vec<Line<'static>> {
                 Line::from(""),
             ];
             for link in links {
-                let object = link.get("object");
-                let title = object
-                    .and_then(|o| o.get("title"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Untitled link");
-                let url = object
-                    .and_then(|o| o.get("url"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-");
                 lines.push(Line::from(Span::styled(
-                    title.to_string(),
+                    link.object.title.clone(),
                     Style::default().add_modifier(Modifier::BOLD),
                 )));
-                lines.push(Line::from(format!("  {url}")));
+                lines.push(Line::from(format!("  {}", link.object.url)));
                 lines.push(Line::from(""));
             }
             lines

--- a/docs/index.html
+++ b/docs/index.html
@@ -430,7 +430,7 @@ $ jirac issue transition CORE-183 --to Done
 
     <section id="tui" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
       <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Interactive TUI</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard-driven issue management, including a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, light and dark themes (including <code>GitHub Light</code>), single worklog entry via <code>w</code>, bulk date-range worklogs via <code>b</code>, and bulk comments via <code>:</code> with confirmation.</p>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard- and mouse-driven issue management, including a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, light and dark themes (including <code>GitHub Light</code>), single worklog entry via <code>w</code>, bulk date-range worklogs via <code>b</code>, and bulk comments via <code>:</code> with confirmation. Click rows, detail tabs, and picker options; double-click to open detail; scroll the wheel to navigate; click outside any popup to dismiss it.</p>
       <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
         <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
           <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
@@ -465,6 +465,27 @@ $ jirac issue transition CORE-183 --to Done
           </tbody>
         </table>
       </div>
+      <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+        <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
+          <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
+            <tr>
+              <th class="px-4 py-3 font-semibold">Mouse</th>
+              <th class="px-4 py-3 font-semibold">Description</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+            <tr><td class="px-4 py-3">Click issue row</td><td class="px-4 py-3">Select that row.</td></tr>
+            <tr><td class="px-4 py-3">Double-click issue row</td><td class="px-4 py-3">Open the split detail view (same as <span class="keycap">Enter</span>).</td></tr>
+            <tr><td class="px-4 py-3">Click detail tab</td><td class="px-4 py-3">Switch to that tab; comments, worklog, and links lazy-load.</td></tr>
+            <tr><td class="px-4 py-3">Click detail pane</td><td class="px-4 py-3">Switch focus to detail when currently on the issue list.</td></tr>
+            <tr><td class="px-4 py-3">Click picker option</td><td class="px-4 py-3">Apply for single-select pickers (transition, assignee, sprint, saved JQL, theme, project versions); toggle for multi-select pickers (components, fix versions, columns).</td></tr>
+            <tr><td class="px-4 py-3">Click outside popup</td><td class="px-4 py-3">Close popup (equivalent to <span class="keycap">Esc</span>). Form modals are exempt to protect in-flight input.</td></tr>
+            <tr><td class="px-4 py-3">Scroll wheel on list</td><td class="px-4 py-3">Previous / next issue.</td></tr>
+            <tr><td class="px-4 py-3">Scroll wheel on picker</td><td class="px-4 py-3">Move picker selection up / down.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-3 text-xs text-slate-500 dark:text-slate-400">To copy terminal text while the TUI is running, hold <span class="keycap">Shift</span> (iTerm2 / most Linux terminals) or <span class="keycap">Option</span> (Terminal.app) while selecting. Under tmux, set <code>set -g mouse on</code> so events reach the TUI.</p>
     </section>
 
     <section id="mcp" class="border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -12,7 +12,7 @@ A fast, polished Jira CLI and TUI built in Rust.
 `jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports custom fields discovered at runtime, native attachment uploads, cursor-based pagination, Jira Cloud, and Jira Data Center.
 
 It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes:
-- an interactive terminal UI with split master-detail, saved JQLs, themes, and native popups
+- an interactive terminal UI with split master-detail, saved JQLs, themes, native popups, and full mouse support (click rows, tabs, picker options; scroll wheel; click outside popup to dismiss)
 - an MCP server for editor and agent integrations
 - a Claude Code plugin
 
@@ -256,6 +256,8 @@ Common shortcuts:
 | `/`         | JQL search |
 | `?`         | Show in-app help |
 | `q` / `Esc` | Quit or go back, depending on context |
+
+The TUI also accepts mouse input: click rows to select, double-click to open detail, click detail tabs to switch, click picker options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only.
 
 ## Configuration
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -15,7 +15,7 @@ This package is a thin installer that downloads the matching prebuilt release fo
 
 `jirac` is a fast Jira terminal client with:
 
-- interactive TUI for browsing and updating issues
+- interactive TUI for browsing and updating issues, with full mouse support (click rows, tabs, picker options; scroll wheel)
 - worklog flows, attachments, and comments
 - bulk actions like bulk-comment, bulk-transition, and bulk-update
 - JQL builder and saved-query workflows


### PR DESCRIPTION
## Summary

Two related work-streams bundled for 1.0.0 stability.

### SDK polish (jira-core)
- Fix silent worklog timestamp corruption (chrono migration)
- Extract execute_with_retry helper; dedupe auth headers
- Move IssueType into model/ for consistency
- Type previously-raw Vec<Value> public returns: RemoteLink, Component, Transition, JiraUser
- Transition uses #[serde(flatten)] extra to preserve full MCP roundtrip shape
- Deprecate JiraClient::create_issue in favor of create_issue_v2
- +5 wiremock tests covering the new typed deserializers

### TUI mouse support
- Click row to select, double-click to open detail
- Click tab to switch detail tab, click pane to switch focus
- Click picker option to apply (single-select) or toggle (multi-select)
- Click outside popup to close (synthesizes Esc)
- Scroll wheel for issue list and pickers
- Form modals intentionally exempt to protect in-flight input

### Docs
- Mouse section added to TUI.md, root README, docs/index.html, chocolatey + npm READMEs, in-app help popup
- jira-core README lists all typed model exports

## Breaking changes

Three `feat!:` commits change public return types in jira-core:
- `get_remote_links`: Vec<Value> -> Vec<RemoteLink>
- `get_project_components`: Vec<Value> -> Vec<Component>
- `get_transitions`: Vec<Value> -> Vec<Transition>
- `search_users`: Vec<Value> -> Vec<JiraUser>

release-please will bump to **1.0.0** on merge.

## Test plan

- [x] cargo fmt --check, clippy -D warnings, test --all (84 passed), build --release
- [x] Manual TUI: mouse interactions across modes (see TUI.md)
- [x] Manual: worklog "started" displays correct date (was silently wrong before chrono fix)
- [x] Manual: MCP transitions response shape preserved (hasScreen, isAvailable still present)
