### PR TITLE
feat: add sprint lifecycle commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ jirac issue sprint-summary -p PROJ                   # current sprint summary
 jirac issue sprints -p PROJ                          # list project sprints
 jirac issue sprint-create -p PROJ --name "Sprint 24" --board-id 12
 jirac issue sprint-start -p PROJ --sprint "Sprint 24" --end-date 2026-06-03
+jirac issue sprint-update -p PROJ --sprint "Sprint 24" --name "Sprint 24A" --end-date 2026-06-04
 jirac issue sprint-complete -p PROJ --sprint "Sprint 24"
+jirac issue sprint-delete -p PROJ --sprint "Sprint 24A" --force
 
 jirac issue view PROJ-123                           # view detail
 jirac issue view PROJ-123 --versions                # include fix-version backlog preview

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ jirac issue list -p PROJ                            # by project
 jirac issue list --jql "status = 'In Progress'"     # custom JQL
 jirac issue standup                                  # daily standup summary
 jirac issue sprint-summary -p PROJ                   # current sprint summary
+jirac issue sprints -p PROJ                          # list project sprints
+jirac issue sprint-create -p PROJ --name "Sprint 24" --board-id 12
+jirac issue sprint-start -p PROJ --sprint "Sprint 24" --end-date 2026-06-03
+jirac issue sprint-complete -p PROJ --sprint "Sprint 24"
 
 jirac issue view PROJ-123                           # view detail
 jirac issue view PROJ-123 --versions                # include fix-version backlog preview

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -948,6 +948,17 @@ impl JiraClient {
             })
     }
 
+    /// Delete a sprint.
+    pub async fn delete_sprint(&self, sprint_id: u64) -> Result<()> {
+        self.raw_request(
+            "DELETE",
+            &format!("/rest/agile/1.0/sprint/{sprint_id}"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Add an issue to a sprint (Agile API).
     pub async fn add_issue_to_sprint(&self, sprint_id: u64, issue_key: &str) -> Result<()> {
         let path = format!("/rest/agile/1.0/sprint/{sprint_id}/issue");
@@ -2182,6 +2193,25 @@ mod tests {
 
         assert_eq!(sprint.id, 42);
         assert_eq!(sprint.state, "active");
+    }
+
+    #[tokio::test]
+    async fn delete_sprint_uses_delete_endpoint() {
+        let server = MockServer::start().await;
+        let expected_auth = cloud_auth();
+
+        Mock::given(method("DELETE"))
+            .and(path("/rest/agile/1.0/sprint/42"))
+            .and(header("authorization", expected_auth.as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        client
+            .delete_sprint(42)
+            .await
+            .expect("delete sprint should succeed");
     }
 
     #[tokio::test]

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -796,8 +796,46 @@ impl JiraClient {
         Ok(version)
     }
 
-    /// List active and future sprints for a project via the Agile API.
-    pub async fn list_sprints_for_project(&self, project_key: &str) -> Result<Vec<Sprint>> {
+    fn parse_sprint_value(&self, value: &Value, board_id: Option<u64>) -> Option<Sprint> {
+        let id = value.get("id").and_then(|v| v.as_u64())?;
+        Some(Sprint {
+            id,
+            name: value
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            state: value
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            board_id,
+            goal: value
+                .get("goal")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+            start_date: value
+                .get("startDate")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+            end_date: value
+                .get("endDate")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+            complete_date: value
+                .get("completeDate")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+        })
+    }
+
+    /// List project sprints for the given sprint states via the Agile API.
+    pub async fn list_sprints_for_project_with_states(
+        &self,
+        project_key: &str,
+        states: &[&str],
+    ) -> Result<Vec<Sprint>> {
         let boards_path =
             format!("/rest/agile/1.0/board?projectKeyOrId={project_key}&maxResults=100");
         let boards_resp = self
@@ -818,51 +856,96 @@ impl JiraClient {
 
         let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
         let mut sprints: Vec<Sprint> = Vec::new();
+        let state_filter = states.join(",");
 
         for board_id in board_ids {
             let sprint_path = format!(
-                "/rest/agile/1.0/board/{board_id}/sprint?state=active,future&maxResults=200"
+                "/rest/agile/1.0/board/{board_id}/sprint?state={state_filter}&maxResults=200"
             );
             let Ok(Some(resp)) = self.raw_request("GET", &sprint_path, None).await else {
                 continue;
             };
             if let Some(values) = resp.get("values").and_then(|v| v.as_array()) {
-                for s in values {
-                    let id = s.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
-                    if id == 0 || !seen.insert(id) {
+                for value in values {
+                    let Some(sprint) = self.parse_sprint_value(value, Some(board_id)) else {
+                        continue;
+                    };
+                    if !seen.insert(sprint.id) {
                         continue;
                     }
-                    sprints.push(Sprint {
-                        id,
-                        name: s
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string(),
-                        state: s
-                            .get("state")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string(),
-                        board_id: Some(board_id),
-                        start_date: s
-                            .get("startDate")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_owned),
-                        end_date: s.get("endDate").and_then(|v| v.as_str()).map(str::to_owned),
-                    });
+                    sprints.push(sprint);
                 }
             }
         }
 
         sprints.sort_by(|a, b| {
-            let order = |s: &str| if s == "active" { 0u8 } else { 1u8 };
+            let order = |s: &str| match s {
+                "active" => 0u8,
+                "future" => 1u8,
+                _ => 2u8,
+            };
             order(&a.state)
                 .cmp(&order(&b.state))
                 .then(a.name.cmp(&b.name))
         });
 
         Ok(sprints)
+    }
+
+    /// List active and future sprints for a project via the Agile API.
+    pub async fn list_sprints_for_project(&self, project_key: &str) -> Result<Vec<Sprint>> {
+        self.list_sprints_for_project_with_states(project_key, &["active", "future"])
+            .await
+    }
+
+    /// Create a sprint on a Jira board.
+    pub async fn create_sprint(
+        &self,
+        board_id: u64,
+        name: &str,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
+        goal: Option<&str>,
+    ) -> Result<Sprint> {
+        let body = json!({
+            "name": name,
+            "originBoardId": board_id,
+            "startDate": start_date,
+            "endDate": end_date,
+            "goal": goal,
+        });
+        let value = self
+            .raw_request("POST", "/rest/agile/1.0/sprint", Some(body))
+            .await?
+            .ok_or_else(|| JiraError::Api {
+                status: 0,
+                message: "Empty response when creating sprint".into(),
+            })?;
+        self.parse_sprint_value(&value, Some(board_id))
+            .ok_or_else(|| JiraError::Api {
+                status: 0,
+                message: "Failed to parse created sprint".into(),
+            })
+    }
+
+    /// Update sprint metadata or lifecycle state.
+    pub async fn update_sprint(&self, sprint_id: u64, body: Value) -> Result<Sprint> {
+        let value = self
+            .raw_request(
+                "PUT",
+                &format!("/rest/agile/1.0/sprint/{sprint_id}"),
+                Some(body),
+            )
+            .await?
+            .ok_or_else(|| JiraError::Api {
+                status: 0,
+                message: "Empty response when updating sprint".into(),
+            })?;
+        self.parse_sprint_value(&value, None)
+            .ok_or_else(|| JiraError::Api {
+                status: 0,
+                message: "Failed to parse updated sprint".into(),
+            })
     }
 
     /// Add an issue to a sprint (Agile API).
@@ -2012,6 +2095,93 @@ mod tests {
         assert_eq!(sprints[0].id, 1);
         assert_eq!(sprints[0].state, "active");
         assert_eq!(sprints[59].id, 60);
+    }
+
+    #[tokio::test]
+    async fn create_sprint_posts_expected_payload() {
+        let server = MockServer::start().await;
+        let expected_auth = cloud_auth();
+
+        Mock::given(method("POST"))
+            .and(path("/rest/agile/1.0/sprint"))
+            .and(header("authorization", expected_auth.as_str()))
+            .and(body_json(json!({
+                "name": "Sprint 42",
+                "originBoardId": 7,
+                "startDate": "2026-05-20T00:00:00.000Z",
+                "endDate": "2026-05-27T00:00:00.000Z",
+                "goal": "Ship sprint lifecycle support"
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": 42,
+                "name": "Sprint 42",
+                "state": "future",
+                "goal": "Ship sprint lifecycle support",
+                "startDate": "2026-05-20T00:00:00.000Z",
+                "endDate": "2026-05-27T00:00:00.000Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let sprint = client
+            .create_sprint(
+                7,
+                "Sprint 42",
+                Some("2026-05-20T00:00:00.000Z"),
+                Some("2026-05-27T00:00:00.000Z"),
+                Some("Ship sprint lifecycle support"),
+            )
+            .await
+            .expect("create sprint should succeed");
+
+        assert_eq!(sprint.id, 42);
+        assert_eq!(sprint.board_id, Some(7));
+        assert_eq!(sprint.state, "future");
+        assert_eq!(
+            sprint.goal.as_deref(),
+            Some("Ship sprint lifecycle support")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_sprint_puts_expected_payload() {
+        let server = MockServer::start().await;
+        let expected_auth = cloud_auth();
+
+        Mock::given(method("PUT"))
+            .and(path("/rest/agile/1.0/sprint/42"))
+            .and(header("authorization", expected_auth.as_str()))
+            .and(body_json(json!({
+                "state": "active",
+                "startDate": "2026-05-20T00:00:00.000Z",
+                "endDate": "2026-05-27T00:00:00.000Z"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": 42,
+                "name": "Sprint 42",
+                "state": "active",
+                "startDate": "2026-05-20T00:00:00.000Z",
+                "endDate": "2026-05-27T00:00:00.000Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let sprint = client
+            .update_sprint(
+                42,
+                json!({
+                    "state": "active",
+                    "startDate": "2026-05-20T00:00:00.000Z",
+                    "endDate": "2026-05-27T00:00:00.000Z"
+                }),
+            )
+            .await
+            .expect("update sprint should succeed");
+
+        assert_eq!(sprint.id, 42);
+        assert_eq!(sprint.state, "active");
     }
 
     #[tokio::test]

--- a/crates/jira-core/src/model/sprint.rs
+++ b/crates/jira-core/src/model/sprint.rs
@@ -6,6 +6,8 @@ pub struct Sprint {
     pub name: String,
     pub state: String,
     pub board_id: Option<u64>,
+    pub goal: Option<String>,
     pub start_date: Option<String>,
     pub end_date: Option<String>,
+    pub complete_date: Option<String>,
 }

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use clap::Subcommand;
 use indicatif::{ProgressBar, ProgressStyle};
-use inquire::{MultiSelect, Select, Text};
+use inquire::{Confirm, MultiSelect, Select, Text};
 use jira_core::{
     model::{
         field::{FieldKind, FieldValue},
@@ -194,6 +194,62 @@ pub enum IssueCommand {
         /// Output the updated sprint as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Update sprint metadata like name, goal, or planned dates
+    ///
+    /// Examples:
+    ///   jirac issue sprint-update -p PROJ --sprint "Sprint 24" --name "Sprint 24A"
+    ///   jirac issue sprint-update -p PROJ --sprint 42 --goal "Ship polish" --start-date 2026-05-20 --end-date 2026-06-03
+    #[command(name = "sprint-update")]
+    SprintUpdate {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Sprint name or numeric sprint ID
+        #[arg(long, value_name = "SPRINT")]
+        sprint: String,
+        /// Rename the sprint
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
+        /// Set or replace the sprint goal
+        #[arg(long, value_name = "TEXT")]
+        goal: Option<String>,
+        /// Clear the sprint goal
+        #[arg(long, conflicts_with = "goal")]
+        clear_goal: bool,
+        /// Set or replace the sprint start date (YYYY-MM-DD)
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        start_date: Option<String>,
+        /// Clear the sprint start date
+        #[arg(long, conflicts_with = "start_date")]
+        clear_start_date: bool,
+        /// Set or replace the sprint end date (YYYY-MM-DD)
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        end_date: Option<String>,
+        /// Clear the sprint end date
+        #[arg(long, conflicts_with = "end_date")]
+        clear_end_date: bool,
+        /// Output the updated sprint as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Delete a sprint permanently
+    ///
+    /// Examples:
+    ///   jirac issue sprint-delete -p PROJ --sprint "Sprint 24" --force
+    #[command(name = "sprint-delete")]
+    SprintDelete {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Sprint name or numeric sprint ID
+        #[arg(long, value_name = "SPRINT")]
+        sprint: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// Scan recent Jira @mentions from issue descriptions and comments
@@ -1124,6 +1180,34 @@ pub async fn handle(
             )
             .await
         }
+        IssueCommand::SprintUpdate {
+            project,
+            sprint,
+            name,
+            goal,
+            clear_goal,
+            start_date,
+            clear_start_date,
+            end_date,
+            clear_end_date,
+            json,
+        } => {
+            let update = SprintUpdateArgs {
+                name,
+                goal,
+                clear_goal,
+                start_date,
+                clear_start_date,
+                end_date,
+                clear_end_date,
+            };
+            update_sprint_command(client, project.or(default_project), sprint, update, json).await
+        }
+        IssueCommand::SprintDelete {
+            project,
+            sprint,
+            force,
+        } => sprint_delete(client, project.or(default_project), sprint, force).await,
         IssueCommand::Notifications {
             project,
             since,
@@ -1701,6 +1785,73 @@ impl ProjectVersionUpdateArgs {
     }
 }
 
+struct SprintUpdateArgs {
+    name: Option<String>,
+    goal: Option<String>,
+    clear_goal: bool,
+    start_date: Option<String>,
+    clear_start_date: bool,
+    end_date: Option<String>,
+    clear_end_date: bool,
+}
+
+impl SprintUpdateArgs {
+    fn has_changes(&self) -> bool {
+        self.name.is_some()
+            || self.goal.is_some()
+            || self.clear_goal
+            || self.start_date.is_some()
+            || self.clear_start_date
+            || self.end_date.is_some()
+            || self.clear_end_date
+    }
+
+    fn to_request(&self) -> Result<Value> {
+        let mut body = serde_json::Map::new();
+
+        if let Some(name) = self
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            body.insert("name".into(), Value::String(name.to_string()));
+        }
+
+        if self.clear_goal {
+            body.insert("goal".into(), Value::String(String::new()));
+        } else if let Some(goal) = normalize_optional_text(self.goal.as_deref()) {
+            body.insert("goal".into(), Value::String(goal));
+        }
+
+        if self.clear_start_date {
+            body.insert("startDate".into(), Value::String(String::new()));
+        } else if let Some(value) = self.start_date.as_deref() {
+            body.insert(
+                "startDate".into(),
+                Value::String(ymd_to_jira_datetime(&validate_ymd_date(
+                    value,
+                    "sprint start date",
+                )?)?),
+            );
+        }
+
+        if self.clear_end_date {
+            body.insert("endDate".into(), Value::String(String::new()));
+        } else if let Some(value) = self.end_date.as_deref() {
+            body.insert(
+                "endDate".into(),
+                Value::String(ymd_to_jira_datetime(&validate_ymd_date(
+                    value,
+                    "sprint end date",
+                )?)?),
+            );
+        }
+
+        Ok(Value::Object(body))
+    }
+}
+
 async fn view_project_versions(
     client: JiraClient,
     project: Option<String>,
@@ -2010,6 +2161,65 @@ async fn sprint_complete(
 
     println!("✓ Completed sprint — {}", project_key);
     print_sprint_metadata(&updated, false);
+    Ok(())
+}
+
+async fn update_sprint_command(
+    client: JiraClient,
+    project: Option<String>,
+    sprint: String,
+    update: SprintUpdateArgs,
+    json: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    if !update.has_changes() {
+        anyhow::bail!(
+            "Sprint update requires at least one change flag like --name, --goal, --start-date, or --end-date"
+        );
+    }
+    let sprint_meta = resolve_sprint_for_project(&client, &project_key, &sprint).await?;
+    let updated = client
+        .update_sprint(sprint_meta.id, update.to_request()?)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&updated)?);
+        return Ok(());
+    }
+
+    println!("✓ Updated sprint — {}", project_key);
+    print_sprint_metadata(&updated, false);
+    Ok(())
+}
+
+async fn sprint_delete(
+    client: JiraClient,
+    project: Option<String>,
+    sprint: String,
+    force: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    let sprint_meta = resolve_sprint_for_project(&client, &project_key, &sprint).await?;
+    if !force {
+        let confirmed = Confirm::new(&format!(
+            "Delete sprint '{}' (id:{}) in project {}? This cannot be undone.",
+            sprint_meta.name, sprint_meta.id, project_key
+        ))
+        .with_default(false)
+        .prompt()
+        .context("Sprint delete confirmation aborted")?;
+        if !confirmed {
+            println!("Canceled sprint deletion.");
+            return Ok(());
+        }
+    }
+    client.delete_sprint(sprint_meta.id).await?;
+    println!(
+        "✓ Deleted sprint — {} / {} (id:{})",
+        project_key, sprint_meta.name, sprint_meta.id
+    );
     Ok(())
 }
 

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -13,7 +13,7 @@ use inquire::{MultiSelect, Select, Text};
 use jira_core::{
     model::{
         field::{FieldKind, FieldValue},
-        CreateIssueRequest, CreateIssueRequestV2, CreateProjectVersionRequest, Issue,
+        CreateIssueRequest, CreateIssueRequestV2, CreateProjectVersionRequest, Issue, Sprint,
         UpdateIssueRequest, UpdateProjectVersionRequest,
     },
     FieldCache, IssueType, JiraClient,
@@ -96,6 +96,102 @@ pub enum IssueCommand {
         #[arg(short, long, default_value = "100", value_name = "N")]
         limit: u32,
         /// Output the summary as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List project sprints and their lifecycle state
+    ///
+    /// Examples:
+    ///   jirac issue sprints -p PROJ
+    ///   jirac issue sprints -p PROJ --state active,future,closed
+    #[command(name = "sprints")]
+    Sprints {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Comma-separated sprint states: active,future,closed
+        #[arg(long, default_value = "active,future,closed", value_name = "STATES")]
+        state: String,
+        /// Output sprints as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Create a new sprint on a scrum board for the project
+    ///
+    /// Examples:
+    ///   jirac issue sprint-create -p PROJ --name "Sprint 24"
+    ///   jirac issue sprint-create -p PROJ --name "Sprint 24" --board-id 12 --goal "Stabilize release" --start-date 2026-05-20 --end-date 2026-06-03
+    #[command(name = "sprint-create")]
+    SprintCreate {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Sprint name
+        #[arg(long, value_name = "NAME")]
+        name: String,
+        /// Scrum board ID. Required only when the project maps to multiple boards.
+        #[arg(long, value_name = "BOARD_ID")]
+        board_id: Option<u64>,
+        /// Optional sprint goal
+        #[arg(long, value_name = "TEXT")]
+        goal: Option<String>,
+        /// Optional planned sprint start date (YYYY-MM-DD)
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        start_date: Option<String>,
+        /// Optional planned sprint end date (YYYY-MM-DD)
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        end_date: Option<String>,
+        /// Output the created sprint as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Start a future sprint
+    ///
+    /// Examples:
+    ///   jirac issue sprint-start -p PROJ --sprint "Sprint 24" --end-date 2026-06-03
+    ///   jirac issue sprint-start -p PROJ --sprint 42 --start-date 2026-05-20 --end-date 2026-06-03
+    #[command(name = "sprint-start")]
+    SprintStart {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Sprint name or numeric sprint ID
+        #[arg(long, value_name = "SPRINT")]
+        sprint: String,
+        /// Sprint start date (YYYY-MM-DD). Defaults to today (UTC).
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        start_date: Option<String>,
+        /// Sprint end date (YYYY-MM-DD)
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        end_date: String,
+        /// Optional sprint goal override
+        #[arg(long, value_name = "TEXT")]
+        goal: Option<String>,
+        /// Output the updated sprint as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Complete/close an active sprint
+    ///
+    /// Examples:
+    ///   jirac issue sprint-complete -p PROJ --sprint "Sprint 24"
+    ///   jirac issue sprint-complete -p PROJ --sprint 42 --complete-date 2026-06-03
+    #[command(name = "sprint-complete")]
+    SprintComplete {
+        /// Project key (e.g. PROJ). Defaults to configured project when present.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Sprint name or numeric sprint ID
+        #[arg(long, value_name = "SPRINT")]
+        sprint: String,
+        /// Completion date (YYYY-MM-DD). Defaults to today (UTC).
+        #[arg(long, value_name = "YYYY-MM-DD")]
+        complete_date: Option<String>,
+        /// Output the updated sprint as JSON
         #[arg(long)]
         json: bool,
     },
@@ -968,6 +1064,66 @@ pub async fn handle(
             limit,
             json,
         } => sprint_summary(client, project.or(default_project), sprint, limit, json).await,
+        IssueCommand::Sprints {
+            project,
+            state,
+            json,
+        } => list_sprints(client, project.or(default_project), state, json).await,
+        IssueCommand::SprintCreate {
+            project,
+            name,
+            board_id,
+            goal,
+            start_date,
+            end_date,
+            json,
+        } => {
+            create_sprint(
+                client,
+                project.or(default_project),
+                name,
+                board_id,
+                goal,
+                start_date,
+                end_date,
+                json,
+            )
+            .await
+        }
+        IssueCommand::SprintStart {
+            project,
+            sprint,
+            start_date,
+            end_date,
+            goal,
+            json,
+        } => {
+            start_sprint(
+                client,
+                project.or(default_project),
+                sprint,
+                start_date,
+                end_date,
+                goal,
+                json,
+            )
+            .await
+        }
+        IssueCommand::SprintComplete {
+            project,
+            sprint,
+            complete_date,
+            json,
+        } => {
+            sprint_complete(
+                client,
+                project.or(default_project),
+                sprint,
+                complete_date,
+                json,
+            )
+            .await
+        }
         IssueCommand::Notifications {
             project,
             since,
@@ -1699,6 +1855,163 @@ async fn view_project_versions(
     Ok(())
 }
 
+async fn list_sprints(
+    client: JiraClient,
+    project: Option<String>,
+    state: String,
+    json: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    let states = parse_sprint_states(&state)?;
+    let sprints = client
+        .list_sprints_for_project_with_states(&project_key, &states)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&sprints)?);
+        return Ok(());
+    }
+
+    if sprints.is_empty() {
+        println!("No sprints found for {} [{}].", project_key, state);
+        return Ok(());
+    }
+
+    println!("Project sprints — {}", project_key);
+    println!();
+    for sprint in &sprints {
+        print_sprint_metadata(sprint, true);
+    }
+    Ok(())
+}
+
+async fn create_sprint(
+    client: JiraClient,
+    project: Option<String>,
+    name: String,
+    board_id: Option<u64>,
+    goal: Option<String>,
+    start_date: Option<String>,
+    end_date: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    let board_id = resolve_board_id_for_project(&client, &project_key, board_id).await?;
+    let start_date = start_date
+        .as_deref()
+        .map(|value| validate_ymd_date(value, "sprint start date"))
+        .transpose()?;
+    let end_date = end_date
+        .as_deref()
+        .map(|value| validate_ymd_date(value, "sprint end date"))
+        .transpose()?;
+    let start_ts = start_date
+        .as_deref()
+        .map(ymd_to_jira_datetime)
+        .transpose()?;
+    let end_ts = end_date.as_deref().map(ymd_to_jira_datetime).transpose()?;
+    let normalized_goal = normalize_optional_text(goal.as_deref());
+    let created = client
+        .create_sprint(
+            board_id,
+            name.trim(),
+            start_ts.as_deref(),
+            end_ts.as_deref(),
+            normalized_goal.as_deref(),
+        )
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&created)?);
+        return Ok(());
+    }
+
+    println!("✓ Created sprint — {} / board {}", project_key, board_id);
+    print_sprint_metadata(&created, false);
+    Ok(())
+}
+
+async fn start_sprint(
+    client: JiraClient,
+    project: Option<String>,
+    sprint: String,
+    start_date: Option<String>,
+    end_date: String,
+    goal: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    let sprint_meta = resolve_sprint_for_project(&client, &project_key, &sprint).await?;
+    let start_date = match start_date {
+        Some(value) => validate_ymd_date(&value, "sprint start date")?,
+        None => Utc::now().date_naive().format("%Y-%m-%d").to_string(),
+    };
+    let end_date = validate_ymd_date(&end_date, "sprint end date")?;
+    let start_ts = ymd_to_jira_datetime(&start_date)?;
+    let end_ts = ymd_to_jira_datetime(&end_date)?;
+    let mut body = serde_json::json!({
+        "state": "active",
+        "startDate": start_ts,
+        "endDate": end_ts,
+    });
+    if let Some(goal) =
+        normalize_optional_text(goal.as_deref()).or_else(|| sprint_meta.goal.clone())
+    {
+        body["goal"] = Value::String(goal);
+    }
+    let updated = client.update_sprint(sprint_meta.id, body).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&updated)?);
+        return Ok(());
+    }
+
+    println!("✓ Started sprint — {}", project_key);
+    print_sprint_metadata(&updated, false);
+    Ok(())
+}
+
+async fn sprint_complete(
+    client: JiraClient,
+    project: Option<String>,
+    sprint: String,
+    complete_date: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let project_key = project
+        .context("Project key is required. Pass --project or configure a default project.")?;
+    let sprint_meta = resolve_sprint_for_project(&client, &project_key, &sprint).await?;
+    let complete_date = match complete_date {
+        Some(value) => validate_ymd_date(&value, "sprint complete date")?,
+        None => Utc::now().date_naive().format("%Y-%m-%d").to_string(),
+    };
+    let complete_ts = ymd_to_jira_datetime(&complete_date)?;
+    let mut body = serde_json::json!({
+        "state": "closed",
+        "completeDate": complete_ts.clone(),
+    });
+    if let Some(end_date) = sprint_meta
+        .end_date
+        .clone()
+        .or_else(|| Some(complete_ts.clone()))
+    {
+        body["endDate"] = Value::String(end_date);
+    }
+    let updated = client.update_sprint(sprint_meta.id, body).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&updated)?);
+        return Ok(());
+    }
+
+    println!("✓ Completed sprint — {}", project_key);
+    print_sprint_metadata(&updated, false);
+    Ok(())
+}
+
 fn print_project_version_metadata(
     project_key: &str,
     version: &jira_core::model::ProjectVersion,
@@ -1736,6 +2049,192 @@ fn validate_ymd_date(value: &str, label: &str) -> Result<String> {
         anyhow::anyhow!("Invalid {} '{}'. Expected format: YYYY-MM-DD", label, value)
     })?;
     Ok(value.to_string())
+}
+
+fn ymd_to_jira_datetime(value: &str) -> Result<String> {
+    let date = NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d").map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid sprint date '{}'. Expected format: YYYY-MM-DD",
+            value.trim()
+        )
+    })?;
+    Ok(format!("{}T00:00:00.000Z", date.format("%Y-%m-%d")))
+}
+
+fn parse_sprint_states(value: &str) -> Result<Vec<&str>> {
+    let mut states = Vec::new();
+    for state in value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        match state {
+            "active" | "future" | "closed" => states.push(state),
+            other => anyhow::bail!(
+                "Unsupported sprint state '{}'. Use a comma-separated subset of: active,future,closed",
+                other
+            ),
+        }
+    }
+    if states.is_empty() {
+        anyhow::bail!("At least one sprint state is required")
+    }
+    Ok(states)
+}
+
+fn print_sprint_metadata(sprint: &Sprint, bullet: bool) {
+    let prefix = if bullet { "  •" } else { "  " };
+    let board = sprint
+        .board_id
+        .map(|id| format!(" | board {id}"))
+        .unwrap_or_default();
+    println!(
+        "{prefix} {} [id:{} | {}{}]",
+        sprint.name, sprint.id, sprint.state, board
+    );
+    if let Some(goal) = sprint
+        .goal
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        println!("    goal: {goal}");
+    }
+    if let Some(start) = sprint.start_date.as_deref() {
+        println!("    start: {}", &start[..10.min(start.len())]);
+    }
+    if let Some(end) = sprint.end_date.as_deref() {
+        println!("    end:   {}", &end[..10.min(end.len())]);
+    }
+    if let Some(complete) = sprint.complete_date.as_deref() {
+        println!("    done:  {}", &complete[..10.min(complete.len())]);
+    }
+}
+
+async fn resolve_board_id_for_project(
+    client: &JiraClient,
+    project_key: &str,
+    requested_board_id: Option<u64>,
+) -> Result<u64> {
+    let boards = client
+        .raw_request(
+            "GET",
+            &format!("/rest/agile/1.0/board?projectKeyOrId={project_key}&maxResults=100"),
+            None,
+        )
+        .await
+        .context("Failed to list boards for sprint creation")?
+        .unwrap_or(Value::Null);
+
+    let board_values = boards
+        .get("values")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            anyhow::anyhow!("Unexpected board response while resolving project board")
+        })?;
+
+    let boards = board_values
+        .iter()
+        .filter_map(|board| {
+            Some((
+                board.get("id").and_then(Value::as_u64)?,
+                board
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Unnamed board")
+                    .to_string(),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    if boards.is_empty() {
+        anyhow::bail!("No sprint-enabled boards found for project {}", project_key);
+    }
+
+    if let Some(board_id) = requested_board_id {
+        if boards.iter().any(|(id, _)| *id == board_id) {
+            return Ok(board_id);
+        }
+        let options = boards
+            .iter()
+            .map(|(id, name)| format!("{name} ({id})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "Board {} is not available for project {}. Available boards: {}",
+            board_id,
+            project_key,
+            options
+        )
+    }
+
+    if boards.len() == 1 {
+        return Ok(boards[0].0);
+    }
+
+    let options = boards
+        .iter()
+        .map(|(id, name)| format!("{name} ({id})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "Project {} maps to multiple boards. Re-run with --board-id. Available boards: {}",
+        project_key,
+        options
+    )
+}
+
+async fn resolve_sprint_for_project(
+    client: &JiraClient,
+    project_key: &str,
+    sprint: &str,
+) -> Result<Sprint> {
+    let sprints = client
+        .list_sprints_for_project_with_states(project_key, &["active", "future", "closed"])
+        .await
+        .context("Failed to list project sprints")?;
+
+    if let Ok(id) = sprint.trim().parse::<u64>() {
+        return sprints
+            .into_iter()
+            .find(|item| item.id == id)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Sprint id {} was not found in project {}", id, project_key)
+            });
+    }
+
+    let matches = sprints
+        .into_iter()
+        .filter(|item| item.name.eq_ignore_ascii_case(sprint.trim()))
+        .collect::<Vec<_>>();
+
+    match matches.len() {
+        0 => anyhow::bail!(
+            "Sprint '{}' was not found on any sprint-enabled board for project {}",
+            sprint,
+            project_key
+        ),
+        1 => Ok(matches.into_iter().next().expect("single sprint match")),
+        _ => {
+            let options = matches
+                .iter()
+                .map(|item| {
+                    format!(
+                        "{} (id:{}, board:{})",
+                        item.name,
+                        item.id,
+                        item.board_id.unwrap_or_default()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "Sprint '{}' matched multiple sprints. Use a numeric sprint ID instead: {}",
+                sprint,
+                options
+            )
+        }
+    }
 }
 
 fn normalize_optional_text(value: Option<&str>) -> Option<String> {

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1886,6 +1886,7 @@ async fn list_sprints(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create_sprint(
     client: JiraClient,
     project: Option<String>,

--- a/crates/jira/src/help_text.rs
+++ b/crates/jira/src/help_text.rs
@@ -20,6 +20,7 @@ pub const ROOT_LONG_ABOUT: &str = concat!(
     "  jirac issue list                       List your assigned issues\n",
     "  jirac issue standup                    Generate a daily standup summary\n",
     "  jirac issue sprint-summary -p MYPROJ   Summarize the current sprint\n",
+    "  jirac issue sprints -p MYPROJ          List project sprints and states\n",
     "  jirac tui -p MYPROJ                    Launch the interactive TUI\n",
     "  jirac issue versions -p MYPROJ         Browse project fix versions\n",
     "  jirac mcp doctor                       Check MCP prerequisites and client readiness\n",


### PR DESCRIPTION
## Description

Add full sprint lifecycle management to the CLI so users can manage sprints without dropping to raw Agile API calls.

This PR adds commands to list, create, start, update, complete, and delete Jira sprints. It also extends `jira-core` sprint parsing with goal and completion metadata, plus create/update/delete Agile API helpers.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

High-signal files:
- `crates/jira/src/cli/issue.rs` for the new CLI surface and command handling
- `crates/jira-core/src/client.rs` for Agile sprint create/update/delete helpers
- `crates/jira-core/src/model/sprint.rs` for richer sprint metadata parsing

Behavior notes:
- `sprint-update` covers rename, goal edits, and start/end date edits
- `sprint-delete` requires `--force` for non-interactive use and otherwise prompts for confirmation
- README examples were updated to match the new command set
