### PR TITLE
fix(release): stop jira-mcp changes from bumping root lane

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,10 @@
       "package-name": "jira-commands",
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
+      "exclude-paths": [
+        "crates/jira-mcp",
+        "packaging/npm-mcp"
+      ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },
         { "type": "generic", "path": "/crates/jira/Cargo.toml" },


### PR DESCRIPTION
## Summary
- scope the root release lane away from jira-mcp-only changes
- keep jira-mcp on its own release lane
- preserve the existing root lane for jira + jira-core releases

## Why
Merging jira-mcp-only feature work currently opens both release PRs because the root `.` package watches the whole repo.

## Change
Add `exclude-paths` to the root package for:
- `crates/jira-mcp`
- `packaging/npm-mcp`

This keeps `jira-mcp` changes on the `crates/jira-mcp` lane instead of also opening a root `jira-commands` release PR.

## Verification
- `jq . release-please-config.json >/dev/null`
- `git diff --check`

Note: I also verified the release-please docs behavior for `.` root packages and `exclude-paths` before making this change.