### PR TITLE
feat(tui): mouse interactions, splitter drag, readline shortcuts

### DIFF
--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -173,6 +173,8 @@ pub(super) struct App {
     pub(super) split_pct: u16,
     /// True while the user is mid-drag on the vertical splitter.
     pub(super) dragging_splitter: bool,
+    /// Vertical scroll offset (in lines) for the Help popup.
+    pub(super) help_scroll: u16,
 }
 
 pub(super) enum AppAction {
@@ -348,6 +350,7 @@ impl App {
             last_click: None,
             split_pct,
             dragging_splitter: false,
+            help_scroll: 0,
         }
     }
 

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -166,6 +166,10 @@ pub(super) struct App {
     pub(super) hit_zones: HitZones,
     /// (when, column, row) of the last left-click. Used to detect double-click.
     pub(super) last_click: Option<(Instant, u16, u16)>,
+    /// Master-detail split percentage [20, 80]. Width of list pane as % of total.
+    pub(super) split_pct: u16,
+    /// True while the user is mid-drag on the vertical splitter.
+    pub(super) dragging_splitter: bool,
 }
 
 pub(super) enum AppAction {
@@ -259,6 +263,7 @@ impl App {
 
     fn new(jql: String, base_url: String, default_project: Option<String>) -> Self {
         let prefs = TuiPreferences::load();
+        let split_pct = prefs.split_pct;
         let mut column_picker_state = ListState::default();
         column_picker_state.select(Some(0));
         let mut saved_jql_state = ListState::default();
@@ -338,6 +343,8 @@ impl App {
             notification_entries: Vec::new(),
             hit_zones: HitZones::default(),
             last_click: None,
+            split_pct,
+            dragging_splitter: false,
         }
     }
 

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -10,7 +10,10 @@ use crate::notifications::{
 };
 use anyhow::Result;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -809,6 +812,16 @@ pub async fn run_tui(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // Best-effort: ask for Kitty keyboard protocol so SUPER (Cmd) modifier and
+    // distinct shifted keys reach the app. Terminals that don't implement it
+    // ignore the sequence — failure is silent on purpose.
+    let _ = execute!(
+        stdout,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+        )
+    );
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -2771,6 +2784,9 @@ pub async fn run_tui(
     }
 
     disable_raw_mode()?;
+    // Pop only if we successfully pushed (silent failure either way — pairs
+    // with the best-effort push above).
+    let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -39,10 +39,7 @@ pub(super) fn handle_key(app: &mut App, event: KeyEvent) -> AppAction {
         Mode::ComponentPicker => handle_component_picker_key(app, code),
         Mode::FixVersionPicker => handle_fix_version_picker_key(app, code),
         Mode::SprintPicker => handle_sprint_picker_key(app, code),
-        Mode::Help => {
-            app.mode = Mode::Browse;
-            AppAction::None
-        }
+        Mode::Help => handle_help_key(app, code),
         Mode::SavedJqlPicker => handle_saved_jql_key(app, code),
         Mode::ThemePicker => handle_theme_picker_key(app, code),
         Mode::ServerInfo | Mode::ConfigView => {
@@ -294,6 +291,41 @@ fn next_word_boundary(s: &str, cursor: usize) -> usize {
         i += 1;
     }
     i
+}
+
+fn handle_help_key(app: &mut App, code: KeyCode) -> AppAction {
+    match code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.help_scroll = app.help_scroll.saturating_sub(1);
+            AppAction::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.help_scroll = app.help_scroll.saturating_add(1);
+            AppAction::None
+        }
+        KeyCode::PageUp => {
+            app.help_scroll = app.help_scroll.saturating_sub(10);
+            AppAction::None
+        }
+        KeyCode::PageDown => {
+            app.help_scroll = app.help_scroll.saturating_add(10);
+            AppAction::None
+        }
+        KeyCode::Home => {
+            app.help_scroll = 0;
+            AppAction::None
+        }
+        KeyCode::End => {
+            app.help_scroll = u16::MAX; // clamped to max_scroll in render
+            AppAction::None
+        }
+        // Any other key closes Help. Reset scroll so next open starts at top.
+        _ => {
+            app.help_scroll = 0;
+            app.mode = Mode::Browse;
+            AppAction::None
+        }
+    }
 }
 
 fn handle_search_key(app: &mut App, event: KeyEvent) -> AppAction {

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::ListState;
 
 use super::app::{App, AppAction};
@@ -31,7 +31,7 @@ pub(super) fn handle_key(app: &mut App, event: KeyEvent) -> AppAction {
                 handle_browse_key(app, code)
             }
         }
-        Mode::Search => handle_search_key(app, code),
+        Mode::Search => handle_search_key(app, event),
         Mode::Transition => handle_transition_key(app, code),
         Mode::ProjectVersionBrowser => handle_project_version_browser_key(app, code),
         Mode::ColumnPicker => handle_column_picker_key(app, code),
@@ -260,7 +260,137 @@ fn handle_view_key(app: &mut App, code: KeyCode) -> AppAction {
     }
 }
 
-fn handle_search_key(app: &mut App, code: KeyCode) -> AppAction {
+/// Byte offset in `s` for the given char cursor position. Clamps to `s.len()`.
+fn char_to_byte(s: &str, char_pos: usize) -> usize {
+    s.char_indices()
+        .nth(char_pos)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+/// Find the char index of the previous word boundary from `cursor` (going left).
+/// Mirrors readline/bash word-erase: skip trailing whitespace then skip word chars.
+fn prev_word_boundary(s: &str, cursor: usize) -> usize {
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = cursor;
+    while i > 0 && chars[i - 1].is_whitespace() {
+        i -= 1;
+    }
+    while i > 0 && !chars[i - 1].is_whitespace() {
+        i -= 1;
+    }
+    i
+}
+
+/// Find the char index of the next word boundary from `cursor` (going right).
+fn next_word_boundary(s: &str, cursor: usize) -> usize {
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let mut i = cursor;
+    while i < len && chars[i].is_whitespace() {
+        i += 1;
+    }
+    while i < len && !chars[i].is_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+fn handle_search_key(app: &mut App, event: KeyEvent) -> AppAction {
+    let code = event.code;
+    let mods = event.modifiers;
+    let ctrl = mods.contains(KeyModifiers::CONTROL);
+    let alt = mods.contains(KeyModifiers::ALT);
+    // SUPER = Cmd on macOS, Win key on Windows. Only forwarded by terminals
+    // that implement the Kitty keyboard protocol (Kitty, WezTerm with
+    // enable_kitty_keyboard, foot, alacritty 0.13+). macOS Terminal.app and
+    // iTerm2 intercept Cmd at the terminal level — those users should fall
+    // back to Ctrl+U / Ctrl+W which work everywhere.
+    let sup = mods.contains(KeyModifiers::SUPER);
+
+    // Cmd+Backspace → delete to line start (Mac-style).
+    // Cmd+Delete   → delete to line end.
+    if sup {
+        match code {
+            KeyCode::Backspace => {
+                let to_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(0..to_b);
+                app.search_cursor = 0;
+                return AppAction::None;
+            }
+            KeyCode::Delete => {
+                let from_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(from_b..);
+                return AppAction::None;
+            }
+            KeyCode::Left => {
+                app.search_cursor = 0;
+                return AppAction::None;
+            }
+            KeyCode::Right => {
+                app.search_cursor = app.search_input.chars().count();
+                return AppAction::None;
+            }
+            _ => {}
+        }
+    }
+
+    // Ctrl/Alt shortcut handling (readline/bash convention). Cross-platform:
+    // - Ctrl+W / Alt+Backspace: delete word back
+    // - Ctrl+U: delete to line start
+    // - Ctrl+K: delete to line end
+    // - Alt+D: delete word forward
+    // - Ctrl+A / Ctrl+E: cursor to start / end
+    if ctrl || alt {
+        match code {
+            KeyCode::Char('w') if ctrl => {
+                let start = prev_word_boundary(&app.search_input, app.search_cursor);
+                let from_b = char_to_byte(&app.search_input, start);
+                let to_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(from_b..to_b);
+                app.search_cursor = start;
+                return AppAction::None;
+            }
+            KeyCode::Backspace if alt => {
+                let start = prev_word_boundary(&app.search_input, app.search_cursor);
+                let from_b = char_to_byte(&app.search_input, start);
+                let to_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(from_b..to_b);
+                app.search_cursor = start;
+                return AppAction::None;
+            }
+            KeyCode::Char('u') if ctrl => {
+                let to_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(0..to_b);
+                app.search_cursor = 0;
+                return AppAction::None;
+            }
+            KeyCode::Char('k') if ctrl => {
+                let from_b = char_to_byte(&app.search_input, app.search_cursor);
+                app.search_input.drain(from_b..);
+                return AppAction::None;
+            }
+            KeyCode::Char('d') if alt => {
+                let end = next_word_boundary(&app.search_input, app.search_cursor);
+                let from_b = char_to_byte(&app.search_input, app.search_cursor);
+                let to_b = char_to_byte(&app.search_input, end);
+                app.search_input.drain(from_b..to_b);
+                return AppAction::None;
+            }
+            KeyCode::Char('a') if ctrl => {
+                app.search_cursor = 0;
+                return AppAction::None;
+            }
+            KeyCode::Char('e') if ctrl => {
+                app.search_cursor = app.search_input.chars().count();
+                return AppAction::None;
+            }
+            // Fall through for unrelated Ctrl/Alt combos (don't insert as text).
+            KeyCode::Char(_) => return AppAction::None,
+            _ => {}
+        }
+    }
+
     match code {
         KeyCode::Esc => {
             app.mode = Mode::Browse;
@@ -298,12 +428,7 @@ fn handle_search_key(app: &mut App, code: KeyCode) -> AppAction {
         KeyCode::Backspace => {
             if app.search_cursor > 0 {
                 app.search_cursor -= 1;
-                let byte_pos = app
-                    .search_input
-                    .char_indices()
-                    .nth(app.search_cursor)
-                    .map(|(i, _)| i)
-                    .unwrap_or(app.search_input.len());
+                let byte_pos = char_to_byte(&app.search_input, app.search_cursor);
                 let char_len = app.search_input[byte_pos..]
                     .chars()
                     .next()
@@ -316,12 +441,7 @@ fn handle_search_key(app: &mut App, code: KeyCode) -> AppAction {
         KeyCode::Delete => {
             let len = app.search_input.chars().count();
             if app.search_cursor < len {
-                let byte_pos = app
-                    .search_input
-                    .char_indices()
-                    .nth(app.search_cursor)
-                    .map(|(i, _)| i)
-                    .unwrap_or(app.search_input.len());
+                let byte_pos = char_to_byte(&app.search_input, app.search_cursor);
                 let char_len = app.search_input[byte_pos..]
                     .chars()
                     .next()
@@ -332,12 +452,7 @@ fn handle_search_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::None
         }
         KeyCode::Char(c) => {
-            let byte_pos = app
-                .search_input
-                .char_indices()
-                .nth(app.search_cursor)
-                .map(|(i, _)| i)
-                .unwrap_or(app.search_input.len());
+            let byte_pos = char_to_byte(&app.search_input, app.search_cursor);
             app.search_input.insert(byte_pos, c);
             app.search_cursor += 1;
             AppAction::None

--- a/crates/jira/src/tui/modal.rs
+++ b/crates/jira/src/tui/modal.rs
@@ -116,6 +116,10 @@ pub(super) struct Modal {
     pub mention_state: ListState,
     pub mention_map: Vec<(String, String)>,
     pub mention_cache: HashMap<String, Vec<PickerOption>>,
+    /// Per-field hit rects captured by the previous render. Same length as
+    /// `fields` after a render pass; empty before the first render. Mouse
+    /// clicks inside a field rect set `focus` to that field's index.
+    pub field_rects: Vec<Rect>,
 }
 
 impl Modal {
@@ -155,6 +159,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -191,6 +196,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -237,6 +243,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -261,6 +268,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -306,6 +314,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -361,6 +370,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -434,6 +444,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -515,6 +526,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -547,6 +559,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -591,6 +604,7 @@ impl Modal {
             mention_state: ListState::default(),
             mention_map: Vec::new(),
             mention_cache: HashMap::new(),
+            field_rects: Vec::new(),
         }
     }
 
@@ -779,7 +793,9 @@ pub(super) fn render_modal(f: &mut Frame, modal: &mut Modal, palette: Palette, a
         .constraints(constraints)
         .split(inner);
 
+    modal.field_rects.clear();
     for (idx, field) in modal.fields.iter().enumerate() {
+        modal.field_rects.push(chunks[idx]);
         let focused = idx == modal.focus;
         let border_style = if focused {
             Style::default()

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -86,6 +86,22 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 }
             }
 
+            // Footer notifications badge — synth `n` (only present when unread > 0).
+            if let Some(rect) = app.hit_zones.notif_button {
+                if contains(&rect, col, row) {
+                    return synth_press(app, KeyCode::Char('n'));
+                }
+            }
+
+            // Footer help button — synth `?`. Note: in Mode::Browse this opens
+            // the help overlay; in other modes the keypress is mostly ignored,
+            // which matches keyboard behaviour.
+            if let Some(rect) = app.hit_zones.help_button {
+                if contains(&rect, col, row) {
+                    return synth_press(app, KeyCode::Char('?'));
+                }
+            }
+
             // Modal form field click → focus that field.
             if app.mode == Mode::Modal {
                 if let Some(modal) = app.modal.as_mut() {
@@ -256,6 +272,15 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
             AppAction::None
         }
         MouseEventKind::ScrollUp => {
+            // Wheel over the Help popup → scroll up.
+            if app.mode == Mode::Help {
+                if let Some(popup) = app.hit_zones.popup {
+                    if contains(&popup, col, row) {
+                        app.help_scroll = app.help_scroll.saturating_sub(3);
+                        return AppAction::None;
+                    }
+                }
+            }
             // Wheel over a picker → move selection up.
             if let Some(picker) = app.hit_zones.picker {
                 if contains(&picker.area, col, row) {
@@ -272,6 +297,14 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
             AppAction::None
         }
         MouseEventKind::ScrollDown => {
+            if app.mode == Mode::Help {
+                if let Some(popup) = app.hit_zones.popup {
+                    if contains(&popup, col, row) {
+                        app.help_scroll = app.help_scroll.saturating_add(3);
+                        return AppAction::None;
+                    }
+                }
+            }
             if let Some(picker) = app.hit_zones.picker {
                 if contains(&picker.area, col, row) {
                     return synth_press(app, KeyCode::Down);

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -86,6 +86,21 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 }
             }
 
+            // Modal form field click → focus that field.
+            if app.mode == Mode::Modal {
+                if let Some(modal) = app.modal.as_mut() {
+                    for (idx, rect) in modal.field_rects.iter().enumerate() {
+                        if contains(rect, col, row) {
+                            modal.focus = idx;
+                            return AppAction::None;
+                        }
+                    }
+                }
+                // Click anywhere else inside an open modal: swallow so we don't
+                // accidentally trigger list/detail handlers behind the popup.
+                return AppAction::None;
+            }
+
             // Picker option click — dispatch per-mode.
             if let Some(picker) = app.hit_zones.picker {
                 if let Some(idx) = picker.row_to_index(row) {

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -77,6 +77,15 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 .unwrap_or(false);
             app.last_click = Some((now, col, row));
 
+            // Splitter grab — start drag. Checked first so it wins over the
+            // adjacent list/detail panes that share the border column.
+            if let Some(splitter) = app.hit_zones.splitter {
+                if contains(&splitter, col, row) {
+                    app.dragging_splitter = true;
+                    return AppAction::None;
+                }
+            }
+
             // Picker option click — dispatch per-mode.
             if let Some(picker) = app.hit_zones.picker {
                 if let Some(idx) = picker.row_to_index(row) {
@@ -207,6 +216,28 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                 }
             }
 
+            AppAction::None
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if app.dragging_splitter {
+                if let Some(area) = app.hit_zones.master_detail_area {
+                    if area.width > 0 && col >= area.x {
+                        let rel = (col - area.x) as u32;
+                        let pct = (rel * 100 / area.width as u32) as u16;
+                        app.split_pct = pct.clamp(20, 80);
+                    }
+                }
+            }
+            AppAction::None
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            if app.dragging_splitter {
+                app.dragging_splitter = false;
+                if app.prefs.split_pct != app.split_pct {
+                    app.prefs.split_pct = app.split_pct;
+                    let _ = app.prefs.save();
+                }
+            }
             AppAction::None
         }
         MouseEventKind::ScrollUp => {

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -93,6 +93,11 @@ pub(super) struct HitZones {
     pub(super) splitter: Option<Rect>,
     /// Full master-detail area. Needed to recompute split percentage on drag.
     pub(super) master_detail_area: Option<Rect>,
+    /// Footer "[?]" help button. Click synthesizes a `?` keypress.
+    pub(super) help_button: Option<Rect>,
+    /// Footer "[🔔 n]" notifications button — only set when unread > 0.
+    /// Click synthesizes an `n` keypress.
+    pub(super) notif_button: Option<Rect>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -114,6 +119,8 @@ impl HitZones {
         self.popup = None;
         self.splitter = None;
         self.master_detail_area = None;
+        self.help_button = None;
+        self.notif_button = None;
     }
 }
 

--- a/crates/jira/src/tui/panel.rs
+++ b/crates/jira/src/tui/panel.rs
@@ -89,6 +89,10 @@ pub(super) struct HitZones {
     /// The currently visible popup bounding box. Clicks *outside* this
     /// rect while a popup mode is active should close the popup.
     pub(super) popup: Option<Rect>,
+    /// Vertical splitter column between list + detail panes (1-col-wide rect).
+    pub(super) splitter: Option<Rect>,
+    /// Full master-detail area. Needed to recompute split percentage on drag.
+    pub(super) master_detail_area: Option<Rect>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -108,6 +112,8 @@ impl HitZones {
         self.detail_tabs.clear();
         self.picker = None;
         self.popup = None;
+        self.splitter = None;
+        self.master_detail_area = None;
     }
 }
 

--- a/crates/jira/src/tui/prefs.rs
+++ b/crates/jira/src/tui/prefs.rs
@@ -21,6 +21,12 @@ pub(super) struct TuiPreferences {
     pub(super) saved_jqls: Vec<SavedJql>,
     #[serde(default)]
     pub(super) theme: ThemeName,
+    #[serde(default = "default_split_pct")]
+    pub(super) split_pct: u16,
+}
+
+fn default_split_pct() -> u16 {
+    46
 }
 
 impl Default for TuiPreferences {
@@ -44,6 +50,7 @@ impl Default for TuiPreferences {
                 },
             ],
             theme: ThemeName::Default,
+            split_pct: default_split_pct(),
         }
     }
 }
@@ -90,6 +97,8 @@ impl TuiPreferences {
 
         self.saved_jqls
             .retain(|saved| !saved.name.trim().is_empty() && !saved.jql.trim().is_empty());
+
+        self.split_pct = self.split_pct.clamp(20, 80);
     }
 }
 

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -86,6 +86,8 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
     );
     f.render_widget(header, chunks[0]);
     render_footer(f, app, chunks[2], palette);
+    // Footer buttons are recorded into hit_zones after the footer text is laid
+    // out — see the end of render_footer.
 
     match app.mode {
         Mode::Browse => render_browse(f, app, chunks[1], palette),
@@ -99,7 +101,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         }
         Mode::Help => {
             render_browse(f, app, chunks[1], palette);
-            let popup = render_help_popup(f, size, palette);
+            let popup = render_help_popup(f, size, palette, app.help_scroll);
             app.hit_zones.popup = Some(popup);
         }
         Mode::ProjectVersionBrowser => {
@@ -154,7 +156,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
     }
 }
 
-fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
+fn render_footer(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
     let text = match &app.mode {
         Mode::Browse if app.focus == Focus::Detail => {
             " ↑/↓:scroll  PgUp/PgDn:fast scroll  Home:top  ←/→:tab  Esc:back  t:transition  e:edit  y:type  M:move  a:assign  ;:comment  ::bulk-comment  w:worklog  b:bulk-log  m:comps  v:versions  u:upload  o:browser  ?:help  q:quit"
@@ -204,10 +206,67 @@ fn render_footer(f: &mut Frame, app: &App, area: Rect, palette: Palette) {
         return;
     }
 
+    // Split the footer row: hint text fills the left side, two button rects
+    // sit at the right edge so they can be hit-tested by the mouse handler.
+    let unread = app.notification_entries.iter().filter(|e| !e.read).count();
+    let help_label = " [?] ";
+    let notif_label = format!(" [🔔 {unread}] ");
+    let help_w = help_label.chars().count() as u16;
+    // emoji + digits — use string width approximation via char count + 1 for
+    // the 2-cell wide bell glyph. Conservative: pad by 1.
+    let notif_w = (notif_label.chars().count() as u16).saturating_add(1);
+
+    let mut buttons_w = help_w;
+    if unread > 0 {
+        buttons_w = buttons_w.saturating_add(notif_w);
+    }
+
+    // Reserve room for the buttons; everything else is hint text.
+    let text_w = area.width.saturating_sub(buttons_w);
+    let text_rect = Rect {
+        x: area.x,
+        y: area.y,
+        width: text_w,
+        height: area.height,
+    };
+
     let footer = Paragraph::new(text)
         .style(Style::default().fg(palette.muted))
         .wrap(Wrap { trim: false });
-    f.render_widget(footer, area);
+    f.render_widget(footer, text_rect);
+
+    // Right-align: help button is rightmost, notif button (if any) sits just
+    // to its left.
+    let help_rect = Rect {
+        x: area.x.saturating_add(area.width).saturating_sub(help_w),
+        y: area.y,
+        width: help_w,
+        height: 1,
+    };
+    f.render_widget(
+        Paragraph::new(help_label).style(
+            Style::default()
+                .fg(palette.tab_active)
+                .add_modifier(Modifier::BOLD),
+        ),
+        help_rect,
+    );
+    app.hit_zones.help_button = Some(help_rect);
+
+    if unread > 0 {
+        let notif_rect = Rect {
+            x: help_rect.x.saturating_sub(notif_w),
+            y: area.y,
+            width: notif_w,
+            height: 1,
+        };
+        let notif_style = Style::default()
+            .fg(Color::Black)
+            .bg(Color::Yellow)
+            .add_modifier(Modifier::BOLD);
+        f.render_widget(Paragraph::new(notif_label).style(notif_style), notif_rect);
+        app.hit_zones.notif_button = Some(notif_rect);
+    }
 }
 
 fn render_browse(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
@@ -1413,15 +1472,21 @@ fn render_text_popup(
     popup_area
 }
 
-fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
+fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette, scroll_offset: u16) -> Rect {
     let popup_area = centered_rect(70, 95, area);
 
-    let lines = vec![
+    // Header (rendered separately, always at top of popup).
+    let header_lines: Vec<Line<'static>> = vec![
         Line::from(Span::styled(
             "Keyboard Shortcuts",
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
+    ];
+
+    // Sections — each is rendered atomically (never split across columns).
+    // Order matters: first section ends up in first column.
+    let issue_list_section: Vec<Line<'static>> = vec![
         Line::from(Span::styled(
             "Issue List:",
             Style::default().fg(palette.tab_active),
@@ -1429,36 +1494,38 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
         Line::from("  ↑/k       Move up"),
         Line::from("  ↓/j       Move down"),
         Line::from("  Enter     Open split detail view"),
-        Line::from("  p         Open saved queries (run/create/edit/delete)"),
-        Line::from("  V         Browse project fix versions + backlog preview"),
-        Line::from("            Enter refreshes preview, n creates, e edits metadata"),
-        Line::from("  T         Open theme picker"),
-        Line::from("  S         Show server info"),
-        Line::from("  g         Show config file"),
-        Line::from("  t         Transition issue"),
-        Line::from("  C         Column settings"),
-        Line::from("  c         Create new issue"),
-        Line::from("  e         Edit selected issue"),
-        Line::from("  y         Change issue type (native Jira move semantics)"),
-        Line::from("  M         Move issue to another project (native, not clone+delete)"),
         Line::from("  a         Assign selected issue"),
-        Line::from("  ;         Add comment"),
-        Line::from("  :         Add the same comment to many issues (JQL or explicit keys)"),
-        Line::from("  w         Add single worklog"),
         Line::from("  b         Add bulk worklog (confirm before submit)"),
+        Line::from("  c         Create new issue"),
+        Line::from("  C         Column settings"),
+        Line::from("  e         Edit selected issue"),
+        Line::from("  g         Show config file"),
         Line::from("  l         Set labels"),
         Line::from("  m         Edit components"),
-        Line::from("  v         Edit fix versions"),
-        Line::from("  s         Add to sprint"),
-        Line::from("  u         Upload attachment"),
-        Line::from("  o         Open issue in browser"),
-        Line::from("  r         Refresh list"),
+        Line::from("  M         Move issue to another project (native, not clone+delete)"),
         Line::from("  n         Scan and open Jira mention notifications"),
-        Line::from("  R         Mark selected notification issue as read"),
-        Line::from("  /         Search with JQL"),
-        Line::from("  ?         Show help"),
+        Line::from("  o         Open issue in browser"),
+        Line::from("  p         Open saved queries (run/create/edit/delete)"),
         Line::from("  q         Quit the TUI"),
-        Line::from(""),
+        Line::from("  r         Refresh list"),
+        Line::from("  R         Mark selected notification issue as read"),
+        Line::from("  s         Add to sprint"),
+        Line::from("  S         Show server info"),
+        Line::from("  t         Transition issue"),
+        Line::from("  T         Open theme picker"),
+        Line::from("  u         Upload attachment"),
+        Line::from("  v         Edit fix versions"),
+        Line::from("  V         Browse project fix versions + backlog preview"),
+        Line::from("            Enter refreshes preview, n creates, e edits metadata"),
+        Line::from("  w         Add single worklog"),
+        Line::from("  y         Change issue type (native Jira move semantics)"),
+        Line::from("  /         Search with JQL"),
+        Line::from("  :         Add the same comment to many issues (JQL or explicit keys)"),
+        Line::from("  ;         Add comment"),
+        Line::from("  ?         Show help"),
+    ];
+
+    let detail_view_section: Vec<Line<'static>> = vec![
         Line::from(Span::styled(
             "Detail View:",
             Style::default().fg(palette.tab_active),
@@ -1467,7 +1534,9 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
         Line::from("  ←/→ / Tab Switch detail tabs"),
         Line::from("  Summary / Versions / Comments / Worklog / Attachments / Subtasks / Links"),
         Line::from("  e,y,M,a,;,w,b,m,v,s,u,t,o also work from detail view"),
-        Line::from(""),
+    ];
+
+    let mouse_section: Vec<Line<'static>> = vec![
         Line::from(Span::styled(
             "Mouse:",
             Style::default().fg(palette.tab_active),
@@ -1478,7 +1547,47 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
         Line::from("  Click detail pane     Focus detail (from list)"),
         Line::from("  Click picker option   Apply (single-select) / toggle (multi-select)"),
         Line::from("  Click outside popup   Close popup (same as Esc)"),
+        Line::from("  Click [?] / [🔔]      Open help / notifications"),
+        Line::from("  Drag splitter         Resize list/detail (saved in prefs)"),
         Line::from("  Scroll wheel          Move selection in list or picker"),
+    ];
+
+    let sections: Vec<Vec<Line<'static>>> =
+        vec![issue_list_section, detail_view_section, mouse_section];
+
+    // Flat single-column form (header + sections joined by blank lines + footer).
+    let mut single_col: Vec<Line<'static>> = header_lines.clone();
+    for (i, sec) in sections.iter().enumerate() {
+        single_col.extend(sec.iter().cloned());
+        if i + 1 < sections.len() {
+            single_col.push(Line::from(""));
+        }
+    }
+    single_col.push(Line::from(""));
+    single_col.push(Line::from(Span::styled(
+        "Press any key to close",
+        Style::default().fg(palette.muted),
+    )));
+    let lines = single_col;
+
+    f.render_widget(Clear, popup_area);
+    let total_lines = lines.len() as u16;
+
+    // Decide layout: if the single-column form fits, use it. Otherwise try a
+    // 2-column section-aware split (sections stay atomic). If even that
+    // overflows, fall back to scroll on single column.
+    let probe_block = Block::default().borders(Borders::ALL);
+    let probe_inner = probe_block.inner(popup_area);
+    let inner_h = probe_inner.height;
+
+    let needs_layout = total_lines > inner_h;
+
+    // Greedy 2-col packing: keep header in col1, then fill col1 with whole
+    // sections until the next one would overflow; remaining sections + the
+    // close hint go to col2. Each section is followed by 1 blank separator
+    // line in its column.
+    let header_h = header_lines.len() as u16;
+    let close_hint = [
         Line::from(""),
         Line::from(Span::styled(
             "Press any key to close",
@@ -1486,17 +1595,67 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette) -> Rect {
         )),
     ];
 
-    f.render_widget(Clear, popup_area);
-    let paragraph = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(palette.focus_border))
-                .title(" Help ")
-                .style(Style::default().bg(Color::Black)),
-        )
-        .wrap(Wrap { trim: false });
-    f.render_widget(paragraph, popup_area);
+    let mut two_col_fits = false;
+    let mut col1: Vec<Line<'static>> = header_lines.clone();
+    let mut col2: Vec<Line<'static>> = Vec::new();
+    if needs_layout {
+        let mut col1_h: u16 = header_h;
+        let mut split_at: usize = sections.len();
+        for (i, sec) in sections.iter().enumerate() {
+            let sec_h = sec.len() as u16 + 1; // +1 for blank separator
+            if col1_h.saturating_add(sec_h) > inner_h {
+                split_at = i;
+                break;
+            }
+            col1.extend(sec.iter().cloned());
+            col1.push(Line::from(""));
+            col1_h = col1_h.saturating_add(sec_h);
+        }
+        if split_at < sections.len() && split_at > 0 {
+            for (i, sec) in sections[split_at..].iter().enumerate() {
+                col2.extend(sec.iter().cloned());
+                if i + 1 < sections.len() - split_at {
+                    col2.push(Line::from(""));
+                }
+            }
+            col2.extend(close_hint.iter().cloned());
+            let col2_h = col2.len() as u16;
+            two_col_fits = col2_h <= inner_h;
+        }
+    }
+
+    let title_bottom = if needs_layout && !two_col_fits {
+        " ↑/↓ PgUp/PgDn: scroll   Esc/?: close "
+    } else {
+        " Esc / ?: close "
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(palette.focus_border))
+        .title(" Help ")
+        .title_bottom(title_bottom)
+        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(popup_area);
+    f.render_widget(block, popup_area);
+
+    if two_col_fits {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(inner);
+        let left = Paragraph::new(col1).wrap(Wrap { trim: false });
+        let right = Paragraph::new(col2).wrap(Wrap { trim: false });
+        f.render_widget(left, cols[0]);
+        f.render_widget(right, cols[1]);
+    } else {
+        let max_scroll = total_lines.saturating_sub(inner.height);
+        let scroll = scroll_offset.min(max_scroll);
+        let paragraph = Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0));
+        f.render_widget(paragraph, inner);
+    }
     popup_area
 }
 

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -219,10 +219,24 @@ fn render_browse(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
 }
 
 fn render_master_detail(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
+    let pct = app.split_pct.clamp(20, 80);
     let cols = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(46), Constraint::Percentage(54)])
+        .constraints([
+            Constraint::Percentage(pct),
+            Constraint::Percentage(100 - pct),
+        ])
         .split(area);
+    app.hit_zones.master_detail_area = Some(area);
+    // Splitter = rightmost column of the list pane (where the border is drawn).
+    // Width 1, full height. Mouse hit-tests + drag updates split_pct.
+    let splitter_x = cols[0].x.saturating_add(cols[0].width).saturating_sub(1);
+    app.hit_zones.splitter = Some(Rect {
+        x: splitter_x,
+        y: area.y,
+        width: 1,
+        height: area.height,
+    });
     render_list(f, app, cols[0], palette);
     render_detail(f, app, cols[1], palette);
 }


### PR DESCRIPTION
  ## Summary
  - **Mouse polish**: splitter drag to resize master/detail (persisted in `tui-preferences.json`), modal form field click-to-focus,
   footer `[?]` help button + `[🔔 N]` notification badge with click-to-open.
  - **Responsive Help overlay**: section-atomic 2-column layout when terminal height is tight; scrollable single-column fallback
  (↑/↓/PgUp/PgDn/wheel) when even 2 columns overflow. Shortcuts re-sorted alphabetically.
  - **Readline shortcuts in Search (`/`) mode**: `Ctrl+W` / `Alt+Backspace` (delete word back), `Ctrl+U` (delete to start),
  `Ctrl+K` (delete to end), `Alt+D` (delete word fwd), `Ctrl+A`/`Ctrl+E` (home/end). Best-effort Kitty keyboard protocol enabled,
  so `Cmd+Backspace` / `Cmd+Delete` work on Kitty/WezTerm/Ghostty (macOS Terminal.app + iTerm2 still intercept Cmd at the terminal
  layer).
  - Modal click swallows clicks behind the popup so the list/detail handlers no longer fire while a modal is open.

  ## Test plan
  - [x] `cargo run -p jira-commands -- tui` — TUI boots, master/detail visible
  - [x] Drag vertical splitter between list/detail → split ratio updates live, clamped 20%–80%
  - [x] Quit + relaunch → split ratio persisted (`~/.config/jirac/tui-preferences.json` contains `split_pct`)
  - [x] Press `;` (comment) → click "Attachment path" field → focus moves there
  - [x] While comment modal open, click into list area → no row selection
  - [x] Press `?` → Help overlay opens; drag terminal shorter → switches to 2 columns with sections intact, then to scrollable
  single column when very short
  - [x] In Help, ↑/↓/PgUp/PgDn/wheel scroll content; any other key closes (scroll resets to top on close)
  - [x] Click `[?]` in footer bottom-right → Help opens; click `[🔔 N]` (when present) → notifications open
  - [x] Press `/` (search) → type query → `Ctrl+W` deletes last word, `Ctrl+U` clears, `Ctrl+K` clears to EOL
  - [x] (Kitty/WezTerm/Ghostty only) `Cmd+Backspace` in search clears to start; macOS Terminal.app / iTerm2 should still use
  `Ctrl+U`
  - [x] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo test --all` — all green