### PR TITLE
feat(cli): add Antigravity MCP client

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -175,6 +175,7 @@ jirac mcp install --client codex
 jirac mcp install --client opencode
 jirac mcp install --client generic-json
 jirac mcp install --client zed
+jirac mcp install --client antigravity
 ```
 
 Supported targets now:
@@ -186,6 +187,7 @@ Supported targets now:
 - `opencode` (`~/.config/opencode/opencode.jsonc`, direct JSONC write)
 - `generic-json` (prints a portable JSON snippet instead of writing a file)
 - `zed` (`~/.config/zed/settings.json` on Linux, `~/Library/Application Support/Zed/settings.json` on macOS, `%APPDATA%/Zed/settings.json` on Windows; seeds `context_servers.jira.settings` for the official Zed marketplace extension published from <https://github.com/mulhamna/jirac-ext>)
+- `antigravity` (`~/.gemini/antigravity/mcp_config.json`, user-level JSON with `mcpServers`)
 
 Helpful flags:
 - `--print` prints the JSON snippet or delegated client command first
@@ -207,3 +209,4 @@ Local verification notes:
 - Claude Desktop user scope writes the platform support directory (`claude_desktop_config.json`); override with `CLAUDE_DESKTOP_CONFIG`
 - Gemini CLI currently stores user MCP config in `~/.gemini/settings.json`; this helper delegates to the Gemini CLI directly
 - Codex stores MCP entries under `~/.codex/config.toml`; this helper delegates to the Codex CLI directly
+- Antigravity user scope writes `~/.gemini/antigravity/mcp_config.json` (top-level `mcpServers`); override with `ANTIGRAVITY_CONFIG`

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -48,6 +48,7 @@ pub enum McpClient {
     OpenCode,
     GenericJson,
     Zed,
+    Antigravity,
 }
 
 impl std::fmt::Display for McpClient {
@@ -62,6 +63,9 @@ impl std::fmt::Display for McpClient {
             McpClient::GeminiCli => "gemini-cli         (delegates to `gemini mcp add`)",
             McpClient::OpenCode => "opencode           (writes opencode.jsonc)",
             McpClient::Zed => "zed                (writes Zed settings.json context_servers)",
+            McpClient::Antigravity => {
+                "antigravity        (writes ~/.gemini/antigravity/mcp_config.json)"
+            }
             McpClient::GenericJson => "generic-json       (print snippet only, no file changes)",
         };
         f.write_str(label)
@@ -150,6 +154,7 @@ fn run_interactive_prereqs_and_pick(server_command: &str) -> Result<McpClient> {
             McpClient::GeminiCli,
             McpClient::OpenCode,
             McpClient::Zed,
+            McpClient::Antigravity,
             McpClient::GenericJson,
         ],
     )
@@ -280,6 +285,7 @@ fn doctor(client: Option<McpClient>, command: &str) -> Result<()> {
             McpClient::OpenCode,
             McpClient::GenericJson,
             McpClient::Zed,
+            McpClient::Antigravity,
         ],
     };
 
@@ -420,6 +426,14 @@ fn install_target(client: &McpClient) -> Result<InstallTarget> {
         McpClient::OpenCode => ("opencode", opencode_settings_path(&home), "mcp"),
         McpClient::GeminiCli | McpClient::Codex | McpClient::GenericJson => unreachable!(),
         McpClient::Zed => ("zed", zed_settings_path(&home), "context_servers"),
+        McpClient::Antigravity => (
+            "antigravity",
+            config_path_from_env_or_default(
+                "ANTIGRAVITY_CONFIG",
+                home.join(".gemini/antigravity/mcp_config.json"),
+            ),
+            "mcpServers",
+        ),
     };
 
     Ok(InstallTarget {
@@ -479,6 +493,13 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
                 .map(|t| t.path)
                 .unwrap_or_else(|_| PathBuf::from("~/.config/zed/settings.json")),
             note: "Writes context_servers.jira.settings for the Zed marketplace extension.",
+        },
+        McpClient::Antigravity => ClientDescriptor::FileTarget {
+            label: "antigravity",
+            path: install_target(client)
+                .map(|t| t.path)
+                .unwrap_or_else(|_| PathBuf::from("~/.gemini/antigravity/mcp_config.json")),
+            note: "Writes user-level config at ~/.gemini/antigravity/mcp_config.json (mcpServers).",
         },
     }
 }

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -1013,6 +1013,24 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_install_target_uses_mcp_servers() {
+        let target = install_target(&McpClient::Antigravity).unwrap();
+        assert_eq!(target.label, "antigravity");
+        assert_eq!(target.top_level_key, "mcpServers");
+        assert!(target.path.ends_with(".gemini/antigravity/mcp_config.json"));
+    }
+
+    #[test]
+    fn antigravity_snippet_uses_standard_mcp_servers_shape() {
+        let snippet =
+            server_spec(&McpClient::Antigravity, "jira", "jirac-mcp", "stdio").json_snippet;
+        let rendered = serde_json::to_string_pretty(&snippet).unwrap();
+        assert!(rendered.contains("\"mcpServers\""));
+        assert!(rendered.contains("\"jira\""));
+        assert!(rendered.contains("\"jirac-mcp\""));
+    }
+
+    #[test]
     fn merge_string_values_only_overwrites_requested_keys() {
         let mut target = Map::new();
         target.insert(


### PR DESCRIPTION
## Description

Adds Antigravity as a supported `jirac mcp install --client` target.

This writes the Jira MCP server entry to the user-level Antigravity config:

```text
~/.gemini/antigravity/mcp_config.json
```

using the standard `mcpServers` top-level key. The path can also be overridden with `ANTIGRAVITY_CONFIG`, matching the existing env override style used by other file-backed clients.

`INSTALL.md` is updated so the documented helper list matches the CLI.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

This PR adds focused MCP unit coverage for the Antigravity target path/top-level key and emitted snippet shape.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

Verification run locally:

```bash
cargo fmt --all --check
cargo test -p jira-commands mcp --lib
cargo clippy -p jira-commands --lib -- -D warnings
ANTIGRAVITY_CONFIG=$(mktemp -d)/mcp_config.json cargo run -q -p jira-commands -- mcp install --client antigravity --name jira --command jirac-mcp --transport stdio
```

The temp install output was validated as:

```json
{"mcpServers":{"jira":{"command":"jirac-mcp","args":["serve","--transport","stdio"]}}}
```
