### PR TITLE
feat(mcp): complete phase 3 batch-one parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ export JIRA_TOKEN=your_api_token
 
 ## MCP server
 
-`jirac-mcp` exposes Jira as typed [Model Context Protocol](https://modelcontextprotocol.io) tools for editors, agents, and desktop apps. See the [jirac-mcp README](crates/jira-mcp/README.md) for setup and available tools.
+`jirac-mcp` exposes Jira as typed [Model Context Protocol](https://modelcontextprotocol.io) tools for editors, agents, and desktop apps. See the [jirac-mcp README](crates/jira-mcp/README.md) for setup and available tools, and [`docs/mcp-roadmap.md`](docs/mcp-roadmap.md) for parity goals plus release-lane direction.
 
 ### MCP install helpers
 

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -59,12 +59,12 @@ jirac auth use work-cloud
 
 The MCP server includes tools for:
 - auth status and credential updates
-- issue list, view, create, update, delete, and clone
+- issue list, view, create, update, delete, clone, and typed batch execution
 - field and transition discovery
 - issue link type discovery plus link create/delete
 - attachment upload
 - worklog operations
-- bulk transition, bulk update, and archive flows
+- bulk create, bulk transition, bulk update, and archive flows
 - plans
 - raw Jira REST API requests
 

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -61,9 +61,10 @@ The MCP server includes tools for:
 - auth status and credential updates
 - issue list, view, create, update, delete, and clone
 - field and transition discovery
+- issue link type discovery plus link create/delete
 - attachment upload
 - worklog operations
-- bulk transition, bulk update, batch, and archive flows
+- bulk transition, bulk update, and archive flows
 - plans
 - raw Jira REST API requests
 

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -20,9 +20,10 @@ use crate::{
     error::{AppError, AppResult},
     models::{
         ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BulkTransitionArgs,
-        BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs,
-        IssueFieldsArgs, IssueKeyArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs,
-        IssueUpdateArgs, WorklogAddArgs, WorklogDeleteArgs,
+        BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs,
+        IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs, IssueLinkDeleteArgs,
+        IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, WorklogAddArgs,
+        WorklogDeleteArgs,
     },
 };
 
@@ -268,6 +269,81 @@ impl JiraApp {
         }))
     }
 
+    pub async fn issue_clone(&self, args: IssueCloneArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let source = client.get_issue(&args.key).await?;
+        let target_project = args
+            .project_key
+            .unwrap_or_else(|| source.project_key.clone());
+        let summary = args.summary.unwrap_or_else(|| source.summary.clone());
+
+        let labels: Vec<String> = source
+            .fields
+            .get("labels")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let components: Vec<String> = source
+            .fields
+            .get("components")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.get("name").and_then(|n| n.as_str()))
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let fix_versions: Vec<String> = source
+            .fields
+            .get("fixVersions")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let cloned = client
+            .create_issue_v2(CreateIssueRequestV2 {
+                project_key: target_project,
+                summary,
+                description: None,
+                description_adf: source.description.clone(),
+                issue_type: source.issue_type.clone(),
+                assignee: args.assignee,
+                priority: source.priority.clone(),
+                labels,
+                components,
+                parent: None,
+                fix_versions,
+                custom_fields: HashMap::new(),
+            })
+            .await?;
+
+        let moved = args.move_issue.unwrap_or(false);
+        if moved {
+            require_confirm(args.confirm)?;
+            client.delete_issue(&args.key).await?;
+        }
+
+        Ok(json!({
+            "source_key": args.key,
+            "target_key": cloned.key,
+            "moved": moved,
+            "issue": cloned
+        }))
+    }
+
     pub async fn issue_transition(&self, args: IssueTransitionArgs) -> AppResult<Value> {
         let client = self.build_client()?;
         let resolved = resolve_transition(&client, &args.key, &args.transition).await?;
@@ -329,6 +405,42 @@ impl JiraApp {
         let client = self.build_client()?;
         let comment = client.add_comment(&args.key, &args.body).await?;
         to_value(comment)
+    }
+
+    pub async fn issue_link_list_types(&self) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let link_types = client.list_issue_link_types().await?;
+        Ok(json!({
+            "link_types": link_types
+        }))
+    }
+
+    pub async fn issue_link_add(&self, args: IssueLinkAddArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        client
+            .link_issues(
+                &args.outward_key,
+                &args.inward_key,
+                &args.link_type,
+                args.comment.as_deref(),
+            )
+            .await?;
+        Ok(json!({
+            "outward_key": args.outward_key,
+            "inward_key": args.inward_key,
+            "link_type": args.link_type,
+            "linked": true
+        }))
+    }
+
+    pub async fn issue_link_delete(&self, args: IssueLinkDeleteArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+        let client = self.build_client()?;
+        client.delete_issue_link(&args.id).await?;
+        Ok(json!({
+            "id": args.id,
+            "deleted": true
+        }))
     }
 
     pub async fn worklog_list(&self, args: IssueKeyArgs) -> AppResult<Value> {

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -19,11 +19,12 @@ use url::form_urlencoded;
 use crate::{
     error::{AppError, AppResult},
     models::{
-        ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BulkTransitionArgs,
-        BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs,
-        IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs, IssueLinkDeleteArgs,
-        IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, WorklogAddArgs,
-        WorklogDeleteArgs,
+        ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BatchArgs,
+        BatchCreateOp, BatchOperation, BatchUpdateOp, BulkCreateArgs, BulkCreateEntry,
+        BulkTransitionArgs, BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs,
+        IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs,
+        IssueLinkDeleteArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs,
+        IssueUpdateArgs, WorklogAddArgs, WorklogDeleteArgs,
     },
 };
 
@@ -197,66 +198,193 @@ impl JiraApp {
     pub async fn issue_create(&self, args: IssueCreateArgs) -> AppResult<Value> {
         let client = self.build_client()?;
         let issue = client
-            .create_issue_v2(CreateIssueRequestV2 {
-                project_key: args.project_key,
-                summary: args.summary,
-                description: args.description,
-                description_adf: args.description_adf,
-                issue_type: args.issue_type,
-                assignee: args.assignee,
-                priority: args.priority,
-                labels: args.labels.unwrap_or_default(),
-                components: args.components.unwrap_or_default(),
-                parent: args.parent,
-                fix_versions: args.fix_versions.unwrap_or_default(),
-                custom_fields: map_custom_fields(args.custom_fields),
-            })
+            .create_issue_v2(create_issue_request_from_args(args))
             .await?;
 
         to_value(issue)
     }
 
-    pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {
+    pub async fn issue_bulk_create(&self, args: BulkCreateArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
         let client = self.build_client()?;
-        let custom_fields = map_custom_fields(args.custom_fields);
-        let has_changes = args.summary.is_some()
-            || args.description.is_some()
-            || args.description_adf.is_some()
-            || args.assignee.is_some()
-            || args.priority.is_some()
-            || args.labels.is_some()
-            || args.components.is_some()
-            || args.parent.is_some()
-            || args.fix_versions.is_some()
-            || !custom_fields.is_empty();
 
-        if !has_changes {
-            return Err(AppError::validation(
-                "Provide at least one field to update on the issue",
-            ));
+        if args.issues.is_empty() {
+            return Ok(json!({
+                "total": 0,
+                "created_count": 0,
+                "failed_count": 0,
+                "created": [],
+                "failed": []
+            }));
         }
 
-        let key = args.key;
-        client
-            .update_issue(
-                &key,
-                UpdateIssueRequest {
-                    summary: args.summary,
-                    description: args.description,
-                    description_adf: args.description_adf,
-                    assignee: args.assignee,
-                    priority: args.priority,
-                    labels: args.labels,
-                    components: args.components,
-                    fix_versions: args.fix_versions,
-                    parent: args.parent,
-                    custom_fields,
-                    ..Default::default()
-                },
-            )
-            .await?;
+        let total = args.issues.len();
+        let mut created = Vec::new();
+        let mut failed = Vec::new();
+
+        for entry in args.issues {
+            let summary = entry.summary.clone();
+            match client
+                .create_issue_v2(create_issue_request_from_bulk_entry(entry))
+                .await
+            {
+                Ok(issue) => created.push(issue),
+                Err(err) => failed.push(json!({
+                    "summary": summary,
+                    "error": err.to_string()
+                })),
+            }
+        }
+
+        Ok(json!({
+            "total": total,
+            "created_count": created.len(),
+            "failed_count": failed.len(),
+            "created": created,
+            "failed": failed
+        }))
+    }
+
+    pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let key = args.key.clone();
+        let request = build_update_issue_request_from_issue(args)?;
+
+        client.update_issue(&key, request).await?;
         let issue = client.get_issue(&key).await?;
         to_value(issue)
+    }
+
+    pub async fn issue_batch(&self, args: BatchArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+        let client = self.build_client()?;
+
+        if args.operations.is_empty() {
+            return Ok(json!({
+                "total": 0,
+                "succeeded": 0,
+                "failed_count": 0,
+                "results": []
+            }));
+        }
+
+        let total = args.operations.len();
+        let mut results = Vec::new();
+        let mut succeeded = 0usize;
+
+        for operation in args.operations {
+            let result = match operation {
+                BatchOperation::Create(entry) => {
+                    let summary = entry.summary.clone();
+                    match client
+                        .create_issue_v2(create_issue_request_from_batch_create(entry))
+                        .await
+                    {
+                        Ok(issue) => {
+                            succeeded += 1;
+                            json!({
+                                "op": "create",
+                                "key": issue.key,
+                                "status": "created",
+                                "issue": issue
+                            })
+                        }
+                        Err(err) => json!({
+                            "op": "create",
+                            "summary": summary,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Update(entry) => {
+                    let key = entry.key.clone();
+                    match build_update_issue_request_from_batch(entry) {
+                        Ok(request) => match client.update_issue(&key, request).await {
+                            Ok(_) => {
+                                succeeded += 1;
+                                json!({
+                                    "op": "update",
+                                    "key": key,
+                                    "status": "updated"
+                                })
+                            }
+                            Err(err) => json!({
+                                "op": "update",
+                                "key": key,
+                                "status": "failed",
+                                "error": err.to_string()
+                            }),
+                        },
+                        Err(err) => json!({
+                            "op": "update",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Transition(entry) => {
+                    let key = entry.key.clone();
+                    let transition = entry.transition.clone();
+                    match resolve_transition(&client, &key, &transition).await {
+                        Ok(resolved) => match client.transition_issue(&key, &resolved.id).await {
+                            Ok(_) => {
+                                succeeded += 1;
+                                json!({
+                                    "op": "transition",
+                                    "key": key,
+                                    "status": "transitioned",
+                                    "transition": {
+                                        "id": resolved.id,
+                                        "name": resolved.name
+                                    }
+                                })
+                            }
+                            Err(err) => json!({
+                                "op": "transition",
+                                "key": key,
+                                "status": "failed",
+                                "error": err.to_string()
+                            }),
+                        },
+                        Err(err) => json!({
+                            "op": "transition",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Archive(entry) => {
+                    let key = entry.key;
+                    match client.archive_issues(std::slice::from_ref(&key)).await {
+                        Ok(_) => {
+                            succeeded += 1;
+                            json!({
+                                "op": "archive",
+                                "key": key,
+                                "status": "archived"
+                            })
+                        }
+                        Err(err) => json!({
+                            "op": "archive",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+            };
+            results.push(result);
+        }
+
+        Ok(json!({
+            "total": total,
+            "succeeded": succeeded,
+            "failed_count": total - succeeded,
+            "results": results
+        }))
     }
 
     pub async fn issue_delete(&self, args: IssueDeleteArgs) -> AppResult<Value> {
@@ -670,6 +798,125 @@ fn map_custom_fields(
         .into_iter()
         .map(|(key, value)| (key, FieldValue::Raw(value)))
         .collect()
+}
+
+fn create_issue_request_from_args(args: IssueCreateArgs) -> CreateIssueRequestV2 {
+    CreateIssueRequestV2 {
+        project_key: args.project_key,
+        summary: args.summary,
+        description: args.description,
+        description_adf: args.description_adf,
+        issue_type: args.issue_type,
+        assignee: args.assignee,
+        priority: args.priority,
+        labels: args.labels.unwrap_or_default(),
+        components: args.components.unwrap_or_default(),
+        parent: args.parent,
+        fix_versions: args.fix_versions.unwrap_or_default(),
+        custom_fields: map_custom_fields(args.custom_fields),
+    }
+}
+
+fn create_issue_request_from_bulk_entry(entry: BulkCreateEntry) -> CreateIssueRequestV2 {
+    CreateIssueRequestV2 {
+        project_key: entry.project_key,
+        summary: entry.summary,
+        description: entry.description,
+        description_adf: entry.description_adf,
+        issue_type: entry.issue_type.unwrap_or_else(|| "Task".to_string()),
+        assignee: entry.assignee,
+        priority: entry.priority,
+        labels: entry.labels.unwrap_or_default(),
+        components: entry.components.unwrap_or_default(),
+        parent: entry.parent,
+        fix_versions: entry.fix_versions.unwrap_or_default(),
+        custom_fields: map_custom_fields(entry.custom_fields),
+    }
+}
+
+fn create_issue_request_from_batch_create(entry: BatchCreateOp) -> CreateIssueRequestV2 {
+    CreateIssueRequestV2 {
+        project_key: entry.project_key,
+        summary: entry.summary,
+        description: entry.description,
+        description_adf: entry.description_adf,
+        issue_type: entry.issue_type.unwrap_or_else(|| "Task".to_string()),
+        assignee: entry.assignee,
+        priority: entry.priority,
+        labels: entry.labels.unwrap_or_default(),
+        components: entry.components.unwrap_or_default(),
+        parent: entry.parent,
+        fix_versions: entry.fix_versions.unwrap_or_default(),
+        custom_fields: map_custom_fields(entry.custom_fields),
+    }
+}
+
+fn build_update_issue_request_from_issue(args: IssueUpdateArgs) -> AppResult<UpdateIssueRequest> {
+    let custom_fields = map_custom_fields(args.custom_fields);
+    let has_changes = args.summary.is_some()
+        || args.description.is_some()
+        || args.description_adf.is_some()
+        || args.assignee.is_some()
+        || args.priority.is_some()
+        || args.labels.is_some()
+        || args.components.is_some()
+        || args.parent.is_some()
+        || args.fix_versions.is_some()
+        || !custom_fields.is_empty();
+
+    if !has_changes {
+        return Err(AppError::validation(
+            "Provide at least one field to update on the issue",
+        ));
+    }
+
+    Ok(UpdateIssueRequest {
+        summary: args.summary,
+        description: args.description,
+        description_adf: args.description_adf,
+        assignee: args.assignee,
+        priority: args.priority,
+        labels: args.labels,
+        components: args.components,
+        fix_versions: args.fix_versions,
+        parent: args.parent,
+        custom_fields,
+        ..Default::default()
+    })
+}
+
+fn build_update_issue_request_from_batch(entry: BatchUpdateOp) -> AppResult<UpdateIssueRequest> {
+    let custom_fields = map_custom_fields(entry.custom_fields);
+    let has_changes = entry.summary.is_some()
+        || entry.description.is_some()
+        || entry.description_adf.is_some()
+        || entry.assignee.is_some()
+        || entry.priority.is_some()
+        || entry.labels.is_some()
+        || entry.components.is_some()
+        || entry.parent.is_some()
+        || entry.fix_versions.is_some()
+        || !custom_fields.is_empty();
+
+    if !has_changes {
+        return Err(AppError::validation(
+            "Provide at least one field to update on the issue",
+        ));
+    }
+
+    Ok(UpdateIssueRequest {
+        summary: entry.summary,
+        description: entry.description,
+        description_adf: entry.description_adf,
+        assignee: entry.assignee,
+        priority: entry.priority,
+        labels: entry.labels,
+        components: entry.components,
+        fix_versions: entry.fix_versions,
+        parent: entry.parent,
+        custom_fields,
+        ..Default::default()
+    })
 }
 
 fn require_confirm(confirm: Option<bool>) -> AppResult<()> {

--- a/crates/jira-mcp/src/error.rs
+++ b/crates/jira-mcp/src/error.rs
@@ -120,3 +120,11 @@ impl From<base64::DecodeError> for AppError {
         Self::validation(format!("Invalid base64 attachment payload: {value}"))
     }
 }
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for AppError {}

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -83,6 +83,32 @@ pub struct IssueCreateArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BulkCreateEntry {
+    pub project_key: String,
+    pub summary: String,
+    pub issue_type: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
+    pub description_adf: Option<Value>,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub components: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
+    pub custom_fields: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BulkCreateArgs {
+    pub issues: Vec<BulkCreateEntry>,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IssueUpdateArgs {
     pub key: String,
     pub summary: Option<String>,
@@ -194,6 +220,71 @@ pub struct BulkUpdateArgs {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ArchiveArgs {
     pub jql: String,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchCreateOp {
+    pub project_key: String,
+    pub summary: String,
+    pub issue_type: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
+    pub description_adf: Option<Value>,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub components: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
+    pub custom_fields: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchUpdateOp {
+    pub key: String,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
+    pub description_adf: Option<Value>,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub components: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
+    pub custom_fields: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchTransitionOp {
+    pub key: String,
+    pub transition: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchArchiveOp {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum BatchOperation {
+    Create(BatchCreateOp),
+    Update(BatchUpdateOp),
+    Transition(BatchTransitionOp),
+    Archive(BatchArchiveOp),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchArgs {
+    pub operations: Vec<BatchOperation>,
     pub confirm: Option<bool>,
 }
 

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -108,9 +108,33 @@ pub struct IssueDeleteArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueCloneArgs {
+    pub key: String,
+    pub project_key: Option<String>,
+    pub summary: Option<String>,
+    pub assignee: Option<String>,
+    pub move_issue: Option<bool>,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IssueTransitionArgs {
     pub key: String,
     pub transition: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueLinkAddArgs {
+    pub outward_key: String,
+    pub inward_key: String,
+    pub link_type: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueLinkDeleteArgs {
+    pub id: String,
+    pub confirm: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -18,9 +18,10 @@ use crate::{
     error::AppResult,
     models::{
         ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BulkTransitionArgs, BulkUpdateArgs,
-        CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs,
-        IssueKeyArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs,
-        ToolResponse, WorklogAddArgs, WorklogDeleteArgs,
+        CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs, IssueDeleteArgs,
+        IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs, IssueLinkDeleteArgs, IssueListArgs,
+        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ToolResponse, WorklogAddArgs,
+        WorklogDeleteArgs,
     },
 };
 
@@ -181,6 +182,17 @@ impl JiraMcpServer {
     }
 
     #[tool(
+        name = "jira_issue_clone",
+        description = "Clone a Jira issue, optionally into another project; moving the issue requires confirm=true"
+    )]
+    pub async fn jira_issue_clone(
+        &self,
+        Parameters(args): Parameters<IssueCloneArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_clone(args).await)
+    }
+
+    #[tool(
         name = "jira_issue_transition",
         description = "Transition a Jira issue by workflow transition name or ID"
     )]
@@ -222,6 +234,36 @@ impl JiraMcpServer {
         Parameters(args): Parameters<CommentAddArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.comment_add(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_list_types",
+        description = "List available Jira issue link types"
+    )]
+    pub async fn jira_issue_link_list_types(&self) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_list_types().await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_add",
+        description = "Create a link between two Jira issues"
+    )]
+    pub async fn jira_issue_link_add(
+        &self,
+        Parameters(args): Parameters<IssueLinkAddArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_add(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_delete",
+        description = "Delete a Jira issue link by ID; requires confirm=true"
+    )]
+    pub async fn jira_issue_link_delete(
+        &self,
+        Parameters(args): Parameters<IssueLinkDeleteArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_delete(args).await)
     }
 
     #[tool(
@@ -422,6 +464,8 @@ mod tests {
         let client = TestClient.serve(client_transport).await?;
         let tools = client.list_all_tools().await?;
         assert!(tools.iter().any(|tool| tool.name == "jira_auth_status"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_clone"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_link_add"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))
@@ -480,6 +524,10 @@ mod tests {
         assert!(tools
             .iter()
             .any(|tool| tool.name == "jira_auth_set_credentials"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_clone"));
+        assert!(tools
+            .iter()
+            .any(|tool| tool.name == "jira_issue_link_delete"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -17,11 +17,11 @@ use crate::{
     app::JiraApp,
     error::AppResult,
     models::{
-        ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BulkTransitionArgs, BulkUpdateArgs,
-        CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs, IssueDeleteArgs,
-        IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs, IssueLinkDeleteArgs, IssueListArgs,
-        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ToolResponse, WorklogAddArgs,
-        WorklogDeleteArgs,
+        ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BatchArgs, BulkCreateArgs,
+        BulkTransitionArgs, BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs,
+        IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkAddArgs,
+        IssueLinkDeleteArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs,
+        IssueUpdateArgs, ToolResponse, WorklogAddArgs, WorklogDeleteArgs,
     },
 };
 
@@ -168,6 +168,28 @@ impl JiraMcpServer {
         Parameters(args): Parameters<IssueUpdateArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.issue_update(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_bulk_create",
+        description = "Create multiple Jira issues from typed entries; requires confirm=true"
+    )]
+    pub async fn jira_issue_bulk_create(
+        &self,
+        Parameters(args): Parameters<BulkCreateArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_bulk_create(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_batch",
+        description = "Run typed create, update, transition, and archive issue operations in sequence; requires confirm=true"
+    )]
+    pub async fn jira_issue_batch(
+        &self,
+        Parameters(args): Parameters<BatchArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_batch(args).await)
     }
 
     #[tool(
@@ -466,6 +488,10 @@ mod tests {
         assert!(tools.iter().any(|tool| tool.name == "jira_auth_status"));
         assert!(tools.iter().any(|tool| tool.name == "jira_issue_clone"));
         assert!(tools.iter().any(|tool| tool.name == "jira_issue_link_add"));
+        assert!(tools
+            .iter()
+            .any(|tool| tool.name == "jira_issue_bulk_create"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_batch"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))
@@ -528,6 +554,10 @@ mod tests {
         assert!(tools
             .iter()
             .any(|tool| tool.name == "jira_issue_link_delete"));
+        assert!(tools
+            .iter()
+            .any(|tool| tool.name == "jira_issue_bulk_create"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_batch"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))

--- a/docs/mcp-roadmap.md
+++ b/docs/mcp-roadmap.md
@@ -7,8 +7,9 @@ Current server focus is **typed tools over MCP**; it does **not** currently expo
 
 Implemented today:
 - auth status / set credentials / logout
-- issue list / view / create / update / delete / transition
-- issue type, field, and transition discovery
+- issue list / view / create / update / delete / clone / transition
+- issue type, field, transition, and issue-link-type discovery
+- issue link create / delete
 - attachment upload
 - comment list / add
 - worklog list / add / delete
@@ -20,10 +21,8 @@ Implemented today:
 - install helpers for Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, OpenCode, generic JSON, and Zed
 
 Not yet at CLI parity:
-- issue clone
 - batch manifest runner
 - bulk create
-- issue link operations
 - sprint lifecycle tools
 - standup / sprint summary helpers
 - fix version browsing / create / update flows
@@ -60,12 +59,8 @@ Done:
 Goal: close the highest-value capability gaps so an MCP client can handle the same day-to-day Jira workflows as the CLI without falling back to shelling out.
 
 Priority 1:
-- `jira_issue_clone`
 - `jira_issue_bulk_create`
 - `jira_issue_batch`
-- `jira_issue_link_list_types`
-- `jira_issue_link_add`
-- `jira_issue_link_delete`
 
 Priority 2:
 - sprint tools:

--- a/docs/mcp-roadmap.md
+++ b/docs/mcp-roadmap.md
@@ -10,6 +10,8 @@ Implemented today:
 - issue list / view / create / update / delete / clone / transition
 - issue type, field, transition, and issue-link-type discovery
 - issue link create / delete
+- bulk create
+- typed batch runner (create / update / transition / archive)
 - attachment upload
 - comment list / add
 - worklog list / add / delete
@@ -21,8 +23,6 @@ Implemented today:
 - install helpers for Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, OpenCode, generic JSON, and Zed
 
 Not yet at CLI parity:
-- batch manifest runner
-- bulk create
 - sprint lifecycle tools
 - standup / sprint summary helpers
 - fix version browsing / create / update flows
@@ -58,9 +58,7 @@ Done:
 
 Goal: close the highest-value capability gaps so an MCP client can handle the same day-to-day Jira workflows as the CLI without falling back to shelling out.
 
-Priority 1:
-- `jira_issue_bulk_create`
-- `jira_issue_batch`
+Priority 1 is now complete on this branch.
 
 Priority 2:
 - sprint tools:

--- a/docs/mcp-roadmap.md
+++ b/docs/mcp-roadmap.md
@@ -1,0 +1,154 @@
+# MCP roadmap
+
+Status note: `jira-mcp` is already useful, but it is not yet at CLI parity.
+Current server focus is **typed tools over MCP**; it does **not** currently expose MCP prompts, resources, or UI surfaces.
+
+## Current MCP capability snapshot
+
+Implemented today:
+- auth status / set credentials / logout
+- issue list / view / create / update / delete / transition
+- issue type, field, and transition discovery
+- attachment upload
+- comment list / add
+- worklog list / add / delete
+- bulk transition / bulk update / archive
+- plan list
+- raw Jira REST request
+- stdio transport
+- streamable HTTP transport
+- install helpers for Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, OpenCode, generic JSON, and Zed
+
+Not yet at CLI parity:
+- issue clone
+- batch manifest runner
+- bulk create
+- issue link operations
+- sprint lifecycle tools
+- standup / sprint summary helpers
+- fix version browsing / create / update flows
+- richer plan operations beyond `plan list`
+- TUI-only workflows that need MCP-friendly equivalents
+- prompts/resources/UI surfaces
+
+## Parity principle
+
+`jira-mcp` should aim for **workflow parity**, not 1:1 command-name parity.
+That means every high-value CLI workflow should have an MCP-safe equivalent, even if the final tool shape differs from the CLI syntax.
+
+## Phase 1 — Foundation
+
+Done:
+- shared auth/config reuse from `jirac`
+- typed MCP server bootstrap on rmcp
+- core issue CRUD surface
+- field/transition discovery
+- attachment and worklog basics
+- raw API escape hatch
+
+## Phase 2 — Agent-safe daily use
+
+Done:
+- bulk transition / update / archive with explicit confirmation
+- comment add/list
+- plans list
+- multi-client install helpers
+- streamable HTTP transport
+
+## Phase 3 — CLI parity push
+
+Goal: close the highest-value capability gaps so an MCP client can handle the same day-to-day Jira workflows as the CLI without falling back to shelling out.
+
+Priority 1:
+- `jira_issue_clone`
+- `jira_issue_bulk_create`
+- `jira_issue_batch`
+- `jira_issue_link_list_types`
+- `jira_issue_link_add`
+- `jira_issue_link_delete`
+
+Priority 2:
+- sprint tools:
+  - `jira_issue_sprints`
+  - `jira_issue_sprint_create`
+  - `jira_issue_sprint_start`
+  - `jira_issue_sprint_update`
+  - `jira_issue_sprint_complete`
+  - `jira_issue_sprint_delete`
+- reporting helpers:
+  - `jira_issue_standup`
+  - `jira_issue_sprint_summary`
+
+Priority 3:
+- fix-version tools:
+  - list / preview backlog
+  - create
+  - rename
+  - set description
+  - set start date
+  - set release date
+  - released / archived toggles
+- plan surface expansion if Jira API coverage is reliable
+
+Guardrails:
+- destructive or bulk-write tools must require `confirm: true`
+- tools should prefer typed structured args over shell-like free-form text
+- when a CLI flow is interactive today, MCP should expose the underlying discrete operations instead of emulating prompts
+- raw API remains available, but parity should reduce the need for it
+
+## Release/versioning direction
+
+`jira-core` and `jira-commands` can stay in the same release lane.
+`jira-mcp` should move to its own version lane because its user-facing capability surface can change independently.
+
+Recommended target model:
+- lane A: `jira-core` + `jira-commands`
+- lane B: `jira-mcp`
+
+Why this split is reasonable:
+- CLI/core changes are tightly coupled already
+- MCP capability growth will often happen without a meaningful CLI release
+- separate release cadence avoids artificial version bumps on the MCP package
+- changelog signal becomes cleaner for MCP users and client integrators
+
+## Release split design sketch
+
+Desired behavior:
+- CLI lane keeps the existing root release flow
+- MCP lane gets its own release-please component, manifest entry, changelog path, and tag prefix
+- MCP publish/build jobs run only when the MCP lane releases
+- npm wrapper `@mulham28/jirac-mcp` follows the MCP lane, not the root `VERSION`
+- Homebrew/Scoop/Winget/Chocolatey mapping stays explicit per artifact
+
+Expected repo changes for that split:
+- stop treating `crates/jira-mcp/Cargo.toml` as part of the root version lane
+- add a dedicated MCP version source (for example `crates/jira-mcp/VERSION` or a package-local release-please manifest entry)
+- split `scripts/sync-npm-version.mjs` into per-lane sync logic
+- update CI checks that currently hard-fail when all Rust crate versions differ
+- update release workflows that currently validate one shared `VERSION`
+- add separate tag handling for MCP releases
+- ensure npm publish and release archives read the correct lane version
+
+## Suggested implementation order
+
+1. land the roadmap + parity checklist
+2. implement missing Phase 3 MCP tools in small batches
+3. add tests for every new tool surface
+4. after parity work starts landing, split the MCP release lane
+5. finally update packaging/docs/install helpers to reflect the dedicated MCP version stream
+
+## Notes for implementation
+
+The release-lane split is possible, but it touches:
+- `Cargo.toml`
+- `release-please-config.json`
+- `.release-please-manifest.json`
+- `VERSION`
+- `scripts/sync-npm-version.mjs`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-please.yml`
+- `.github/workflows/release-tag.yml`
+- `.github/workflows/release-recover.yml`
+- npm packaging checks and publish steps
+
+So it should be done as a focused release-infra change, not mixed casually into feature work.


### PR DESCRIPTION
## Summary
- add typed `jira_issue_bulk_create` MCP support with confirm gating and structured results
- add typed `jira_issue_batch` support for create/update/transition/archive sequences
- update MCP docs/roadmap to reflect completed batch-one parity and expose the new tools

## Validation
- cargo test -p jira-mcp
- cargo clippy -p jira-mcp --all-targets -- -D warnings