### PR TITLE
fix(ci): repair jira-mcp scoop manifest seed step

### DIFF
--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -489,26 +489,26 @@ jobs:
           mkdir -p bucket/bucket
           if [ ! -f bucket/bucket/jirac-mcp.json ]; then
             cat > bucket/bucket/jirac-mcp.json <<'EOF'
-            {
-              "version": "0.0.0",
-              "description": "Typed Jira MCP server built in Rust.",
-              "homepage": "https://github.com/mulhamna/jira-commands",
-              "license": [
-                "MIT",
-                "Apache-2.0"
-              ],
-              "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
-              "hash": "",
-              "bin": "jirac-mcp.exe",
-              "checkver": {
-                "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
-                "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
-              },
-              "autoupdate": {
-                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
-              }
-            }
-            EOF
+{
+  "version": "0.0.0",
+  "description": "Typed Jira MCP server built in Rust.",
+  "homepage": "https://github.com/mulhamna/jira-commands",
+  "license": [
+    "MIT",
+    "Apache-2.0"
+  ],
+  "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
+  "hash": "",
+  "bin": "jirac-mcp.exe",
+  "checkver": {
+    "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
+    "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
+  },
+  "autoupdate": {
+    "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
+  }
+}
+EOF
           fi
 
       - name: Update Scoop manifest


### PR DESCRIPTION
Fixes the broken heredoc in `.github/workflows/release-tag-mcp.yml` so the `update-scoop-bucket` job can seed `jirac-mcp.json` correctly when missing.

This is the root cause behind the failed `jira-mcp-v2.0.0` release rerun.