### PR TITLE
feat(jira-mcp): add issue and remote link tools

### DIFF
--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -22,10 +22,11 @@ use crate::{
     models::{
         ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BulkTransitionArgs,
         BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs,
-        IssueFieldsArgs, IssueKeyArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs,
-        IssueUpdateArgs, ProjectKeyArgs, ProjectVersionCreateArgs, ProjectVersionUpdateArgs,
-        SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs, SprintListArgs, SprintUpdateArgs,
-        WorklogAddArgs, WorklogDeleteArgs,
+        IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs,
+        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
+        ProjectVersionCreateArgs, ProjectVersionUpdateArgs, RemoteLinkAddArgs,
+        RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs,
+        SprintListArgs, SprintUpdateArgs, WorklogAddArgs, WorklogDeleteArgs,
     },
 };
 
@@ -493,6 +494,73 @@ impl JiraApp {
         let client = self.build_client()?;
         let comment = client.add_comment(&args.key, &args.body).await?;
         to_value(comment)
+    }
+
+    pub async fn issue_link_types_list(&self) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let link_types = client.list_issue_link_types().await?;
+        Ok(json!({
+            "link_types": link_types
+        }))
+    }
+
+    pub async fn issue_link_create(&self, args: IssueLinkCreateArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        client
+            .link_issues(
+                &args.outward_key,
+                &args.inward_key,
+                &args.link_type,
+                args.comment.as_deref(),
+            )
+            .await?;
+        Ok(json!({
+            "outward_key": args.outward_key,
+            "inward_key": args.inward_key,
+            "link_type": args.link_type,
+            "created": true
+        }))
+    }
+
+    pub async fn issue_link_delete(&self, args: IssueLinkDeleteArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+        let client = self.build_client()?;
+        client.delete_issue_link(&args.link_id).await?;
+        Ok(json!({
+            "link_id": args.link_id,
+            "deleted": true
+        }))
+    }
+
+    pub async fn remote_link_list(&self, args: IssueKeyArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let links = client.get_remote_links(&args.key).await?;
+        Ok(json!({
+            "key": args.key,
+            "remote_links": links
+        }))
+    }
+
+    pub async fn remote_link_add(&self, args: RemoteLinkAddArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let link = client
+            .add_remote_link(&args.key, &args.url, &args.title)
+            .await?;
+        Ok(json!({
+            "key": args.key,
+            "remote_link": link
+        }))
+    }
+
+    pub async fn remote_link_delete(&self, args: RemoteLinkDeleteArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+        let client = self.build_client()?;
+        client.delete_remote_link(&args.key, &args.link_id).await?;
+        Ok(json!({
+            "key": args.key,
+            "link_id": args.link_id,
+            "deleted": true
+        }))
     }
 
     pub async fn worklog_list(&self, args: IssueKeyArgs) -> AppResult<Value> {
@@ -1126,5 +1194,76 @@ mod tests {
         .expect_err("duplicate query should fail");
 
         assert_eq!(err.to_mcp().message, "validation_error");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn issue_link_types_list_returns_values() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let mock_server = MockServer::start().await;
+        set_test_env(&temp_dir, Some(&mock_server.uri()));
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issueLinkType"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "issueLinkTypes": [{
+                    "id": "10000",
+                    "name": "Blocks",
+                    "inward": "is blocked by",
+                    "outward": "blocks"
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let result = JiraApp
+            .issue_link_types_list()
+            .await
+            .expect("link type list");
+
+        assert_eq!(result["link_types"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            result["link_types"][0]["name"],
+            Value::String("Blocks".into())
+        );
+
+        clear_test_env();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn remote_link_list_returns_links() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let mock_server = MockServer::start().await;
+        set_test_env(&temp_dir, Some(&mock_server.uri()));
+
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/PROJ-1/remotelink"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "id": 321,
+                "relationship": "references",
+                "object": {
+                    "title": "Spec",
+                    "url": "https://example.com/spec"
+                }
+            }])))
+            .mount(&mock_server)
+            .await;
+
+        let result = JiraApp
+            .remote_link_list(IssueKeyArgs {
+                key: "PROJ-1".into(),
+            })
+            .await
+            .expect("remote links");
+
+        assert_eq!(result["key"], Value::String("PROJ-1".into()));
+        assert_eq!(result["remote_links"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            result["remote_links"][0]["object"]["title"],
+            Value::String("Spec".into())
+        );
+
+        clear_test_env();
     }
 }

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -203,6 +203,34 @@ pub struct CommentAddArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueLinkCreateArgs {
+    pub outward_key: String,
+    pub inward_key: String,
+    pub link_type: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueLinkDeleteArgs {
+    pub link_id: String,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemoteLinkAddArgs {
+    pub key: String,
+    pub url: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemoteLinkDeleteArgs {
+    pub key: String,
+    pub link_id: String,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WorklogAddArgs {
     pub key: String,
     pub time_spent: String,

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -19,8 +19,9 @@ use crate::{
     models::{
         ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BulkTransitionArgs, BulkUpdateArgs,
         CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs,
-        IssueKeyArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs,
-        ProjectKeyArgs, ProjectVersionCreateArgs, ProjectVersionUpdateArgs, SprintAddIssueArgs,
+        IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs, IssueTransitionArgs,
+        IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs, ProjectVersionCreateArgs,
+        ProjectVersionUpdateArgs, RemoteLinkAddArgs, RemoteLinkDeleteArgs, SprintAddIssueArgs,
         SprintCreateArgs, SprintDeleteArgs, SprintListArgs, SprintUpdateArgs, ToolResponse,
         WorklogAddArgs, WorklogDeleteArgs,
     },
@@ -323,6 +324,69 @@ impl JiraMcpServer {
         Parameters(args): Parameters<CommentAddArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.comment_add(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_types_list",
+        description = "List available Jira issue link types such as blocks, relates to, and duplicates"
+    )]
+    pub async fn jira_issue_link_types_list(&self) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_types_list().await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_create",
+        description = "Create a link between two Jira issues using a Jira link type name"
+    )]
+    pub async fn jira_issue_link_create(
+        &self,
+        Parameters(args): Parameters<IssueLinkCreateArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_create(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_link_delete",
+        description = "Delete a Jira issue link by link ID; requires confirm=true"
+    )]
+    pub async fn jira_issue_link_delete(
+        &self,
+        Parameters(args): Parameters<IssueLinkDeleteArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_link_delete(args).await)
+    }
+
+    #[tool(
+        name = "jira_remote_link_list",
+        description = "List remote links attached to a Jira issue"
+    )]
+    pub async fn jira_remote_link_list(
+        &self,
+        Parameters(args): Parameters<IssueKeyArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.remote_link_list(args).await)
+    }
+
+    #[tool(
+        name = "jira_remote_link_add",
+        description = "Attach a remote URL link to a Jira issue"
+    )]
+    pub async fn jira_remote_link_add(
+        &self,
+        Parameters(args): Parameters<RemoteLinkAddArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.remote_link_add(args).await)
+    }
+
+    #[tool(
+        name = "jira_remote_link_delete",
+        description = "Delete a remote link from a Jira issue; requires confirm=true"
+    )]
+    pub async fn jira_remote_link_delete(
+        &self,
+        Parameters(args): Parameters<RemoteLinkDeleteArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.remote_link_delete(args).await)
     }
 
     #[tool(


### PR DESCRIPTION
## Summary
- add MCP tools for Jira issue link types, create, and delete
- add MCP tools for Jira remote link list, create, and delete
- cover the new MCP surface with focused app tests

## New tools
- `jira_issue_link_types_list`
- `jira_issue_link_create`
- `jira_issue_link_delete`
- `jira_remote_link_list`
- `jira_remote_link_add`
- `jira_remote_link_delete`

## Verification
- `cargo test -p jira-mcp` via `podman` with `docker.io/library/rust:latest`
- `cargo fmt --all --check` via `podman` with `docker.io/library/rust:latest`

## Notes
The host toolchain is too old for this workspace (`cargo 1.46` / `rustc 1.48`), so verification was run in a modern Rust container instead.