### PR TITLE
feat(mcp): fix client compatibility, interactive install, split npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
               - 'packaging/winget/**'
               - 'packaging/scoop/**'
               - 'packaging/npm/**'
+              - 'packaging/npm-mcp/**'
               - 'install.ps1'
             release:
               - 'release-please-config.json'
@@ -391,34 +392,48 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Verify npm package version matches workspace version
+      - name: Verify npm package versions match workspace version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          NPM_MCP_VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
           HEAD_REF="${GITHUB_HEAD_REF:-}"
 
-          echo "workspace: $VERSION"
-          echo "npm:       $NPM_VERSION"
-          echo "head_ref:  $HEAD_REF"
+          echo "workspace:     $VERSION"
+          echo "npm jirac:     $NPM_VERSION"
+          echo "npm jirac-mcp: $NPM_MCP_VERSION"
+          echo "head_ref:      $HEAD_REF"
 
-          if [ "$VERSION" != "$NPM_VERSION" ]; then
+          mismatch=0
+          [ "$VERSION" = "$NPM_VERSION" ] || mismatch=1
+          [ "$VERSION" = "$NPM_MCP_VERSION" ] || mismatch=1
+
+          if [ "$mismatch" != "0" ]; then
             if [[ "$HEAD_REF" == release-please--branches--* ]]; then
               echo "Release Please branch version mismatch detected."
-              echo "This branch is expected to lag because release-please does not rewrite packaging/npm/package.json in this repo's current setup."
-              echo "The publish workflows still resync packaging/npm/package.json from VERSION before npm publish."
+              echo "This branch is expected to lag because release-please does not rewrite packaging/npm*/package.json in this repo's current setup."
+              echo "The publish workflows still resync packaging/npm*/package.json from VERSION before npm publish."
               exit 0
             fi
 
-            echo "ERROR: packaging/npm/package.json version is out of sync."
+            echo "ERROR: one or more packaging/npm*/package.json versions are out of sync."
             echo "Run: node scripts/sync-npm-version.mjs"
             exit 1
           fi
 
-      - name: npm pack smoke test
+      - name: npm pack smoke test (jirac)
         run: |
-          rm -f jira-commands-*.tgz
+          rm -f mulham28-jirac-*.tgz
           npm pack ./packaging/npm
-          PACKAGE_TGZ=$(ls -1 mulham28-jirac-*.tgz | head -n 1)
+          PACKAGE_TGZ=$(ls -1 mulham28-jirac-*.tgz | grep -v 'jirac-mcp' | head -n 1)
+          test -n "$PACKAGE_TGZ"
+          tar -tzf "$PACKAGE_TGZ" >/dev/null
+
+      - name: npm pack smoke test (jirac-mcp)
+        run: |
+          rm -f mulham28-jirac-mcp-*.tgz
+          npm pack ./packaging/npm-mcp
+          PACKAGE_TGZ=$(ls -1 mulham28-jirac-mcp-*.tgz | head -n 1)
           test -n "$PACKAGE_TGZ"
           tar -tzf "$PACKAGE_TGZ" >/dev/null
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,19 +61,19 @@ jobs:
         id: sync
         run: |
           node scripts/sync-npm-version.mjs
-          if git diff --quiet -- packaging/npm/package.json; then
+          if git diff --quiet -- packaging/npm/package.json packaging/npm-mcp/package.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit synced npm package version
+      - name: Commit synced npm package versions
         if: steps.sync.outputs.changed == 'true'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add packaging/npm/package.json
-          git commit -m "chore(npm): sync package version with VERSION"
+          git add packaging/npm/package.json packaging/npm-mcp/package.json
+          git commit -m "chore(npm): sync package versions with VERSION"
           git push
 
   release-please:
@@ -117,13 +117,13 @@ jobs:
           git checkout -B "$BRANCH" "origin/$BRANCH"
           node scripts/sync-npm-version.mjs
 
-          if git diff --quiet -- packaging/npm/package.json; then
-            echo "packaging/npm/package.json already matches VERSION"
+          if git diff --quiet -- packaging/npm/package.json packaging/npm-mcp/package.json; then
+            echo "packaging npm package.json files already match VERSION"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packaging/npm/package.json
-          git commit -m "chore(npm): sync package version with VERSION"
+          git add packaging/npm/package.json packaging/npm-mcp/package.json
+          git commit -m "chore(npm): sync package versions with VERSION"
           git push origin "HEAD:$BRANCH"

--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -281,33 +281,39 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Sync npm package version from release version
+      - name: Sync npm package versions from release version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           VERSION="$VERSION" node - <<'EOF'
           const fs = require('fs');
-          const path = 'packaging/npm/package.json';
-          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          pkg.version = process.env.VERSION;
-          if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
-          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+          for (const path of ['packaging/npm/package.json', 'packaging/npm-mcp/package.json']) {
+            if (!fs.existsSync(path)) continue;
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.version = process.env.VERSION;
+            if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+            console.log(`synced ${pkg.name} -> ${pkg.version}`);
+          }
           EOF
-          echo "synced npm package.json version to $VERSION"
+          echo "synced npm package.json versions to $VERSION"
 
-      - name: Verify npm package version matches release tag
+      - name: Verify npm package versions match release tag
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          NPM_MCP_VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
           EXPECTED_TAG="v${VERSION}"
 
-          echo "tag:       ${{ inputs.release_tag }}"
-          echo "workspace: $VERSION"
-          echo "npm:       $NPM_VERSION"
+          echo "tag:           ${{ inputs.release_tag }}"
+          echo "workspace:     $VERSION"
+          echo "npm jirac:     $NPM_VERSION"
+          echo "npm jirac-mcp: $NPM_MCP_VERSION"
 
           test "${{ inputs.release_tag }}" = "$EXPECTED_TAG"
           test "$NPM_VERSION" = "$VERSION"
+          test "$NPM_MCP_VERSION" = "$VERSION"
 
-      - name: Publish npm package (skip if already published)
+      - name: Publish @mulham28/jirac (skip if already published)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -316,6 +322,17 @@ jobs:
             echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
             npm publish ./packaging/npm --access public
+          fi
+
+      - name: Publish @mulham28/jirac-mcp (skip if already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
+          if npm view @mulham28/jirac-mcp@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ @mulham28/jirac-mcp npm v$VERSION already published, skipping"
+          else
+            npm publish ./packaging/npm-mcp --access public
           fi
 
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -382,23 +382,27 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Sync npm package version from release version
+      - name: Sync npm package versions from release version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           VERSION="$VERSION" node - <<'EOF'
           const fs = require('fs');
-          const path = 'packaging/npm/package.json';
-          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-          pkg.version = process.env.VERSION;
-          if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
-          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+          for (const path of ['packaging/npm/package.json', 'packaging/npm-mcp/package.json']) {
+            if (!fs.existsSync(path)) continue;
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.version = process.env.VERSION;
+            if (!pkg.version) throw new Error('VERSION env missing for npm package sync');
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+            console.log(`synced ${pkg.name} -> ${pkg.version}`);
+          }
           EOF
-          echo "synced npm package.json version to $VERSION"
+          echo "synced npm package.json versions to $VERSION"
 
-      - name: Verify npm package version matches release tag
+      - name: Verify npm package versions match release tag
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           NPM_VERSION=$(node -p "require('./packaging/npm/package.json').version")
+          NPM_MCP_VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
           EXPECTED_TAG="v${VERSION}"
           TAG="${GITHUB_REF_NAME}"
 
@@ -406,14 +410,16 @@ jobs:
             TAG="${{ inputs.release_tag }}"
           fi
 
-          echo "tag:       $TAG"
-          echo "workspace: $VERSION"
-          echo "npm:       $NPM_VERSION"
+          echo "tag:           $TAG"
+          echo "workspace:     $VERSION"
+          echo "npm jirac:     $NPM_VERSION"
+          echo "npm jirac-mcp: $NPM_MCP_VERSION"
 
           test "$TAG" = "$EXPECTED_TAG"
           test "$NPM_VERSION" = "$VERSION"
+          test "$NPM_MCP_VERSION" = "$VERSION"
 
-      - name: Publish npm package (skip if already published)
+      - name: Publish @mulham28/jirac (skip if already published)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -422,6 +428,17 @@ jobs:
             echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
             npm publish ./packaging/npm --access public
+          fi
+
+      - name: Publish @mulham28/jirac-mcp (skip if already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
+          if npm view @mulham28/jirac-mcp@"$VERSION" version >/dev/null 2>&1; then
+            echo "✓ @mulham28/jirac-mcp npm v$VERSION already published, skipping"
+          else
+            npm publish ./packaging/npm-mcp --access public
           fi
 
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
 
   # ── 1. CVE scan (rustsec advisory database) ───────────────────────────────
   # Uses plain shell commands instead of rustsec/audit-check action to avoid
@@ -74,7 +74,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2
         with:
           command: check all
 
@@ -111,6 +111,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
+      - uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
         with:
           sarif_file: scorecard-results.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,9 +1929,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2592,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2624,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "0.39.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "0.39.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "0.39.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,13 +72,16 @@ cargo install jira-commands
 
 ## npm
 
+Install the CLI, the MCP server, or both:
+
 ```bash
-npm install -g @mulham28/jirac
+npm install -g @mulham28/jirac        # jirac CLI + TUI
+npm install -g @mulham28/jirac-mcp    # jirac-mcp MCP server
 ```
 
-The npm package downloads the matching prebuilt `jirac` release binary during install. Linux support depends on the release binary's glibc compatibility.
+Each package downloads the matching prebuilt release binary during install. Linux support depends on the release binary's glibc compatibility.
 
-Install MCP binary:
+Alternatively, install the MCP server from crates.io:
 
 ```bash
 cargo install jira-mcp
@@ -146,7 +149,15 @@ jirac tui --help
 
 ## MCP client install helper
 
-If you want Jira available inside an MCP-capable client, install `jirac-mcp` first, then use:
+If you want Jira available inside an MCP-capable client, install `jirac-mcp` first, then run the helper.
+
+Interactive mode (recommended) — verifies prereqs and shows a picker:
+
+```bash
+jirac mcp install
+```
+
+Non-interactive mode for scripts — pass `--client` explicitly:
 
 ```bash
 jirac mcp install --client claude-code
@@ -160,8 +171,8 @@ jirac mcp install --client zed
 ```
 
 Supported targets now:
-- `claude-code` (`.mcp.json`, project-style JSON)
-- `claude-desktop` (`~/.claude.json`, user-level JSON)
+- `claude-code` (`~/.claude.json`, user-level JSON with `mcpServers`)
+- `claude-desktop` (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows)
 - `cursor` (`~/.cursor/mcp.json`, provisional path until verified in a real Cursor install)
 - `gemini-cli` (delegates to `gemini mcp add -s user ...`)
 - `codex` (delegates to `codex mcp add ...`)
@@ -185,7 +196,7 @@ jirac mcp doctor
 ```
 
 Local verification notes:
-- Claude Code project scope writes `.mcp.json`
-- Claude Desktop user scope writes `~/.claude.json`
+- Claude Code user scope writes `~/.claude.json` (top-level `mcpServers`); project-scoped MCP servers live in `<repo>/.mcp.json` and are not written by this helper
+- Claude Desktop user scope writes the platform support directory (`claude_desktop_config.json`); override with `CLAUDE_DESKTOP_CONFIG`
 - Gemini CLI currently stores user MCP config in `~/.gemini/settings.json`; this helper delegates to the Gemini CLI directly
 - Codex stores MCP entries under `~/.codex/config.toml`; this helper delegates to the Codex CLI directly

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ export JIRA_TOKEN=your_api_token
 
 ### MCP install helpers
 
-Use `jirac mcp install --client <target>` to register `jirac-mcp` with supported clients, or `jirac mcp doctor` to check prerequisites.
+Run `jirac mcp install` with no arguments for an interactive picker that first verifies the prerequisites (jirac-mcp binary on PATH, Jira auth configured) and then writes the right config file for the client you pick. Pass `--client <target>` to skip the picker for scripts, or `jirac mcp doctor` to check prerequisites without writing anything.
 
 Supported helpers include Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, OpenCode, generic JSON snippets, and Zed. Zed uses the official `Jira` marketplace extension from <https://github.com/mulhamna/jirac-ext>, while `jirac mcp install --client zed` seeds `context_servers.jira.settings` in `settings.json`.
 

--- a/crates/jira-mcp/Cargo.toml
+++ b/crates/jira-mcp/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1"
 axum = "0.8"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
-rmcp = { version = "1.6.0", features = [
+rmcp = { version = "1.7.0", features = [
   "client",
   "macros",
   "reqwest",

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -18,6 +18,9 @@ brew install jira-mcp
 
 # Cargo
 cargo install jira-mcp
+
+# npm (Node 18+)
+npm install -g @mulham28/jirac-mcp
 ```
 
 You can also use the workspace shell installer on macOS/Linux, the PowerShell installer flow on Windows, or download packaged release archives from GitHub Releases.
@@ -69,10 +72,16 @@ The MCP server includes tools for:
 
 ## Client install helper
 
-If you already have both `jirac` and `jirac-mcp` installed, you can register the MCP server into supported clients with:
+If you already have both `jirac` and `jirac-mcp` installed, register the MCP server into a supported client with:
 
 ```bash
-jirac mcp doctor
+jirac mcp doctor          # check prereqs only
+jirac mcp install         # interactive picker (recommended)
+```
+
+The interactive flow verifies that `jirac-mcp` is on PATH and that Jira auth is configured, then lets you pick the client to install into. Pass `--client` explicitly to skip the picker in scripts:
+
+```bash
 jirac mcp install --client claude-code
 jirac mcp install --client claude-desktop
 jirac mcp install --client cursor
@@ -84,6 +93,8 @@ jirac mcp install --client zed
 ```
 
 Notes:
+- `claude-code` writes user-level `~/.claude.json` (`mcpServers`); project-scope `.mcp.json` is not written by this helper
+- `claude-desktop` writes the platform support dir (`claude_desktop_config.json`) — macOS Library, Windows APPDATA, Linux XDG
 - `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows; `opencode` writes `~/.config/opencode/opencode.jsonc` directly
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -1,11 +1,28 @@
 use std::collections::BTreeMap;
 
-use rmcp::schemars::JsonSchema;
+use rmcp::schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
+
+fn any_json_object(_: &mut SchemaGenerator) -> Schema {
+    serde_json::from_value(json!({
+        "type": "object",
+        "additionalProperties": {}
+    }))
+    .expect("static schema literal must deserialize")
+}
+
+fn any_json_object_map(_: &mut SchemaGenerator) -> Schema {
+    serde_json::from_value(json!({
+        "type": "object",
+        "additionalProperties": {}
+    }))
+    .expect("static schema literal must deserialize")
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ToolResponse {
+    #[schemars(schema_with = "any_json_object")]
     pub result: Value,
 }
 
@@ -51,6 +68,8 @@ pub struct IssueCreateArgs {
     pub summary: String,
     pub issue_type: String,
     pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
     pub assignee: Option<String>,
     pub priority: Option<String>,
@@ -58,6 +77,8 @@ pub struct IssueCreateArgs {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
     pub custom_fields: Option<BTreeMap<String, Value>>,
 }
 
@@ -66,6 +87,8 @@ pub struct IssueUpdateArgs {
     pub key: String,
     pub summary: Option<String>,
     pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
     pub assignee: Option<String>,
     pub priority: Option<String>,
@@ -73,6 +96,8 @@ pub struct IssueUpdateArgs {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
     pub custom_fields: Option<BTreeMap<String, Value>>,
 }
 
@@ -152,6 +177,10 @@ pub struct ArchiveArgs {
 pub struct ApiRequestArgs {
     pub method: String,
     pub path: String,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
     pub query: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
     pub body: Option<Value>,
 }

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -45,7 +45,7 @@ jirac issue create -p MYPROJ
 jirac issue render --input desc.md
 jirac tui -p MYPROJ
 jirac mcp doctor
-jirac mcp install --client claude-code
+jirac mcp install
 ```
 
 ## Config and auth
@@ -99,10 +99,18 @@ Useful skills include:
 
 ## MCP helper
 
-If you also installed `jirac-mcp`, `jirac` can register the MCP server into supported clients for you:
+If you also installed `jirac-mcp`, `jirac` can register the MCP server into supported clients for you.
+
+Interactive (recommended):
 
 ```bash
-jirac mcp doctor
+jirac mcp doctor          # check prereqs only
+jirac mcp install         # verifies prereqs, then shows a client picker
+```
+
+Non-interactive (pass `--client` for scripts):
+
+```bash
 jirac mcp install --client claude-code
 jirac mcp install --client claude-desktop
 jirac mcp install --client cursor
@@ -114,6 +122,8 @@ jirac mcp install --client zed
 ```
 
 Notes:
+- `claude-code` writes user-level `~/.claude.json` (`mcpServers`); the project-scoped `<repo>/.mcp.json` is not written by this helper
+- `claude-desktop` writes the platform support directory (`claude_desktop_config.json`) on macOS/Windows/Linux
 - `gemini-cli` and `codex` delegate to their native CLI `mcp add` flows; `opencode` writes `~/.config/opencode/opencode.jsonc` directly
 - `generic-json` prints a portable JSON snippet instead of writing a file
 - `cursor` remains provisional until verified in a real Cursor install

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 #[derive(Debug, Subcommand)]
 pub enum McpCommand {
-    /// Install jirac-mcp into a supported MCP client config
+    /// Install jirac-mcp into a supported MCP client config.
+    ///
+    /// Omit `--client` to run interactively: prereqs are checked and a picker is shown.
     Install {
         #[arg(long, value_enum)]
-        client: McpClient,
+        client: Option<McpClient>,
         #[arg(long, default_value = "jira")]
         name: String,
         #[arg(long, default_value = "jirac-mcp")]
@@ -48,6 +50,24 @@ pub enum McpClient {
     Zed,
 }
 
+impl std::fmt::Display for McpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            McpClient::ClaudeCode => "claude-code        (writes ~/.claude.json mcpServers)",
+            McpClient::ClaudeDesktop => {
+                "claude-desktop     (writes claude_desktop_config.json in Claude support dir)"
+            }
+            McpClient::Cursor => "cursor             (writes ~/.cursor/mcp.json)",
+            McpClient::Codex => "codex              (delegates to `codex mcp add`)",
+            McpClient::GeminiCli => "gemini-cli         (delegates to `gemini mcp add`)",
+            McpClient::OpenCode => "opencode           (writes opencode.jsonc)",
+            McpClient::Zed => "zed                (writes Zed settings.json context_servers)",
+            McpClient::GenericJson => "generic-json       (print snippet only, no file changes)",
+        };
+        f.write_str(label)
+    }
+}
+
 pub fn handle(command: McpCommand) -> Result<()> {
     match command {
         McpCommand::Install {
@@ -58,9 +78,85 @@ pub fn handle(command: McpCommand) -> Result<()> {
             print,
             dry_run,
             force,
-        } => install_client(client, &name, &command, &transport, print, dry_run, force),
+        } => {
+            let resolved_client = match client {
+                Some(c) => c,
+                None => run_interactive_prereqs_and_pick(&command)?,
+            };
+            install_client(
+                resolved_client,
+                &name,
+                &command,
+                &transport,
+                print,
+                dry_run,
+                force,
+            )
+        }
         McpCommand::Doctor { client, command } => doctor(client, &command),
     }
+}
+
+fn run_interactive_prereqs_and_pick(server_command: &str) -> Result<McpClient> {
+    use inquire::Select;
+
+    println!("jirac mcp install — interactive setup");
+    println!("─────────────────────────────────────");
+
+    let mcp_bin = resolve_command_path(server_command);
+    match &mcp_bin {
+        Some(path) => println!("[ok]   MCP server binary: {}", path.display()),
+        None => println!("[warn] MCP server binary not on PATH: {}", server_command),
+    }
+
+    let jirac_bin = resolve_command_path("jirac");
+    match &jirac_bin {
+        Some(path) => println!("[ok]   jirac CLI:         {}", path.display()),
+        None => println!("[info] jirac CLI not on PATH (optional, used for TUI and auth login)"),
+    }
+
+    let jira = JiraConfig::load().unwrap_or_default();
+    let auth_ok = !jira.base_url.trim().is_empty()
+        && jira.token_present()
+        && (!jira.requires_user_identity() || !jira.email.trim().is_empty());
+
+    if auth_ok {
+        println!("[ok]   Jira auth config present");
+    } else {
+        println!("[fail] Jira auth config missing or incomplete");
+    }
+
+    if mcp_bin.is_none() {
+        bail!(
+            "MCP server binary '{}' not found on PATH. Install it first:\n  cargo install jira-mcp\n  # or download from https://github.com/mulhamna/jira-commands/releases",
+            server_command
+        );
+    }
+
+    if !auth_ok {
+        bail!(
+            "Jira credentials not configured. Set them up first:\n\n  Option A (recommended): install the jirac CLI and run auth login\n    cargo install jira-commands\n    jirac auth login\n\n  Option B: edit the config file directly\n    ~/.config/jirac/config.toml (or platform equivalent)\n\nThen re-run `jirac mcp install` to register the MCP entry."
+        );
+    }
+
+    println!();
+    let choice = Select::new(
+        "Pick the MCP client to install into:",
+        vec![
+            McpClient::ClaudeCode,
+            McpClient::ClaudeDesktop,
+            McpClient::Cursor,
+            McpClient::Codex,
+            McpClient::GeminiCli,
+            McpClient::OpenCode,
+            McpClient::Zed,
+            McpClient::GenericJson,
+        ],
+    )
+    .prompt()
+    .context("MCP client selection cancelled")?;
+
+    Ok(choice)
 }
 
 fn install_client(
@@ -305,12 +401,15 @@ fn install_target(client: &McpClient) -> Result<InstallTarget> {
     let (label, path, top_level_key) = match client {
         McpClient::ClaudeCode => (
             "claude-code",
-            config_path_from_env_or_default("CLAUDE_CODE_CONFIG", home.join(".mcp.json")),
+            config_path_from_env_or_default("CLAUDE_CODE_CONFIG", home.join(".claude.json")),
             "mcpServers",
         ),
         McpClient::ClaudeDesktop => (
             "claude-desktop",
-            config_path_from_env_or_default("CLAUDE_DESKTOP_CONFIG", home.join(".claude.json")),
+            config_path_from_env_or_default(
+                "CLAUDE_DESKTOP_CONFIG",
+                claude_desktop_settings_path(&home),
+            ),
             "mcpServers",
         ),
         McpClient::Cursor => (
@@ -336,15 +435,15 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
             label: "claude-code",
             path: install_target(client)
                 .map(|t| t.path)
-                .unwrap_or_else(|_| PathBuf::from(".mcp.json")),
-            note: "Writes project-style JSON at .mcp.json by default.",
+                .unwrap_or_else(|_| PathBuf::from("~/.claude.json")),
+            note: "Writes user-level config at ~/.claude.json (mcpServers).",
         },
         McpClient::ClaudeDesktop => ClientDescriptor::FileTarget {
             label: "claude-desktop",
             path: install_target(client)
                 .map(|t| t.path)
-                .unwrap_or_else(|_| PathBuf::from("~/.claude.json")),
-            note: "Writes user-level JSON at ~/.claude.json by default.",
+                .unwrap_or_else(|_| PathBuf::from("claude_desktop_config.json")),
+            note: "macOS: ~/Library/Application Support/Claude/claude_desktop_config.json; Windows: %APPDATA%\\Claude\\claude_desktop_config.json.",
         },
         McpClient::Cursor => ClientDescriptor::FileTarget {
             label: "cursor",
@@ -589,6 +688,22 @@ fn zed_settings_path(home: &Path) -> PathBuf {
             .map(PathBuf::from)
             .unwrap_or_else(|| home.join(".config"))
             .join("zed/settings.json")
+    }
+}
+
+fn claude_desktop_settings_path(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Claude/claude_desktop_config.json")
+    } else if cfg!(target_os = "windows") {
+        env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("AppData/Roaming"))
+            .join("Claude/claude_desktop_config.json")
+    } else {
+        env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"))
+            .join("Claude/claude_desktop_config.json")
     }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -366,11 +366,12 @@ $ jirac issue transition CORE-183 --to Done
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-brew" class="break-all">brew tap mulhamna/tap && brew install jira-commands jira-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-brew">Copy</button></div>
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-cargo" class="break-all">cargo install jira-commands</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-cargo">Copy</button></div>
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-npm" class="break-all">npm install -g @mulham28/jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-npm">Copy</button></div>
+            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-npm-mcp" class="break-all">npm install -g @mulham28/jirac-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-npm-mcp">Copy</button></div>
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-scoop" class="break-all">scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket && scoop install mulhamna/jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-scoop">Copy</button></div>
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-winget" class="break-all">winget install mulhamna.jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-winget">Copy</button></div>
             <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-choco" class="break-all">choco install jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-choco">Copy</button></div>
           </div>
-          <p class="mt-4 text-xs text-slate-500 dark:text-slate-400">Pick one. Homebrew can install both <code>jirac</code> and <code>jirac-mcp</code>; Cargo, npm, GitHub Releases, PowerShell, Scoop, Winget, and Chocolatey cover the release binaries too. See <a class="text-brand-700 hover:underline" href="https://github.com/mulhamna/jira-commands/blob/main/INSTALL.md">INSTALL.md</a> for full matrix.</p>
+          <p class="mt-4 text-xs text-slate-500 dark:text-slate-400">Pick one. Homebrew, Cargo, and npm all expose <code>jirac</code> and <code>jirac-mcp</code> as independent packages — install whichever you need. GitHub Releases, PowerShell, Scoop, Winget, and Chocolatey cover the release binaries too. See <a class="text-brand-700 hover:underline" href="https://github.com/mulhamna/jira-commands/blob/main/INSTALL.md">INSTALL.md</a> for full matrix.</p>
         </article>
         <article class="doc-card rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
           <h3 class="font-semibold">First login</h3>
@@ -508,7 +509,14 @@ jirac-mcp serve --transport stdio</code></pre>
           </article>
           <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
             <h3 class="font-semibold">One-command client install</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400"><code>jirac</code> can register <code>jirac-mcp</code> into supported client configs for you.</p>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400"><code>jirac</code> can register <code>jirac-mcp</code> into supported client configs for you. Run with no arguments for an interactive picker; pass <code>--client</code> for scripts.</p>
+            <div class="mt-3">
+              <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
+                <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-install-interactive">Copy</button>
+              </div>
+              <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="cmd-mcp-install-interactive">jirac mcp install
+# verifies prereqs, then shows a picker</code></pre>
+            </div>
             <div class="mt-3">
               <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
                 <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-install-clients">Copy</button>
@@ -523,6 +531,8 @@ jirac mcp install --client generic-json
 jirac mcp install --client zed</code></pre>
             </div>
             <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-600 dark:text-slate-400">
+              <li><code>claude-code</code> writes user-level <code>~/.claude.json</code> (<code>mcpServers</code>); the project-scoped <code>&lt;repo&gt;/.mcp.json</code> is not written by this helper.</li>
+              <li><code>claude-desktop</code> writes the platform support dir (<code>claude_desktop_config.json</code>) on macOS, Windows, or Linux.</li>
               <li><code>generic-json</code> prints a portable JSON snippet instead of writing a file.</li>
               <li><code>gemini-cli</code> and <code>codex</code> delegate to their native <code>mcp add</code> commands.</li>
               <li><code>opencode</code> writes <code>~/.config/opencode/opencode.jsonc</code> directly because its CLI flow is interactive.</li>

--- a/packaging/npm-mcp/README.md
+++ b/packaging/npm-mcp/README.md
@@ -1,0 +1,61 @@
+# jirac-mcp for npm
+
+[![npm version](https://img.shields.io/npm/v/%40mulham28%2Fjirac-mcp)](https://www.npmjs.com/package/@mulham28/jirac-mcp)
+[![Docs](https://img.shields.io/badge/docs-jirac.keton.id-0ea5e9)](https://jirac.keton.id)
+[![Crates.io](https://img.shields.io/crates/v/jira-mcp.svg)](https://crates.io/crates/jira-mcp)
+
+Install the **MCP server for Jira** (`jirac-mcp`) with npm.
+
+This package is a thin installer that downloads the matching prebuilt release for your platform during `postinstall`, so you get the same Rust binary shipped on GitHub Releases — not a separate JavaScript reimplementation.
+
+**Docs:** <https://jirac.keton.id>
+
+## Install
+
+```bash
+npm install -g @mulham28/jirac-mcp
+```
+
+## Register the MCP server with your CLI
+
+If the [jirac CLI](https://www.npmjs.com/package/@mulham28/jirac) is also installed, you can register the server interactively:
+
+```bash
+jirac mcp install
+```
+
+The interactive picker checks prerequisites (binary on PATH, Jira auth configured) and writes the right config file for your client (Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI, OpenCode, Zed, or a generic JSON snippet).
+
+Without the jirac CLI, register manually — for example, OpenCode:
+
+```jsonc
+// ~/.config/opencode/opencode.jsonc
+{
+  "mcp": {
+    "jira": {
+      "type": "local",
+      "command": ["jirac-mcp", "serve", "--transport", "stdio"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Or Codex CLI:
+
+```bash
+codex mcp add jira -- jirac-mcp serve --transport stdio
+```
+
+## Companion packages
+
+| Package | Crate | What it ships |
+|---|---|---|
+| [`@mulham28/jirac`](https://www.npmjs.com/package/@mulham28/jirac) | `jira-commands` | The Jira CLI + TUI (`jirac` binary) |
+| [`@mulham28/jirac-mcp`](https://www.npmjs.com/package/@mulham28/jirac-mcp) | `jira-mcp` | The MCP server (`jirac-mcp` binary) — **this package** |
+
+The CLI and the MCP server are independent — install whichever you need.
+
+## License
+
+MIT OR Apache-2.0

--- a/packaging/npm-mcp/bin/jirac-mcp.js
+++ b/packaging/npm-mcp/bin/jirac-mcp.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const binName = process.platform === 'win32' ? 'jirac-mcp.exe' : 'jirac-mcp';
+const installedBin = path.join(__dirname, '..', 'lib', 'bin', binName);
+
+if (!fs.existsSync(installedBin)) {
+  console.error('jirac-mcp binary not installed yet. Re-run: npm rebuild -g @mulham28/jirac-mcp');
+  process.exit(1);
+}
+
+const result = spawnSync(installedBin, process.argv.slice(2), { stdio: 'inherit' });
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 0);

--- a/packaging/npm-mcp/lib/install.js
+++ b/packaging/npm-mcp/lib/install.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { pipeline } = require('node:stream/promises');
+const { Readable } = require('node:stream');
+const { spawnSync } = require('node:child_process');
+
+const REPO = 'mulhamna/jira-commands';
+const VERSION = require('../package.json').version;
+const TAG = `v${VERSION}`;
+const BASE_URL = `https://github.com/${REPO}/releases/download/${TAG}`;
+const BIN_DIR = path.join(__dirname, 'bin');
+const TMP_DIR = path.join(os.tmpdir(), `jirac-mcp-npm-${process.pid}-${Date.now()}`);
+
+function getPlatformAsset() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'darwin' && arch === 'arm64') return { archive: 'jirac-mcp-macos-aarch64.tar.gz', binary: 'jirac-mcp' };
+  if (platform === 'darwin' && arch === 'x64') return { archive: 'jirac-mcp-macos-x86_64.tar.gz', binary: 'jirac-mcp' };
+  if (platform === 'linux' && arch === 'x64') return { archive: 'jirac-mcp-linux-x86_64.tar.gz', binary: 'jirac-mcp' };
+  if (platform === 'linux' && arch === 'arm64') return { archive: 'jirac-mcp-linux-aarch64.tar.gz', binary: 'jirac-mcp' };
+  if (platform === 'win32' && arch === 'x64') return { archive: 'jirac-mcp-windows-x86_64.zip', binary: 'jirac-mcp.exe' };
+
+  throw new Error(`Unsupported platform for jirac-mcp npm install: ${platform}/${arch}`);
+}
+
+async function fetchToFile(url, outPath) {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': 'jirac-mcp-npm-installer'
+    }
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed: ${url} (${response.status})`);
+  }
+
+  await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+  await pipeline(Readable.fromWeb(response.body), fs.createWriteStream(outPath));
+}
+
+async function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  const stream = fs.createReadStream(filePath);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function extractArchive(archivePath, destDir) {
+  await fs.promises.mkdir(destDir, { recursive: true });
+
+  if (archivePath.endsWith('.tar.gz')) {
+    const result = spawnSync('tar', ['-xzf', archivePath, '-C', destDir], { stdio: 'inherit' });
+    if (result.status !== 0) throw new Error('Failed to extract tar.gz archive with tar');
+    return;
+  }
+
+  if (archivePath.endsWith('.zip')) {
+    if (process.platform === 'win32') {
+      const command = `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${destDir.replace(/'/g, "''")}' -Force`;
+      const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], { stdio: 'inherit' });
+      if (result.status !== 0) throw new Error('Failed to extract zip archive with PowerShell');
+      return;
+    }
+
+    const result = spawnSync('unzip', ['-o', archivePath, '-d', destDir], { stdio: 'inherit' });
+    if (result.status !== 0) throw new Error('Failed to extract zip archive with unzip');
+    return;
+  }
+
+  throw new Error(`Unsupported archive format: ${archivePath}`);
+}
+
+async function main() {
+  const { archive, binary } = getPlatformAsset();
+  const archiveUrl = `${BASE_URL}/${archive}`;
+  const checksumsUrl = `${BASE_URL}/checksums.txt`;
+  const archivePath = path.join(TMP_DIR, archive);
+  const checksumsPath = path.join(TMP_DIR, 'checksums.txt');
+  const extractDir = path.join(TMP_DIR, 'extract');
+  const finalBinPath = path.join(BIN_DIR, binary);
+
+  console.log(`jirac-mcp npm installer: ${TAG} -> ${archive}`);
+
+  await fetchToFile(checksumsUrl, checksumsPath);
+  await fetchToFile(archiveUrl, archivePath);
+
+  const checksums = await fs.promises.readFile(checksumsPath, 'utf8');
+  const expectedLine = checksums.split(/\r?\n/).find((line) => line.includes(archive));
+  if (!expectedLine) throw new Error(`Missing checksum entry for ${archive}`);
+  const expectedSha = expectedLine.trim().split(/\s+/)[0];
+  const actualSha = await sha256File(archivePath);
+  if (expectedSha !== actualSha) {
+    throw new Error(`Checksum mismatch for ${archive}. Expected ${expectedSha}, got ${actualSha}`);
+  }
+
+  await extractArchive(archivePath, extractDir);
+
+  const candidates = [
+    path.join(extractDir, binary),
+    path.join(extractDir, archive.replace(/\.tar\.gz$/, '').replace(/\.zip$/, ''))
+  ];
+  const extractedBinary = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!extractedBinary) {
+    throw new Error(`Extracted binary not found in archive: ${binary}`);
+  }
+
+  await fs.promises.mkdir(BIN_DIR, { recursive: true });
+  await fs.promises.copyFile(extractedBinary, finalBinPath);
+
+  if (process.platform !== 'win32') {
+    await fs.promises.chmod(finalBinPath, 0o755);
+  }
+
+  await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  console.log(`Installed ${finalBinPath}`);
+}
+
+main().catch(async (error) => {
+  console.error(error.message || error);
+  try {
+    await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  } catch {}
+  process.exit(1);
+});

--- a/packaging/npm-mcp/package.json
+++ b/packaging/npm-mcp/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@mulham28/jirac-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for Jira powered by jira-core — installed from npm via GitHub Releases",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mulhamna/jira-commands.git"
+  },
+  "homepage": "https://jirac.keton.id",
+  "bugs": {
+    "url": "https://github.com/mulhamna/jira-commands/issues"
+  },
+  "keywords": [
+    "jira",
+    "atlassian",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "llm",
+    "claude",
+    "codex",
+    "opencode"
+  ],
+  "bin": {
+    "jirac-mcp": "bin/jirac-mcp.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node ./lib/install.js",
+    "release:check": "node ../../scripts/sync-npm-version.mjs && git diff --exit-code -- packaging/npm-mcp/package.json"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -30,6 +30,13 @@ jirac auth login
 jirac --help
 ```
 
+If you also want the Jira **MCP server** (for Claude Code, Cursor, Codex, OpenCode, etc.), install the companion package:
+
+```bash
+npm install -g @mulham28/jirac-mcp
+jirac mcp install   # interactive picker, registers the server into your MCP client
+```
+
 ## Quick examples
 
 ```bash

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -13,7 +13,7 @@ This plugin is versioned and released independently from the main CLI/MCP worksp
 >
 > **Compatibility note:** the next release requires `jirac`. If you still have old scripts or aliases that call `jira`, update them before upgrading.
 
-> **Also available:** if you prefer MCP clients over Claude Code skills, install `jirac-mcp` with `cargo install jira-mcp`.
+> **Also available:** if you prefer MCP clients over Claude Code skills, install `jirac-mcp` (`cargo install jira-mcp`, `npm install -g @mulham28/jirac-mcp`, or `brew install mulhamna/tap/jira-mcp`) and then run `jirac mcp install` for an interactive picker.
 >
 > **Positioning note:** this directory is the Claude Code surface only. OpenClaw / ClawHub should be modeled as a separate integration surface with its own packaging, docs, and release flow.
 

--- a/scripts/sync-npm-version.mjs
+++ b/scripts/sync-npm-version.mjs
@@ -3,10 +3,17 @@ import path from 'node:path';
 
 const root = process.cwd();
 const versionPath = path.join(root, 'VERSION');
-const pkgPath = path.join(root, 'packaging', 'npm', 'package.json');
-
 const version = fs.readFileSync(versionPath, 'utf8').trim();
-const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-pkg.version = version;
-fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-console.log(`synced ${pkg.name} -> ${version}`);
+
+const pkgPaths = [
+  path.join(root, 'packaging', 'npm', 'package.json'),
+  path.join(root, 'packaging', 'npm-mcp', 'package.json'),
+];
+
+for (const pkgPath of pkgPaths) {
+  if (!fs.existsSync(pkgPath)) continue;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  pkg.version = version;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`synced ${pkg.name} -> ${version}`);
+}


### PR DESCRIPTION
## Summary

  Three related improvements to the MCP server experience, plus the documentation catch-up.

  ### 1. Fix MCP tool schemas for strict clients (commit 1ce9d0b)

  Strict MCP clients (OpenCode, Codex, Cursor) reject boolean JSON Schema values like `"body": true` at `tools/list` time and mark the server as
  disconnected. `serde_json::Value` and `BTreeMap<String, Value>` fields in `crates/jira-mcp/src/models.rs` were producing exactly those boolean
  schemas.

  Fix: annotate the offending fields with `#[schemars(schema_with = ...)]` so they serialize as `{"type": "object", "additionalProperties": {}}`. Add
   `#[serde(default)]` on the optional ones so schemars does not include them in `required` when `schema_with` masks the `Option<_>` wrapper.

  **Live result:** OpenCode now lists all 22 `jira_*` tools after restart.

---

 ### 2. Interactive `jirac mcp install` + correct claude-code / claude-desktop paths (commit e268f3c)

  #### Interactive install
  `--client` is now optional. With no arguments, `jirac mcp install` runs a prereq check (jirac-mcp on PATH, jirac CLI optional, Jira auth
  configured) and shows an `inquire` picker:

  [ok]   MCP server binary: /Users/you/.cargo/bin/jirac-mcp
  [ok]   jirac CLI:         /Users/you/.cargo/bin/jirac
  [ok]   Jira auth config present

  ? Pick the MCP client to install into:

  ▎ claude-code        (writes ~/.claude.json mcpServers)
  ▎ claude-desktop     (writes claude_desktop_config.json in Claude support dir)
  ▎ ...

  Passing `--client <name>` still works exactly as before. **No breaking change** for current scripts.

  #### Path fix
  Previous defaults pointed at files the actual clients never read:

  | Client | Before | After |
  |---|---|---|
  | claude-code | `~/.mcp.json` (neither user nor project scope) | `~/.claude.json` (user-level `mcpServers`) |
  | claude-desktop macOS | `~/.claude.json` (claude-code's file) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
  | claude-desktop Windows | `~/.claude.json` | `%APPDATA%\Claude\claude_desktop_config.json` |
  | claude-desktop Linux | `~/.claude.json` | `$XDG_CONFIG_HOME/Claude/claude_desktop_config.json` |

  `CLAUDE_CODE_CONFIG` and `CLAUDE_DESKTOP_CONFIG` overrides still apply. Zed path is intentionally untouched.

---

  ### 3. Split npm publish (commit 192eb16)

  `@mulham28/jirac-mcp` is now a separate npm package alongside `@mulham28/jirac`. Users who only want the MCP server can install just it:

  ```bash
  npm install -g @mulham28/jirac-mcp
```

  Both packages mirror the same installer flow: postinstall downloads the matching prebuilt release archive from GitHub Releases, verifies SHA-256
  against checksums.txt, and installs the binary.

  Workflow updates:
  - scripts/sync-npm-version.mjs — syncs both packages from VERSION
  - .github/workflows/release-tag.yml — verifies and publishes both
  - .github/workflows/release-recover.yml — mirrors release-tag changes
  - .github/workflows/release-please.yml — syncs and commits both package.json files on the release PR branch
  - .github/workflows/ci.yml — validates and npm-packs both packages

---

### 4. Documentation alignment (commit 1e69330)

  - README.md, INSTALL.md, crates/jira/README.md, crates/jira-mcp/README.md — interactive flow first, scripted second; corrected claude-code/-desktop
   paths
  - packaging/npm/README.md — companion package callout
  - plugin/README.md — brew/npm/cargo options for jirac-mcp plus the interactive picker
  - docs/index.html — new npm install -g @mulham28/jirac-mcp row, interactive code block, updated client-specific bullets, refreshed install-options
  footer

  User flow (clean machine)

  #### 1. Install binaries (pick one)
```bash
brew install mulhamna/tap/jira-mcp mulhamna/tap/jira-commands
```
or
```bash
cargo install jira-mcp jira-commands
```
or
```bash
npm install -g @mulham28/jirac-mcp @mulham28/jirac
```

  #### 2. Configure Jira auth
```bash  
jirac auth login
```

  #### 3. Register MCP into your client
```bash
jirac mcp install   # interactive picker
```

  #### 4. Restart the client (Claude Code / OpenCode / Codex / etc.)

---

  ### Test plan

  - cargo fmt --all -- --check
  - cargo clippy --all-targets --all-features -- -D warnings
  - cargo test --all (84 passed)
  - cargo build --all
  - Manual stdio handshake: jirac-mcp serve --transport stdio returns valid initialize + tools/list with object schemas (verified)
  - OpenCode lists jira_* tools after restart (verified live)
  - jirac mcp install interactive picker happy path
  - jirac mcp install failure path (missing binary / missing auth) prints friendly setup guide
  - jirac mcp install --client codex still works non-interactively (verified entry in ~/.codex/config.toml)
  - npm pack ./packaging/npm and npm pack ./packaging/npm-mcp succeed; install.js end-to-end pulls v1.0.0 archive and produces a runnable binary
  - Codex: entry registered (codex mcp list shows enabled); tool calls pending fresh Codex restart
  - Verify on a clean machine via the user flow above

---

  ### Breaking changes

  None. All existing jirac mcp install --client X invocations behave the same way. The existing @mulham28/jirac npm package is unchanged.

---

## Supersedes
Closes #256
Closes #257 