### PR TITLE
feat(release): add jira-mcp scoop docs and automation

### DIFF
--- a/.github/scripts/refresh_release_readme.py
+++ b/.github/scripts/refresh_release_readme.py
@@ -82,6 +82,7 @@ cargo install jira-commands
 # Windows (Scoop)
 scoop bucket add mulhamna https://github.com/{SCOOP_BUCKET}
 scoop install mulhamna/jirac
+scoop install mulhamna/jirac-mcp
 
 # Windows (winget)
 winget install mulhamna.jirac
@@ -137,7 +138,7 @@ def refresh_install_md(text: str) -> str:
         r"## PowerShell installer \(Windows\)\n.*?## Cargo\n",
         flags=re.S,
     )
-    new = f"""## PowerShell installer (Windows)\n\n```powershell\npowershell -ExecutionPolicy Bypass -Command \"& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))\"\n```\n\nInstall `jirac-mcp` instead:\n\n```powershell\npowershell -ExecutionPolicy Bypass -Command \"& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))\" -Binary jirac-mcp\n```\n\n## Scoop (Windows)\n\n```powershell\nscoop bucket add mulhamna https://github.com/{SCOOP_BUCKET}\nscoop install mulhamna/jirac\n```\n\n## Cargo\n"""
+    new = f"""## PowerShell installer (Windows)\n\n```powershell\npowershell -ExecutionPolicy Bypass -Command \"& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))\"\n```\n\nInstall `jirac-mcp` instead:\n\n```powershell\npowershell -ExecutionPolicy Bypass -Command \"& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))\" -Binary jirac-mcp\n```\n\n## Scoop (Windows)\n\n```powershell\nscoop bucket add mulhamna https://github.com/{SCOOP_BUCKET}\nscoop install mulhamna/jirac\nscoop install mulhamna/jirac-mcp\n```\n\n## Cargo\n"""
     if not pattern.search(text):
         raise SystemExit("expected PowerShell/Cargo section not found in INSTALL.md")
     return pattern.sub(new, text, count=1)

--- a/.github/scripts/update_scoop_manifest.py
+++ b/.github/scripts/update_scoop_manifest.py
@@ -9,13 +9,28 @@ VERSION = os.environ["VERSION"]
 SHA_WINDOWS_X86 = os.environ["SHA_WINDOWS_X86"]
 REPOSITORY = os.environ.get("REPOSITORY", "mulhamna/jira-commands")
 MANIFEST_PATH = Path(os.environ.get("SCOOP_MANIFEST_PATH", "bucket/jirac.json"))
+SCOOP_BINARY = os.environ.get("SCOOP_BINARY", "jirac")
+SCOOP_RELEASE_TAG_PREFIX = os.environ.get("SCOOP_RELEASE_TAG_PREFIX", "v")
+SCOOP_WINDOWS_ARCHIVE = os.environ.get(
+    "SCOOP_WINDOWS_ARCHIVE",
+    f"{SCOOP_BINARY}-windows-x86_64.zip",
+)
 
 manifest = json.loads(MANIFEST_PATH.read_text())
 manifest["version"] = VERSION
-manifest["url"] = f"https://github.com/{REPOSITORY}/releases/download/v{VERSION}/jirac-windows-x86_64.zip"
+manifest["url"] = (
+    f"https://github.com/{REPOSITORY}/releases/download/"
+    f"{SCOOP_RELEASE_TAG_PREFIX}{VERSION}/{SCOOP_WINDOWS_ARCHIVE}"
+)
 manifest["hash"] = SHA_WINDOWS_X86
 manifest.setdefault("checkver", {})
 manifest.setdefault("autoupdate", {})
-manifest["autoupdate"]["url"] = "https://github.com/{repo}/releases/download/v$version/jirac-windows-x86_64.zip".format(repo=REPOSITORY)
+manifest["autoupdate"]["url"] = (
+    "https://github.com/{repo}/releases/download/{tag}$version/{archive}".format(
+        repo=REPOSITORY,
+        tag=SCOOP_RELEASE_TAG_PREFIX,
+        archive=SCOOP_WINDOWS_ARCHIVE,
+    )
+)
 MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")
 print(f"updated {MANIFEST_PATH} -> v{VERSION}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,16 @@ jobs:
             echo "ERROR: README.md must document Scoop installation."
             exit 1
           fi
+          if ! grep -qF "scoop install mulhamna/jirac-mcp" README.md; then
+            echo "ERROR: README.md must document jira-mcp Scoop installation."
+            exit 1
+          fi
           if ! grep -qF "scoop install mulhamna/jirac" INSTALL.md; then
             echo "ERROR: INSTALL.md must document Scoop installation."
+            exit 1
+          fi
+          if ! grep -qF "scoop install mulhamna/jirac-mcp" INSTALL.md; then
+            echo "ERROR: INSTALL.md must document jira-mcp Scoop installation."
             exit 1
           fi
           if ! grep -qF "<!-- contributors:start -->" README.md || ! grep -qF "<!-- contributors:end -->" README.md; then

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -349,6 +349,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.vars.outputs.version }}
+      sha_windows_x86: ${{ steps.vars.outputs.sha_windows_x86 }}
       sha_mcp_macos_arm: ${{ steps.vars.outputs.sha_mcp_macos_arm }}
       sha_mcp_macos_x86: ${{ steps.vars.outputs.sha_mcp_macos_x86 }}
       sha_mcp_linux_arm: ${{ steps.vars.outputs.sha_mcp_linux_arm }}
@@ -372,14 +373,17 @@ jobs:
           SHA_MCP_MACOS_X86=$(grep -E '(^|/)jirac-mcp-macos-x86_64\.tar\.gz$'  checksums.txt | awk '{print $1}')
           SHA_MCP_LINUX_ARM=$(grep -E '(^|/)jirac-mcp-linux-aarch64\.tar\.gz$'  checksums.txt | awk '{print $1}')
           SHA_MCP_LINUX_X86=$(grep -E '(^|/)jirac-mcp-linux-x86_64\.tar\.gz$'   checksums.txt | awk '{print $1}')
+          SHA_WINDOWS_X86=$(grep -E '(^|/)jirac-mcp-windows-x86_64\.zip$' checksums.txt | awk '{print $1}')
 
           test -n "$SHA_MCP_MACOS_ARM"
           test -n "$SHA_MCP_MACOS_X86"
           test -n "$SHA_MCP_LINUX_ARM"
           test -n "$SHA_MCP_LINUX_X86"
+          test -n "$SHA_WINDOWS_X86"
 
           {
             echo "version=$VERSION"
+            echo "sha_windows_x86=$SHA_WINDOWS_X86"
             echo "sha_mcp_macos_arm=$SHA_MCP_MACOS_ARM"
             echo "sha_mcp_macos_x86=$SHA_MCP_MACOS_X86"
             echo "sha_mcp_linux_arm=$SHA_MCP_LINUX_ARM"
@@ -450,4 +454,74 @@ jobs:
           git add Formula/jira-mcp.rb
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: bump jira-mcp to v${VERSION}"
+          git push
+
+  update-scoop-bucket:
+    name: Update Scoop bucket manifest (jira-mcp)
+    runs-on: ubuntu-latest
+    needs: collect-release-metadata
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.collect-release-metadata.outputs.version }}
+      SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
+      REPOSITORY: ${{ github.repository }}
+      SCOOP_BINARY: jirac-mcp
+      SCOOP_RELEASE_TAG_PREFIX: jira-mcp-v
+      SCOOP_WINDOWS_ARCHIVE: jirac-mcp-windows-x86_64.zip
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+          path: repo
+
+      - name: Checkout scoop bucket
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: mulhamna/scoop-bucket
+          token: ${{ secrets.SCOOP_BUCKET_PAT }}
+          path: bucket
+
+      - name: Seed jirac-mcp manifest if missing
+        run: |
+          mkdir -p bucket/bucket
+          if [ ! -f bucket/bucket/jirac-mcp.json ]; then
+            cat > bucket/bucket/jirac-mcp.json <<'EOF'
+            {
+              "version": "0.0.0",
+              "description": "Typed Jira MCP server built in Rust.",
+              "homepage": "https://github.com/mulhamna/jira-commands",
+              "license": [
+                "MIT",
+                "Apache-2.0"
+              ],
+              "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
+              "hash": "",
+              "bin": "jirac-mcp.exe",
+              "checkver": {
+                "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
+                "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
+              },
+              "autoupdate": {
+                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
+              }
+            }
+            EOF
+          fi
+
+      - name: Update Scoop manifest
+        env:
+          SCOOP_MANIFEST_PATH: bucket/bucket/jirac-mcp.json
+        run: python3 repo/.github/scripts/update_scoop_manifest.py
+
+      - name: Commit and push Scoop manifest
+        run: |
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/jirac-mcp.json
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: bump jirac-mcp to v${VERSION}"
           git push

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ Detailed installation guide for `jirac` and `jirac-mcp`.
 | From source          | ✅    | ✅    | ✅      | `cargo install --path` from a local checkout    |
 | npm                  | ✅    | ✅    | ✅      | Downloads prebuilt release binary               |
 | GitHub Releases      | ✅    | ✅    | ✅      | Manual download of archives/binaries            |
-| Scoop                | ❌    | ❌    | ✅      | Custom bucket `mulhamna/scoop-bucket`           |
+| Scoop                | ❌    | ❌    | ✅      | Custom bucket `mulhamna/scoop-bucket` for `jirac` + `jirac-mcp` |
 | Winget               | ❌    | ❌    | ✅      | Windows package manager                         |
 
 ## Homebrew (macOS / Linux)
@@ -62,6 +62,7 @@ powershell -ExecutionPolicy Bypass -Command "& ([scriptblock]::Create((Invoke-We
 ```powershell
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
 scoop install mulhamna/jirac
+scoop install mulhamna/jirac-mcp
 ```
 
 ## Cargo
@@ -125,6 +126,7 @@ If you prefer Scoop, use the custom bucket instead:
 ```powershell
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
 scoop install mulhamna/jirac
+scoop install mulhamna/jirac-mcp
 ```
 
 ## After install

--- a/README.md
+++ b/README.md
@@ -3,16 +3,13 @@
 Jira on the command line.
 
 [![CI](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml/badge.svg)](https://github.com/mulhamna/jira-commands/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/jira-commands.svg)](https://crates.io/crates/jira-commands)
-[![npm](https://img.shields.io/npm/v/%40mulham28%2Fjirac)](https://www.npmjs.com/package/@mulham28/jirac)
-
-[![Homebrew](https://img.shields.io/github/v/release/mulhamna/jira-commands?label=homebrew&color=fbb040)](https://github.com/mulhamna/homebrew-tap)
-[![Winget](https://img.shields.io/winget/v/mulhamna.jirac)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac)
-[![Scoop](https://img.shields.io/badge/dynamic/json?label=scoop&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac.json&color=00b4ff)](https://github.com/mulhamna/scoop-bucket)
-
 [![License: MIT + Apache-2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+
+| `jirac` | `jira-mcp` | `plugin` | `clawhub` |
+| --- | --- | --- | --- |
+| [![crate jirac](https://img.shields.io/crates/v/jira-commands.svg?label=crate)](https://crates.io/crates/jira-commands)<br>[![npm jirac](https://img.shields.io/npm/v/%40mulham28%2Fjirac?label=npm)](https://www.npmjs.com/package/@mulham28/jirac)<br>[![homebrew jirac](https://img.shields.io/badge/homebrew-1.2.2-fbb040)](https://github.com/mulhamna/homebrew-tap/blob/main/Formula/jira-commands.rb)<br>[![scoop jirac](https://img.shields.io/badge/scoop-1.2.2-00b4ff)](https://github.com/mulhamna/scoop-bucket/blob/main/bucket/jirac.json)<br>[![winget jirac](https://img.shields.io/badge/winget-1.2.2-2b579a)](https://github.com/mulhamna/winget-pkgs/tree/main/manifests/m/mulhamna/jirac) | [![crate jira-mcp](https://img.shields.io/crates/v/jira-mcp.svg?label=crate)](https://crates.io/crates/jira-mcp)<br>[![npm jira-mcp](https://img.shields.io/npm/v/%40mulham28%2Fjirac-mcp?label=npm)](https://www.npmjs.com/package/@mulham28/jirac-mcp)<br>[![homebrew jira-mcp](https://img.shields.io/badge/homebrew-1.2.0-fbb040)](https://github.com/mulhamna/homebrew-tap/blob/main/Formula/jira-mcp.rb)<br>[![scoop jira-mcp](https://img.shields.io/badge/scoop-next%20release-f5a623)](https://github.com/mulhamna/scoop-bucket) | [![plugin jira](https://img.shields.io/badge/plugin-0.17.0-7c3aed)](plugin/README.md) | [![clawhub jirac](https://img.shields.io/badge/clawhub-0.1.8-0f766e)](clawhub/jirac/SKILL.md) |
 
 `jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It supports Jira Cloud and Jira Data Center, stores multiple login profiles, and discovers custom fields at runtime so there is little to configure beyond your credentials.
 
@@ -90,6 +87,7 @@ cargo install jira-commands
 # Windows (Scoop)
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
 scoop install mulhamna/jirac
+scoop install mulhamna/jirac-mcp
 
 # Windows (winget)
 winget install mulhamna.jirac

--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -22,6 +22,10 @@ cargo install jira-mcp
 # npm (Node 18+)
 npm install -g @mulham28/jirac-mcp
 
+# Scoop (Windows)
+scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
+scoop install mulhamna/jirac-mcp
+
 # From a local checkout
 cargo install --path crates/jira-mcp --locked
 ```

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -26,6 +26,7 @@ cargo install --path crates/jira-mcp --locked
 Or use one of the workspace-level install options from the root README:
 - Homebrew (`brew tap mulhamna/tap && brew install jira-commands jira-mcp`)
 - npm (`npm install -g @mulham28/jirac` / `@mulham28/jirac-mcp`)
+- Scoop (`scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket && scoop install mulhamna/jirac mulhamna/jirac-mcp`)
 - shell installer on macOS/Linux
 - PowerShell installer on Windows
 - GitHub Releases archives and packaged binaries

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -1,18 +1,19 @@
 # Scoop packaging
 
-This directory documents the Scoop manifest source of truth for `jirac`.
+This directory documents the Scoop manifest source of truth for `jirac` and `jirac-mcp`.
 
 ## Install
 
 ```powershell
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
 scoop install mulhamna/jirac
+scoop install mulhamna/jirac-mcp
 ```
 
 ## Release flow
 
 1. Publish the GitHub release and checksums.
-2. Release CI updates the `jirac.json` manifest in `mulhamna/scoop-bucket`.
-3. Scoop users can install or upgrade with `scoop install mulhamna/jirac` or `scoop update jirac`.
+2. Release CI updates the relevant manifest in `mulhamna/scoop-bucket` (`jirac.json` or `jirac-mcp.json`).
+3. Scoop users can install or upgrade with `scoop install mulhamna/jirac`, `scoop install mulhamna/jirac-mcp`, or the matching `scoop update` command.
 
 The bucket repo is external by design, so this directory is docs-only and the automation lives in the release workflow.


### PR DESCRIPTION
## Summary
- split the root README version badges between `jirac` and `jira-mcp`
- document `scoop install mulhamna/jirac-mcp` across README and install docs
- add jira-mcp release automation to seed and update `mulhamna/scoop-bucket`

## Why
`jira-mcp` already has its own release lane, but the Windows Scoop installation and docs still only cover `jirac`. This PR makes the MCP package visible in docs and prepares the bucket automation for the next `jira-mcp` release.

## Verification
- `python3 -m py_compile .github/scripts/update_scoop_manifest.py .github/scripts/refresh_release_readme.py`
- `git diff --check`

## Notes
This PR prepares the `jirac-mcp` Scoop manifest flow inside `jira-commands`. The first actual `bucket/jirac-mcp.json` publish will happen on the next `jira-mcp` tagged release via `release-tag-mcp.yml`.