### PR TITLE
docs: refresh sprint and TUI docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -144,6 +144,7 @@ Then verify:
 jirac auth status
 jirac auth profiles
 jirac --help
+jirac issue --help
 jirac tui --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Jira on the command line.
 
 ## Highlights
 
-- **Interactive TUI** — browse, search, create, edit, change type, move between projects, transition, assign, comment, bulk-comment, worklog, upload, and inspect issues without leaving the terminal
-- **Mouse-driven TUI** — click rows, tabs, picker options, and outside-popup; scroll wheel navigates lists; double-click opens detail
+- **Sprint lifecycle management** — list, create, start, update, complete, and delete project sprints from the CLI
+- **Interactive TUI** — browse, search, create, edit, change type, move between projects, transition, assign, comment, bulk-comment, worklog, upload, inspect issues, and manage project sprints without leaving the terminal
+- **Mouse-driven TUI** — click rows, tabs, picker/browser options, and outside-popup; scroll wheel navigates lists; double-click opens detail
 - **Split master-detail UI** — keep the issue list visible while opening summary, comments, worklog, attachments, subtasks, and links
 - **Saved query and theme preferences** — reuse saved JQLs, persist visible columns, and switch TUI themes (including GitHub Light)
 - **Multi-profile auth** — store and switch between multiple Jira accounts or deployments
@@ -253,7 +254,7 @@ jirac auth use client-dc
 
 The TUI is a full-screen terminal interface for browsing and managing issues. Recent builds include a split master-detail layout, a project-level sprint browser (`P`) for create/edit/start/complete/delete flows, a project-level fix-version browser (`V`) with backlog preview plus in-place version creation (`n`) and metadata editing (`e`), saved JQL picker, theme picker, server summary, config summary overlays, in-TUI modals for native issue type changes and project moves, and both single (`w`) and bulk (`b`) worklog flows. Press `?` inside the TUI for a complete shortcut reference.
 
-The TUI also accepts full mouse input: click any issue row to select, double-click (or click a tab) to open the detail view, click picker options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only so in-flight input isn't lost.
+The TUI also accepts full mouse input: click any issue row to select, double-click (or click a tab) to open the detail view, click picker and browser options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only so in-flight input isn't lost.
 
 ```bash
 jirac tui -p PROJ

--- a/TUI.md
+++ b/TUI.md
@@ -189,7 +189,7 @@ The TUI is fully keyboard-driven, but every pointer-friendly interaction is also
 | Double-click issue row  | Open split detail view (same as `Enter`)                                |
 | Click detail tab        | Switch to that tab; lazy-fetches comments/worklog/links as needed       |
 | Click detail pane       | Switch focus to detail when currently focused on the list               |
-| Click picker option     | Apply for single-select pickers (transition, assignee, sprint, saved JQL, theme, project versions browser); toggle for multi-select pickers (components, fix versions, columns) |
+| Click picker option     | Apply for single-select pickers and browsers (transition, assignee, sprint, saved JQL, theme, project versions, project sprints); toggle for multi-select pickers (components, fix versions, columns) |
 | Click outside a popup   | Close popup (equivalent to `Esc`)                                       |
 | Scroll wheel on list    | Previous / next issue                                                   |
 | Scroll wheel on picker  | Move picker selection up / down                                         |

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -26,9 +26,9 @@ Or use one of the workspace-level install options from the root README:
 ## What this crate provides
 
 - `jirac` primary CLI binary
-- issue listing, viewing, create, update, transition, delete, clone
+- issue listing, viewing, create, update, transition, delete, clone, and sprint lifecycle flows
 - worklog, attachment, bulk-update, bulk-transition, archive, batch, and bulk-create flows
-- interactive TUI flows, including split master-detail, saved JQL picker, theme picker, searchable assignee picker, project-scoped component picker, server summary, config summary, and saved column settings — fully usable with mouse (click rows, tabs, picker options; scroll wheel; click outside popup to dismiss)
+- interactive TUI flows, including split master-detail, saved JQL picker, project sprint browser, project fix-version browser, theme picker, searchable assignee picker, project-scoped component picker, server summary, config summary, and saved column settings — fully usable with mouse (click rows, tabs, picker/browser options; scroll wheel; click outside popup to dismiss)
 - raw Jira REST API passthrough
 - shared config with multi-profile auth support
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,17 +10,17 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="jirac is a Jira CLI and terminal UI for Jira issue management, JQL search, fix versions, worklogs, MCP integration, and automation-friendly workflows." />
+  <meta name="description" content="jirac is a Jira CLI and terminal UI for Jira issue management, JQL search, sprint lifecycle, fix versions, worklogs, MCP integration, and automation-friendly workflows." />
   <meta name="keywords" content="jira cli,jira command line,jira terminal,jira tui,jql cli,jira mcp,jira automation,jira-commands,jirac" />
   <link rel="canonical" href="https://mulhamna.github.io/jira-commands/" />
   <meta property="og:title" content="jirac — Jira CLI, terminal UI, and MCP tooling" />
-  <meta property="og:description" content="Open-source Jira CLI for terminal-first teams: search Jira, browse issues, manage fix versions, log work, and run Jira through TUI or MCP." />
+  <meta property="og:description" content="Open-source Jira CLI for terminal-first teams: search Jira, manage sprint lifecycle and fix versions, log work, and run Jira through TUI or MCP." />
   <meta property="og:image" content="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" />
   <meta property="og:url" content="https://mulhamna.github.io/jira-commands/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="jirac — Jira CLI, terminal UI, and MCP tooling" />
-  <meta name="twitter:description" content="A modern Jira CLI for issue management, JQL, worklogs, fix versions, and terminal-first workflows." />
+  <meta name="twitter:description" content="A modern Jira CLI for issue management, JQL, sprint lifecycle, fix versions, and terminal-first workflows." />
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23124ee5'/%3E%3Ctext x='32' y='41' font-size='26' font-weight='700' text-anchor='middle' fill='white' font-family='Arial, sans-serif'%3Ejc%3C/text%3E%3C/svg%3E" />
   <title>Jira CLI for Terminal, TUI, and MCP | jirac Docs</title>
   <script type="application/ld+json">
@@ -31,7 +31,7 @@
       "alternateName": ["jira-commands", "Jira CLI"],
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
-      "description": "Open-source Jira CLI with terminal UI, JQL search, fix-version management, worklogs, and MCP integration.",
+      "description": "Open-source Jira CLI with terminal UI, JQL search, sprint lifecycle, fix-version management, worklogs, and MCP integration.",
       "url": "https://mulhamna.github.io/jira-commands/",
       "downloadUrl": "https://github.com/mulhamna/jira-commands",
       "softwareHelp": "https://mulhamna.github.io/jira-commands/",
@@ -251,7 +251,7 @@
         <div class="max-w-2xl">
           <p class="mb-3 inline-flex rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700">Jira CLI + terminal UI + MCP</p>
           <h1 class="text-4xl font-extrabold tracking-tight text-slate-900 dark:text-slate-100 sm:text-5xl">A modern <span class="text-brand-700">Jira CLI</span> for terminal-first teams</h1>
-          <p class="mt-5 text-lg leading-relaxed text-slate-600 dark:text-slate-400">jirac is an open-source Jira command-line tool with a full TUI, JQL search, fix-version management, worklogs, attachments, backlog moves, and MCP integration for AI-assisted workflows.</p>
+          <p class="mt-5 text-lg leading-relaxed text-slate-600 dark:text-slate-400">jirac is an open-source Jira command-line tool with a full TUI, JQL search, sprint lifecycle management, fix-version management, worklogs, attachments, backlog moves, and MCP integration for AI-assisted workflows.</p>
           <div class="mt-8 flex flex-wrap gap-3">
             <a href="#quickstart" class="rounded-md bg-brand-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-700">Get Started</a>
             <a href="#non-tech" class="rounded-md border border-slate-300 bg-white dark:bg-slate-900 px-5 py-2.5 text-sm font-medium text-slate-700 dark:text-slate-300 hover:border-brand-300 hover:text-brand-700">For Non-Tech Users</a>
@@ -301,11 +301,11 @@ $ jirac issue transition CORE-183 --to Done
         <div class="mt-6 grid gap-4 lg:grid-cols-3">
           <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
             <h3 class="font-semibold">More than a thin wrapper</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">jirac is not just a couple of REST helpers. It ships a daily-driver Jira CLI, interactive TUI, MCP server, saved JQL flows, version browsing, and native-style issue move/type actions.</p>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">jirac is not just a couple of REST helpers. It ships a daily-driver Jira CLI, interactive TUI, MCP server, saved JQL flows, sprint and version browsing, and native-style issue move/type actions.</p>
           </article>
           <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
             <h3 class="font-semibold">Built for real Jira workflows</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use it to list assigned issues, generate daily standups and sprint summaries, search with JQL, update assignees, log work, preview fix-version backlog, manage project versions, and handle mention notifications from the terminal.</p>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use it to list assigned issues, generate daily standups and sprint summaries, search with JQL, update assignees, manage sprint lifecycle, log work, preview fix-version backlog, manage project versions, and handle mention notifications from the terminal.</p>
           </article>
           <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
             <h3 class="font-semibold">Good fit for humans and agents</h3>
@@ -399,6 +399,11 @@ $ jirac issue transition CORE-183 --to Done
               <tr><td class="px-4 py-3">List by project</td><td class="px-4 py-3 command-cell"><code>jirac issue list --project MYPROJ</code></td></tr>
               <tr><td class="px-4 py-3">Daily standup summary</td><td class="px-4 py-3 command-cell"><code>jirac issue standup</code></td></tr>
               <tr><td class="px-4 py-3">Current sprint summary</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-summary --project MYPROJ</code></td></tr>
+              <tr><td class="px-4 py-3">List project sprints</td><td class="px-4 py-3 command-cell"><code>jirac issue sprints --project MYPROJ</code></td></tr>
+              <tr><td class="px-4 py-3">Create a sprint</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-create --project MYPROJ --name "Sprint 24" --board-id 12</code></td></tr>
+              <tr><td class="px-4 py-3">Start a future sprint</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-start --project MYPROJ --sprint "Sprint 24" --end-date 2026-06-03</code></td></tr>
+              <tr><td class="px-4 py-3">Update sprint name or dates</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-update --project MYPROJ --sprint "Sprint 24" --name "Sprint 24A" --end-date 2026-06-04</code></td></tr>
+              <tr><td class="px-4 py-3">Complete a sprint</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-complete --project MYPROJ --sprint "Sprint 24"</code></td></tr>
               <tr><td class="px-4 py-3">View issue detail</td><td class="px-4 py-3 command-cell"><code>jirac issue view MYPROJ-123</code></td></tr>
               <tr><td class="px-4 py-3">View issue detail with fix-version backlog preview</td><td class="px-4 py-3 command-cell"><code>jirac issue view MYPROJ-123 --versions</code></td></tr>
               <tr><td class="px-4 py-3">Browse project fix versions</td><td class="px-4 py-3 command-cell"><code>jirac issue versions --project MYPROJ</code></td></tr>
@@ -431,7 +436,7 @@ $ jirac issue transition CORE-183 --to Done
 
     <section id="tui" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
       <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Interactive TUI</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard- and mouse-driven issue management, including a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, light and dark themes (including <code>GitHub Light</code>), single worklog entry via <code>w</code>, bulk date-range worklogs via <code>b</code>, and bulk comments via <code>:</code> with confirmation. Click rows, detail tabs, and picker options; double-click to open detail; scroll the wheel to navigate; click outside any popup to dismiss it.</p>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard- and mouse-driven issue management, including a project-level sprint browser via <code>P</code>, a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, light and dark themes (including <code>GitHub Light</code>), single worklog entry via <code>w</code>, bulk date-range worklogs via <code>b</code>, and bulk comments via <code>:</code> with confirmation. Click rows, detail tabs, and picker/browser options; double-click to open detail; scroll the wheel to navigate; click outside any popup to dismiss it.</p>
       <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
         <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
           <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
@@ -454,6 +459,7 @@ $ jirac issue transition CORE-183 --to Done
             <tr><td class="px-4 py-3"><span class="keycap">C</span></td><td class="px-4 py-3">Choose which table columns stay visible and persist that preference.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">T</span></td><td class="px-4 py-3">Open the theme picker, including Kanagawa Wave.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">p</span></td><td class="px-4 py-3">Open saved JQL queries.</td></tr>
+            <tr><td class="px-4 py-3"><span class="keycap">P</span></td><td class="px-4 py-3">Browse project sprints and manage create/edit/start/complete/delete flows.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">V</span></td><td class="px-4 py-3">Browse project fix versions and preview backlog for the selected version.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">;</span></td><td class="px-4 py-3">Add one comment to the selected issue.</td></tr>
             <tr><td class="px-4 py-3"><span class="keycap">:</span></td><td class="px-4 py-3">Bulk-comment many issues by current/custom JQL or explicit issue keys.</td></tr>
@@ -479,7 +485,7 @@ $ jirac issue transition CORE-183 --to Done
             <tr><td class="px-4 py-3">Double-click issue row</td><td class="px-4 py-3">Open the split detail view (same as <span class="keycap">Enter</span>).</td></tr>
             <tr><td class="px-4 py-3">Click detail tab</td><td class="px-4 py-3">Switch to that tab; comments, worklog, and links lazy-load.</td></tr>
             <tr><td class="px-4 py-3">Click detail pane</td><td class="px-4 py-3">Switch focus to detail when currently on the issue list.</td></tr>
-            <tr><td class="px-4 py-3">Click picker option</td><td class="px-4 py-3">Apply for single-select pickers (transition, assignee, sprint, saved JQL, theme, project versions); toggle for multi-select pickers (components, fix versions, columns).</td></tr>
+            <tr><td class="px-4 py-3">Click picker option</td><td class="px-4 py-3">Apply for single-select pickers and browsers (transition, assignee, sprint, saved JQL, theme, project versions, project sprints); toggle for multi-select pickers (components, fix versions, columns).</td></tr>
             <tr><td class="px-4 py-3">Click outside popup</td><td class="px-4 py-3">Close popup (equivalent to <span class="keycap">Esc</span>). Form modals are exempt to protect in-flight input.</td></tr>
             <tr><td class="px-4 py-3">Scroll wheel on list</td><td class="px-4 py-3">Previous / next issue.</td></tr>
             <tr><td class="px-4 py-3">Scroll wheel on picker</td><td class="px-4 py-3">Move picker selection up / down.</td></tr>

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -12,7 +12,7 @@ A fast, polished Jira CLI and TUI built in Rust.
 `jirac` is an opinionated Jira terminal client for people who want terminal speed without giving up modern Jira workflows. It supports custom fields discovered at runtime, native attachment uploads, cursor-based pagination, Jira Cloud, and Jira Data Center.
 
 It ships as a single binary with no runtime dependencies, runs on macOS, Linux, and Windows, and includes:
-- an interactive terminal UI with split master-detail, saved JQLs, themes, native popups, and full mouse support (click rows, tabs, picker options; scroll wheel; click outside popup to dismiss)
+- sprint lifecycle commands plus an interactive terminal UI with split master-detail, saved JQLs, project sprint/version browsers, themes, native popups, and full mouse support (click rows, tabs, picker/browser options; scroll wheel; click outside popup to dismiss)
 - an MCP server for editor and agent integrations
 - a Claude Code plugin
 
@@ -239,6 +239,8 @@ Common shortcuts:
 | `j` / `k`   | Navigate up / down |
 | `Enter`     | Open split detail view |
 | `p`         | Open saved JQL queries |
+| `P`         | Open project sprint browser |
+| `V`         | Open project fix-version browser |
 | `T`         | Open theme picker |
 | `S`         | Show server summary |
 | `g`         | Show config summary |
@@ -257,7 +259,7 @@ Common shortcuts:
 | `?`         | Show in-app help |
 | `q` / `Esc` | Quit or go back, depending on context |
 
-The TUI also accepts mouse input: click rows to select, double-click to open detail, click detail tabs to switch, click picker options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only.
+The TUI also accepts mouse input: click rows to select, double-click to open detail, click detail tabs to switch, click picker and browser options to apply or toggle, scroll the wheel to navigate, and click outside any popup to dismiss it. Form modals stay keyboard-only.
 
 ## Configuration
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -15,8 +15,8 @@ This package is a thin installer that downloads the matching prebuilt release fo
 
 `jirac` is a fast Jira terminal client with:
 
-- interactive TUI for browsing and updating issues, with full mouse support (click rows, tabs, picker options; scroll wheel)
-- worklog flows, attachments, and comments
+- interactive TUI for browsing and updating issues, including project sprint/version browsers and full mouse support (click rows, tabs, picker/browser options; scroll wheel)
+- sprint lifecycle commands, worklog flows, attachments, and comments
 - bulk actions like bulk-comment, bulk-transition, and bulk-update
 - JQL builder and saved-query workflows
 - MCP-friendly tooling for editor and agent setups
@@ -41,6 +41,7 @@ jirac mcp install   # interactive picker, registers the server into your MCP cli
 
 ```bash
 jirac issue list
+jirac issue sprints -p PROJ
 jirac issue view PROJ-123
 jirac issue transition PROJ-123 --to "In Progress"
 jirac issue bulk-comment --jql 'project = PROJ AND sprint = openSprints()' --body 'Please post your update before standup'


### PR DESCRIPTION
## Description

Refreshes the user-facing docs so they match the sprint lifecycle CLI work from #261 and the TUI sprint browser work from #262.

Updates include:
- README highlights and TUI copy
- TUI mouse-support wording for project sprint/version browsers
- INSTALL verification snippet to include `jirac issue --help`
- `docs/index.html` marketing + command reference updates for sprint lifecycle and TUI sprint management

This PR is intentionally stacked on top of #262 because the docs describe the TUI sprint browser introduced there.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo audit` passes (no new CVEs introduced)
- [ ] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No crate code changed in this PR, so there were no new code-path tests to add. Validation was via full workspace checks plus a simple HTML parse sanity check for `docs/index.html`.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- Base branch for review is `feat/tui-sprint-management` / PR #262.
- Main user-visible changes are in `README.md`, `TUI.md`, `INSTALL.md`, and `docs/index.html`.
- `docs/index.html` now mentions sprint lifecycle in SEO/meta copy, command examples, and the TUI section so the website matches the current feature set.
