### PR TITLE
fix(release): split CLI and MCP release assets

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -106,33 +106,23 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: jirac-linux-x86_64
-            mcp_artifact: jirac-mcp-linux-x86_64
             archive_artifact: jirac-linux-x86_64.tar.gz
-            mcp_archive_artifact: jirac-mcp-linux-x86_64.tar.gz
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: jirac-linux-aarch64
-            mcp_artifact: jirac-mcp-linux-aarch64
             archive_artifact: jirac-linux-aarch64.tar.gz
-            mcp_archive_artifact: jirac-mcp-linux-aarch64.tar.gz
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact: jirac-macos-x86_64
-            mcp_artifact: jirac-mcp-macos-x86_64
             archive_artifact: jirac-macos-x86_64.tar.gz
-            mcp_archive_artifact: jirac-mcp-macos-x86_64.tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: jirac-macos-aarch64
-            mcp_artifact: jirac-mcp-macos-aarch64
             archive_artifact: jirac-macos-aarch64.tar.gz
-            mcp_archive_artifact: jirac-mcp-macos-aarch64.tar.gz
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: jirac-windows-x86_64.exe
-            mcp_artifact: jirac-mcp-windows-x86_64.exe
             archive_artifact: jirac-windows-x86_64.zip
-            mcp_archive_artifact: jirac-mcp-windows-x86_64.zip
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -156,61 +146,48 @@ jobs:
 
       - name: Build (zigbuild — Linux x86_64)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
+        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17 -p jira-commands
 
       - name: Build (zigbuild — Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.17 -p jira-commands -p jira-mcp
+        run: cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.17 -p jira-commands
 
       - name: Build (native)
         if: matrix.target != 'x86_64-unknown-linux-gnu' && matrix.target != 'aarch64-unknown-linux-gnu'
-        run: cargo build --release --target ${{ matrix.target }} -p jira-commands -p jira-mcp
+        run: cargo build --release --target ${{ matrix.target }} -p jira-commands
 
       - name: Copy binaries (Unix)
         if: matrix.os != 'windows-latest'
         run: |
           cp target/${{ matrix.target }}/release/jirac ${{ matrix.artifact }}
-          cp target/${{ matrix.target }}/release/jirac-mcp ${{ matrix.mcp_artifact }}
 
       - name: Copy binaries (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           Copy-Item target/${{ matrix.target }}/release/jirac.exe ${{ matrix.artifact }}
-          Copy-Item target/${{ matrix.target }}/release/jirac-mcp.exe ${{ matrix.mcp_artifact }}
 
       - name: Package archives (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          mkdir -p dist/jirac dist/jirac-mcp
+          mkdir -p dist/jirac
           cp ${{ matrix.artifact }} dist/jirac/
-          cp ${{ matrix.mcp_artifact }} dist/jirac-mcp/
           cp README.md LICENSE-MIT LICENSE-APACHE dist/jirac/
-          cp README.md LICENSE-MIT LICENSE-APACHE dist/jirac-mcp/
           tar -czf ${{ matrix.archive_artifact }} -C dist/jirac .
-          tar -czf ${{ matrix.mcp_archive_artifact }} -C dist/jirac-mcp .
 
       - name: Package archives (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist/jirac, dist/jirac-mcp | Out-Null
+          New-Item -ItemType Directory -Force -Path dist/jirac | Out-Null
           Copy-Item ${{ matrix.artifact }} dist/jirac/
-          Copy-Item ${{ matrix.mcp_artifact }} dist/jirac-mcp/
           Copy-Item README.md, LICENSE-MIT, LICENSE-APACHE dist/jirac/
-          Copy-Item README.md, LICENSE-MIT, LICENSE-APACHE dist/jirac-mcp/
           Compress-Archive -Path dist/jirac/* -DestinationPath ${{ matrix.archive_artifact }}
-          Compress-Archive -Path dist/jirac-mcp/* -DestinationPath ${{ matrix.mcp_archive_artifact }}
 
       - name: Generate build provenance attestation (jirac)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: ${{ matrix.artifact }}
-
-      - name: Generate build provenance attestation (jirac-mcp)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-path: ${{ matrix.mcp_artifact }}
 
       - name: Upload artifact (jirac)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -219,15 +196,6 @@ jobs:
           path: |
             ${{ matrix.artifact }}
             ${{ matrix.archive_artifact }}
-          if-no-files-found: error
-
-      - name: Upload artifact (jirac-mcp)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.mcp_artifact }}
-          path: |
-            ${{ matrix.mcp_artifact }}
-            ${{ matrix.mcp_archive_artifact }}
           if-no-files-found: error
 
 
@@ -320,11 +288,7 @@ jobs:
             -name 'jirac-*' -o \
             -name 'jirac-*.exe' -o \
             -name 'jirac-*.tar.gz' -o \
-            -name 'jirac-*.zip' -o \
-            -name 'jirac-mcp-*' -o \
-            -name 'jirac-mcp-*.exe' -o \
-            -name 'jirac-mcp-*.tar.gz' -o \
-            -name 'jirac-mcp-*.zip' \
+            -name 'jirac-*.zip' \
           \) -print0 | sort -z | while IFS= read -r -d '' file; do
             sha256sum "$file" >> checksums.txt
           done
@@ -336,8 +300,8 @@ jobs:
           cat > release-notes-footer.md <<'EOF'
           ## Packaging notes
 
-          - Release artifacts ship `jirac` (CLI) and `jirac-mcp` (MCP server) binaries.
-          - The `jira-mcp` crate (crates.io) and `@mulham28/jirac-mcp` npm package are published on the separate `jira-mcp-v*` tag lane — only the binaries are attached here so the Zed extension keeps resolving from "latest release".
+          - Release artifacts ship `jirac` (CLI) binaries only.
+          - `jirac-mcp` binaries, the `jira-mcp` crate (crates.io), and `@mulham28/jirac-mcp` npm package are published on the separate `jira-mcp-v*` tag lane.
           - Windows installer entrypoint: `install.ps1`.
           - Winget source manifests live in `packaging/winget/` and should be updated from the published release artifacts before submission.
           - If you still have scripts that call `jira`, update them to `jirac` before using this release.


### PR DESCRIPTION
## Summary
- stop attaching `jirac-mcp` artifacts to the root `v*` release lane
- keep the root release workflow building and packaging only `jirac`
- update release notes to point MCP users at the separate `jira-mcp-v*` lane

## Why
The repo already has a dedicated MCP release lane, but the root release workflow was still publishing `jirac-mcp` assets. This makes the release assets look unsplit and creates ambiguity for downstream package lanes.