### PR TITLE
feat(cli): add issue browser shortcut

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,13 +33,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
 
   # ── 1. CVE scan (rustsec advisory database) ───────────────────────────────
   # Uses plain shell commands instead of rustsec/audit-check action to avoid
@@ -74,7 +74,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2
+      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2
         with:
           command: check all
 
@@ -111,6 +111,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v3
+      - uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
         with:
           sarif_file: scorecard-results.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "1.2.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2892,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ jirac issue list
 # View an issue
 jirac issue view PROJ-123
 jirac issue view PROJ-123 --versions
+jirac PROJ-123 --web
 
 # Browse or manage project fix versions
 jirac issue versions -p PROJ --version "v1.2.0"
@@ -142,6 +143,7 @@ jirac issue sprint-delete -p PROJ --sprint "Sprint 24A" --force
 
 jirac issue view PROJ-123                           # view detail
 jirac issue view PROJ-123 --versions                # include fix-version backlog preview
+jirac PROJ-123 --web                                # open issue in browser
 jirac issue versions -p PROJ                        # list project fix versions
 jirac issue versions -p PROJ --version "v1.2.0"    # preview backlog for one fix version
 jirac issue versions -p PROJ --version "v1.2.0" --set-start-date 2026-05-20

--- a/crates/jira/README.md
+++ b/crates/jira/README.md
@@ -48,6 +48,7 @@ jirac auth profiles
 jirac issue list
 jirac issue view MYPROJ-123
 jirac issue view MYPROJ-123 --versions
+jirac MYPROJ-123 --web
 jirac issue versions -p MYPROJ --version "v1.2.0"
 jirac issue create -p MYPROJ
 jirac issue render --input desc.md

--- a/crates/jira/src/help_text.rs
+++ b/crates/jira/src/help_text.rs
@@ -18,6 +18,7 @@ pub const ROOT_LONG_ABOUT: &str = concat!(
     "Quick start:\n",
     "  jirac auth login                       Set up credentials\n",
     "  jirac issue list                       List your assigned issues\n",
+    "  jirac PROJ-123 --web                   Open an issue in your browser\n",
     "  jirac issue standup                    Generate a daily standup summary\n",
     "  jirac issue sprint-summary -p MYPROJ   Summarize the current sprint\n",
     "  jirac issue sprints -p MYPROJ          List project sprints and states\n",

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -9,11 +9,20 @@ use tracing_subscriber::{fmt, EnvFilter};
     name = "jirac",
     about = "jirac — terminal client for the Jira ecosystem",
     long_about = help_text::ROOT_LONG_ABOUT,
-    version
+    version,
+    args_conflicts_with_subcommands = true
 )]
 struct Cli {
+    /// Issue key shortcut. Use with --web to open in Jira.
+    #[arg(value_name = "ISSUE")]
+    issue: Option<String>,
+
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
+
+    /// Open the issue shortcut in your browser (for example: jirac PROJ-123 --web)
+    #[arg(long, requires = "issue")]
+    web: bool,
 
     /// Enable verbose logging (sets RUST_LOG=debug)
     #[arg(short, long, global = true)]
@@ -81,7 +90,21 @@ async fn main() -> Result<()> {
 
     fmt().with_env_filter(filter).with_target(false).init();
 
-    match cli.command {
+    if let Some(issue) = cli.issue {
+        if cli.web {
+            open_issue_shortcut(&issue)?;
+            if let Some(notice) = &update_notice {
+                eprintln!("{}", version_check::cli_message(notice));
+            }
+            return Ok(());
+        }
+    }
+
+    let Some(command) = cli.command else {
+        anyhow::bail!("No command provided. Run `jirac --help` for usage.");
+    };
+
+    match command {
         Commands::Auth { command } => {
             cli::auth::handle(command).await?;
             if let Some(notice) = &update_notice {
@@ -126,6 +149,30 @@ async fn main() -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn open_issue_shortcut(issue: &str) -> Result<()> {
+    let config = JiraConfig::load().unwrap_or_default();
+
+    if config.base_url.is_empty() {
+        anyhow::bail!(
+            "Jira URL not configured. Run `jirac auth login` or set JIRA_URL environment variable."
+        );
+    }
+
+    let issue = issue.trim();
+    if issue.is_empty() {
+        anyhow::bail!("Issue key cannot be empty.");
+    }
+    if !issue.contains('-') {
+        anyhow::bail!("Issue shortcut expects a full issue key like `PROJ-123`.");
+    }
+
+    let base = config.base_url.trim_end_matches('/');
+    let url = format!("{base}/browse/{issue}");
+    open::that(&url).with_context(|| format!("Failed to open browser for {issue}"))?;
+    println!("Opened {url}");
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Adds a small CLI shortcut to open a Jira issue directly from the shell:

```bash
jirac PROJ-123 --web
```

This PR also folds in the two open Dependabot updates so the dependency bumps stay separate from the feature commit while avoiding multiple tiny PRs.

Dependabot updates included:
- `serde_json` `1.0.149` -> `1.0.150`
- pinned security workflow actions:
  - `github/codeql-action` `4.35.5` -> `4.36.0`
  - `EmbarkStudios/cargo-deny-action` `2.0.18` -> `2.0.19`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No dedicated regression test was added because this is a thin clap entrypoint plus `open::that` integration. Existing CLI regression jobs cover parser compatibility, and local/manual validation confirms the shortcut parses without breaking existing subcommands.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

Workflow changes are Dependabot-only pin bumps for existing security workflow actions. No workflow logic or permissions changed.

`jirac PROJ-123 --web` launches the configured Jira browser URL locally; it does not add a network client path in `jira-core`.

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

Commit split is intentional:
1. `chore(deps): bump serde_json`
2. `chore(deps): bump GitHub Actions pins`
3. `feat(cli): add issue browser shortcut`

Validation run locally:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo audit`
- `cargo run --quiet --bin jirac -- --help`
- `cargo run --quiet --bin jirac -- issue --help`
- `cargo run --quiet --bin jirac -- PROJ-123 --web` (expected config error without Jira URL in this environment)

## Related
Close #297 
Close #298 
