### PR TITLE
fix(ci): rewrite jira-mcp scoop seed step without nested python heredoc

### DIFF
--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -489,31 +489,24 @@ jobs:
         run: |
           mkdir -p bucket/bucket
           if [ ! -f bucket/bucket/jirac-mcp.json ]; then
-            python3 - <<'PY'
-            import json
-            from pathlib import Path
-
-            manifest = {
-                "version": "0.0.0",
-                "description": "Typed Jira MCP server built in Rust.",
-                "homepage": "https://github.com/mulhamna/jira-commands",
-                "license": ["MIT", "Apache-2.0"],
-                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
-                "hash": "",
-                "bin": "jirac-mcp.exe",
-                "checkver": {
-                    "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
-                    "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\"",
-                },
-                "autoupdate": {
-                    "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip",
-                },
+            cat > bucket/bucket/jirac-mcp.json <<'JSON'
+          {
+            "version": "0.0.0",
+            "description": "Typed Jira MCP server built in Rust.",
+            "homepage": "https://github.com/mulhamna/jira-commands",
+            "license": ["MIT", "Apache-2.0"],
+            "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
+            "hash": "",
+            "bin": "jirac-mcp.exe",
+            "checkver": {
+              "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
+              "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
+            },
+            "autoupdate": {
+              "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
             }
-
-            Path("bucket/bucket/jirac-mcp.json").write_text(
-                json.dumps(manifest, indent=2) + "\n"
-            )
-            PY
+          }
+          JSON
           fi
 
       - name: Update Scoop manifest


### PR DESCRIPTION
## Why

  Every `Release jira-mcp` workflow run since the lane was added has
  failed at the `Seed jirac-mcp manifest if missing` step with:

  warning: here-document at line 3 delimited by end-of-file (wanted `PY')
  syntax error: unexpected end of file

  Root cause: nested heredoc inside a YAML `run: |` block. YAML preserves
  the literal leading whitespace of each line, so the closing `PY`
  delimiter was emitted as `            PY` (12 spaces). Bash never
  matched it as a delimiter — the rest of the script was swallowed into
  the heredoc body until EOF, then bash errored.

  The previous fix attempt (#287) addressed the *other* scoop step
  (`Update Scoop manifest`) but did not touch this seed step.

  ## Changes

  Replace the nested `python3 - <<'PY' ... PY` heredoc with a direct
  `cat > file <<'JSON' ... JSON` heredoc. The closing `JSON` delimiter is
  placed at the YAML base indent level (10 spaces), which YAML strips
  down to column 0, allowing bash to recognize it.

  Behavior unchanged: same JSON manifest content, same placeholder
  version, same target path.

  ## Why we did not notice earlier

  The seed step only matters at cold-start (file missing in scoop-bucket
  repo). When this lane was first wired up, someone manually committed
  `bucket/jirac-mcp.json` to `mulhamna/scoop-bucket` (commit cec392c) as
  a placeholder, which masked the seed-step bug for normal runs that
  should have skipped it. However the `if [ ! -f ... ]` guard somehow
  still let the broken heredoc execute every release run, causing the
  job to fail.

  ## Verification

  After merge, manually re-trigger the v2.0.1 release pipeline to
  complete the scoop publish that failed:

  ```bash
  gh workflow run "Release jira-mcp" -f release_tag=jira-mcp-v2.0.1

  Expected: scoop step passes, mulhamna/scoop-bucket bucket/jirac-mcp.json
  gets bumped from 0.0.0 → 2.0.1 with real SHA + tag URL.

  ### Action 2: Re-run jira-mcp-v2.0.1 release after fix merged

  ```bash
  gh workflow run "Release jira-mcp" -f release_tag=jira-mcp-v2.0.1
  gh run watch

  Idempotent steps that will harmlessly re-run:
  - crates.io publish → skip (already published)
  - npm publish → skip (already published)
  - GitHub Release → exists, will update assets
  - Homebrew formula → idempotent bump
  - Scoop bucket → now succeeds, file 0.0.0 → 2.0.1

  Action 3: (Bonus) Verify local scoop-bucket post-fix

  cd ~/Development/github/scoop-bucket
  git pull origin main
  jq .version bucket/jirac-mcp.json   # expected: "2.0.1"

  ---