### PR TITLE
fix(ci): seed jirac-mcp manifest without heredoc

### DIFF
--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -488,27 +488,31 @@ jobs:
         run: |
           mkdir -p bucket/bucket
           if [ ! -f bucket/bucket/jirac-mcp.json ]; then
-            cat > bucket/bucket/jirac-mcp.json <<'EOF'
-{
-  "version": "0.0.0",
-  "description": "Typed Jira MCP server built in Rust.",
-  "homepage": "https://github.com/mulhamna/jira-commands",
-  "license": [
-    "MIT",
-    "Apache-2.0"
-  ],
-  "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
-  "hash": "",
-  "bin": "jirac-mcp.exe",
-  "checkver": {
-    "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
-    "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
-  },
-  "autoupdate": {
-    "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
-  }
-}
-EOF
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            manifest = {
+                "version": "0.0.0",
+                "description": "Typed Jira MCP server built in Rust.",
+                "homepage": "https://github.com/mulhamna/jira-commands",
+                "license": ["MIT", "Apache-2.0"],
+                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
+                "hash": "",
+                "bin": "jirac-mcp.exe",
+                "checkver": {
+                    "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
+                    "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\"",
+                },
+                "autoupdate": {
+                    "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip",
+                },
+            }
+
+            Path("bucket/bucket/jirac-mcp.json").write_text(
+                json.dumps(manifest, indent=2) + "\n"
+            )
+            PY
           fi
 
       - name: Update Scoop manifest


### PR DESCRIPTION
Replaces the brittle heredoc-based seed step in `release-tag-mcp.yml` with an inline Python writer.

Verified facts:
- there was no manual rerun after #287 merge
- the failures after #287 were fresh `push` failures on `main`
- those runs had zero jobs, indicating workflow-level failure before job execution
- `#287` changed the workflow in a way that introduced a new invalid state for GitHub Actions parsing/evaluation

This patch avoids heredoc parsing entirely.