### PR TITLE
ci: add jira-mcp winget submit workflow

### DIFF
--- a/.github/scripts/submit-winget-pr.py
+++ b/.github/scripts/submit-winget-pr.py
@@ -10,15 +10,38 @@ SHA_WINDOWS_X86 = os.environ['SHA_WINDOWS_X86']
 RELEASE_DATE = os.environ['RELEASE_DATE']
 FORK_REPO = os.environ.get('WINGET_FORK_REPO', 'mulhamna/winget-pkgs')
 UPSTREAM_REPO = os.environ.get('WINGET_UPSTREAM_REPO', 'microsoft/winget-pkgs')
-BRANCH = f'chore/jirac-winget-v{VERSION}'
-TITLE = f'Add version: mulhamna.jirac version {VERSION}'
-BODY = f'Automated submission for jirac {VERSION} generated from the published GitHub release assets.'
+PACKAGE_IDENTIFIER = os.environ.get('WINGET_PACKAGE_IDENTIFIER', 'mulhamna.jirac')
+PACKAGE_NAME = os.environ.get('WINGET_PACKAGE_NAME', 'jirac')
+PACKAGE_MONIKER = os.environ.get('WINGET_PACKAGE_MONIKER', PACKAGE_NAME)
+PACKAGE_DESCRIPTION = os.environ.get(
+    'WINGET_PACKAGE_DESCRIPTION',
+    'jirac is a Rust-based Jira CLI with interactive TUI flows, issue transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.',
+)
+PACKAGE_SHORT_DESCRIPTION = os.environ.get(
+    'WINGET_PACKAGE_SHORT_DESCRIPTION',
+    'Jira terminal client with TUI, MCP support, and release archives for Windows, macOS, and Linux.',
+)
+PACKAGE_TAGS = [tag for tag in os.environ.get('WINGET_PACKAGE_TAGS', 'jira,atlassian,cli,tui,mcp').split(',') if tag]
+RELEASE_TAG_PREFIX = os.environ.get('WINGET_RELEASE_TAG_PREFIX', 'v')
+WINDOWS_ARCHIVE = os.environ.get('WINGET_WINDOWS_ARCHIVE', 'jirac-windows-x86_64.zip')
+NESTED_INSTALLER_FILE = os.environ.get('WINGET_NESTED_INSTALLER_FILE', 'jirac-windows-x86_64.exe')
+PORTABLE_COMMAND_ALIAS = os.environ.get('WINGET_PORTABLE_COMMAND_ALIAS', 'jirac')
+BRANCH_PREFIX = os.environ.get('WINGET_BRANCH_PREFIX', 'jirac-winget')
+BRANCH = f'chore/{BRANCH_PREFIX}-v{VERSION}'
+TITLE = f'Add version: {PACKAGE_IDENTIFIER} version {VERSION}'
+BODY = f'Automated submission for {PACKAGE_NAME} {VERSION} generated from the published GitHub release assets.'
 FORK_BRANCH_URL = f'https://github.com/{FORK_REPO}/tree/{BRANCH}'
 COMPARE_URL = f'https://github.com/{UPSTREAM_REPO}/compare/master...{FORK_REPO.split("/")[0]}:{BRANCH}?expand=1'
 
 
 def run(cmd, cwd=None, check=True, capture_output=False):
     return subprocess.run(cmd, cwd=cwd, check=check, text=True, capture_output=capture_output)
+
+
+parts = PACKAGE_IDENTIFIER.split('.', 2)
+if len(parts) != 2:
+    raise SystemExit(f'Expected WINGET_PACKAGE_IDENTIFIER like publisher.package, got: {PACKAGE_IDENTIFIER!r}')
+publisher_slug, package_slug = parts
 
 with tempfile.TemporaryDirectory() as tmp:
     repo_dir = Path(tmp) / 'winget-pkgs'
@@ -28,54 +51,51 @@ with tempfile.TemporaryDirectory() as tmp:
     run(['git', 'config', 'user.email', 'mulhamna@gmail.com'], cwd=repo_dir)
     run(['git', 'switch', '-C', BRANCH], cwd=repo_dir)
 
-    manifest_dir = repo_dir / 'manifests' / 'm' / 'mulhamna' / 'jirac' / VERSION
+    manifest_dir = repo_dir / 'manifests' / publisher_slug[0].lower() / publisher_slug / package_slug / VERSION
     manifest_dir.mkdir(parents=True, exist_ok=True)
+    tags_yaml = '\n'.join(f'  - {tag}' for tag in PACKAGE_TAGS)
 
     files = {
-        manifest_dir / 'mulhamna.jirac.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
-PackageIdentifier: mulhamna.jirac
+        manifest_dir / f'{PACKAGE_IDENTIFIER}.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: {PACKAGE_IDENTIFIER}
 PackageVersion: {VERSION}
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0
 ''',
-        manifest_dir / 'mulhamna.jirac.installer.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
-PackageIdentifier: mulhamna.jirac
+        manifest_dir / f'{PACKAGE_IDENTIFIER}.installer.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: {PACKAGE_IDENTIFIER}
 PackageVersion: {VERSION}
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
-  - RelativeFilePath: jirac-windows-x86_64.exe
-    PortableCommandAlias: jirac
+  - RelativeFilePath: {NESTED_INSTALLER_FILE}
+    PortableCommandAlias: {PORTABLE_COMMAND_ALIAS}
 ReleaseDate: {RELEASE_DATE}
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v{VERSION}/jirac-windows-x86_64.zip
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/{RELEASE_TAG_PREFIX}{VERSION}/{WINDOWS_ARCHIVE}
     InstallerSha256: {SHA_WINDOWS_X86}
 ManifestType: installer
 ManifestVersion: 1.9.0
 ''',
-        manifest_dir / 'mulhamna.jirac.locale.en-US.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
-PackageIdentifier: mulhamna.jirac
+        manifest_dir / f'{PACKAGE_IDENTIFIER}.locale.en-US.yaml': f'''# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: {PACKAGE_IDENTIFIER}
 PackageVersion: {VERSION}
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna
 PublisherSupportUrl: https://github.com/mulhamna/jira-commands/issues
 Author: mulhamna
-PackageName: jirac
+PackageName: {PACKAGE_NAME}
 PackageUrl: https://github.com/mulhamna/jira-commands
 License: MIT OR Apache-2.0
 LicenseUrl: https://github.com/mulhamna/jira-commands/blob/main/LICENSE
-ShortDescription: Jira terminal client with TUI, MCP support, and release archives for Windows, macOS, and Linux.
-Description: jirac is a Rust-based Jira CLI with interactive TUI flows, issue transitions, comments, worklogs, attachments, and jirac-mcp for editor and agent integrations.
-Moniker: jirac
+ShortDescription: {PACKAGE_SHORT_DESCRIPTION}
+Description: {PACKAGE_DESCRIPTION}
+Moniker: {PACKAGE_MONIKER}
 Tags:
-  - jira
-  - atlassian
-  - cli
-  - tui
-  - mcp
+{tags_yaml}
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0
 ''',

--- a/.github/workflows/winget-submit-mcp.yml
+++ b/.github/workflows/winget-submit-mcp.yml
@@ -1,0 +1,107 @@
+name: Winget Submit jira-mcp
+
+on:
+  workflow_run:
+    workflows: ["Release jira-mcp"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to submit, for example jira-mcp-v0.5.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: winget-submit-mcp-${{ github.event.workflow_run.head_sha || github.event.inputs.release_tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  submit-winget:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.name == 'Release jira-mcp' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}
+    steps:
+      - name: Require Winget token
+        run: test -n "${GH_TOKEN}"
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: vars
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="${{ inputs.release_tag }}"
+          else
+            RELEASE_TAG=$(git tag --points-at "${{ github.event.workflow_run.head_sha }}" | grep '^jira-mcp-v' | head -n 1 || true)
+          fi
+
+          case "$RELEASE_TAG" in
+            jira-mcp-v*) ;;
+            *)
+              echo "Skipping Winget submit because no jira-mcp release tag could be resolved for '$RELEASE_TAG'."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if ! gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Skipping Winget submit because GitHub release '$RELEASE_TAG' is not published yet."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${RELEASE_TAG#jira-mcp-v}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows ZIP and compute Winget SHA
+        if: steps.vars.outputs.skip != 'true'
+        id: checksums
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ steps.vars.outputs.release_tag }}"
+          RELEASE_DATE=$(date -u +%F)
+          ASSET_URL="https://github.com/mulhamna/jira-commands/releases/download/${RELEASE_TAG}/jirac-mcp-windows-x86_64.zip"
+          curl -fsSL "$ASSET_URL" -o jirac-mcp-windows-x86_64.zip
+          SHA_WINDOWS_X86=$(sha256sum jirac-mcp-windows-x86_64.zip | awk '{print $1}')
+          test -n "$SHA_WINDOWS_X86"
+          echo "sha_windows_x86=$SHA_WINDOWS_X86" >> "$GITHUB_OUTPUT"
+          echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Submit Winget PR
+        if: steps.vars.outputs.skip != 'true'
+        run: python3 .github/scripts/submit-winget-pr.py
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PKGS_TOKEN }}
+          VERSION: ${{ steps.vars.outputs.version }}
+          SHA_WINDOWS_X86: ${{ steps.checksums.outputs.sha_windows_x86 }}
+          RELEASE_DATE: ${{ steps.checksums.outputs.release_date }}
+          WINGET_PACKAGE_IDENTIFIER: mulhamna.jirac-mcp
+          WINGET_PACKAGE_NAME: jirac-mcp
+          WINGET_PACKAGE_MONIKER: jirac-mcp
+          WINGET_PACKAGE_SHORT_DESCRIPTION: Typed Jira MCP server built in Rust.
+          WINGET_PACKAGE_DESCRIPTION: jirac-mcp exposes Jira as typed MCP tools for editors and AI agents, with release archives for Windows, macOS, and Linux.
+          WINGET_PACKAGE_TAGS: jira,atlassian,cli,mcp,ai
+          WINGET_RELEASE_TAG_PREFIX: jira-mcp-v
+          WINGET_WINDOWS_ARCHIVE: jirac-mcp-windows-x86_64.zip
+          WINGET_NESTED_INSTALLER_FILE: jirac-mcp-windows-x86_64.exe
+          WINGET_PORTABLE_COMMAND_ALIAS: jirac-mcp
+          WINGET_BRANCH_PREFIX: jirac-mcp-winget


### PR DESCRIPTION
## Summary
- add a dedicated `winget-submit-mcp.yml` workflow triggered by successful `Release jira-mcp` runs
- generalize the Winget submission script so CLI and MCP lanes can share the same submission logic
- parameterize package id, asset names, command alias, and release tag prefix for the MCP package

## Validation
- `python3 -m py_compile .github/scripts/submit-winget-pr.py`
