### PR TITLE
chore(packaging): refresh release docs and manifests for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jira on the command line.
 [![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
 [![npm](https://img.shields.io/npm/v/%40mulham28%2Fjirac)](https://www.npmjs.com/package/@mulham28/jirac)
 
-[![Homebrew](https://img.shields.io/badge/homebrew-v0.38.1-orange)](https://github.com/mulhamna/homebrew-tap)
+[![Homebrew](https://img.shields.io/badge/homebrew-v1.0.0-orange)](https://github.com/mulhamna/homebrew-tap)
 [![Winget](https://img.shields.io/winget/v/mulhamna.jirac)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac)
 [![Chocolatey](https://img.shields.io/chocolatey/v/jirac)](https://community.chocolatey.org/packages/jirac)
 [![Scoop](https://img.shields.io/badge/dynamic/json?label=scoop&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac.json&color=00b4ff)](https://github.com/mulhamna/scoop-bucket)

--- a/packaging/chocolatey/jirac.nuspec
+++ b/packaging/chocolatey/jirac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jirac</id>
-    <version>0.39.0</version>
+    <version>1.0.0</version>
     <packageSourceUrl>https://github.com/mulhamna/jira-commands</packageSourceUrl>
     <owners>mulhamna</owners>
     <title>jirac</title>
@@ -16,7 +16,7 @@
     <tags>jira atlassian cli tui rust mcp</tags>
     <summary>Jira terminal client with TUI, MCP support, and native release archives.</summary>
     <description>jirac is a fast Jira CLI and TUI built in Rust. It supports interactive issue browsing, transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.</description>
-    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v0.39.0</releaseNotes>
+    <releaseNotes>https://github.com/mulhamna/jira-commands/releases/tag/v1.0.0</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'jirac'
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v0.39.0/jirac-windows-x86_64.zip'
-$checksum64 = '73e92a6c485b094979f8530150ce6822ba21f54bc1290ef4641c0a85839cdfec'
+$url64 = 'https://github.com/mulhamna/jira-commands/releases/download/v1.0.0/jirac-windows-x86_64.zip'
+$checksum64 = 'd8daf59dcaa39c11b15e15f1dc1440b9be5561dd4161334e41f296b010bca513'
 
 $packageArgs = @{
   packageName    = $packageName

--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.39.0
+PackageVersion: 1.0.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
-ReleaseDate: 2026-05-16
+ReleaseDate: 2026-05-17
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v0.39.0/jirac-windows-x86_64.zip
-    InstallerSha256: 73e92a6c485b094979f8530150ce6822ba21f54bc1290ef4641c0a85839cdfec
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v1.0.0/jirac-windows-x86_64.zip
+    InstallerSha256: d8daf59dcaa39c11b15e15f1dc1440b9be5561dd4161334e41f296b010bca513
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.39.0
+PackageVersion: 1.0.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 0.39.0
+PackageVersion: 1.0.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh root README.md and INSTALL.md for the released version
- refresh contributor avatars in the README footer
- refresh in-repo Winget source manifests for v1.0.0
- refresh in-repo Chocolatey package source for v1.0.0
- update Windows installer URL and SHA256 from the published release

## Notes

- generated by the release workflow after publishing GitHub release assets
- Winget community submission remains a separate follow-up workflow
- Chocolatey publish uses the refreshed source package metadata