### PR TITLE
fix(jira-mcp): implement Display and std::error::Error for AppError

### DIFF
--- a/crates/jira-mcp/src/error.rs
+++ b/crates/jira-mcp/src/error.rs
@@ -86,6 +86,14 @@ impl AppError {
     }
 }
 
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.stable_code, self.detail)
+    }
+}
+
+impl std::error::Error for AppError {}
+
 impl From<jira_core::JiraError> for AppError {
     fn from(value: jira_core::JiraError) -> Self {
         match value {


### PR DESCRIPTION
## Why

  `AppError` in `crates/jira-mcp/src/error.rs` previously only derived
  `Debug`. This made the type incompatible with:

  - `anyhow::Error::from()` / `?` propagation from contexts expecting
    `std::error::Error`
  - `tracing`'s `error` field (`%err` / `?err`)
  - Standard `{}` formatting in log messages

  ## Changes

  - Implement `std::fmt::Display` using format `<stable_code>: <detail>`
  - Implement `std::error::Error` (no `source` — `AppError` already absorbs
    underlying errors into `detail` via the `From` impls)

  ## Release lane scoping test

  This PR also exercises the dual-lane release-please setup. Edits touch
  **only** `crates/jira-mcp/src/**`, so we expect:

  - ✅ release-please opens **one** PR on lane `jira-mcp` (bump 2.0.0 → 2.0.1)
  - ❌ **No** PR opens on lane `jira-commands`
  - Manifest guard remains green

  ## Verification

  ```bash
  cargo fmt --check
  cargo clippy -p jira-mcp --all-features -- -D warnings
  cargo test -p jira-mcp

  All pass locally (15 tests, 0 warnings).