### PR TITLE
fix(mcp): align antigravity-cli config target

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -188,7 +188,7 @@ Supported targets now:
 - `generic-json` (prints a portable JSON snippet instead of writing a file)
 - `zed` (`~/.config/zed/settings.json` on Linux, `~/Library/Application Support/Zed/settings.json` on macOS, `%APPDATA%/Zed/settings.json` on Windows; seeds `context_servers.jira.settings` for the official Zed marketplace extension published from <https://github.com/mulhamna/jirac-ext>)
 - `antigravity` (`~/.gemini/antigravity/mcp_config.json`, user-level JSON with `mcpServers`)
-- `antigravity-cli` (`~/.gemini/antigravity-cli/settings.json`, user-level JSON with `mcp.servers`)
+- `antigravity-cli` (`~/.gemini/config/mcp_config.json`, user-level JSON with `mcpServers`)
 
 Helpful flags:
 - `--print` prints the JSON snippet or delegated client command first
@@ -211,5 +211,5 @@ Local verification notes:
 - Gemini CLI currently stores user MCP config in `~/.gemini/settings.json`; this helper delegates to the Gemini CLI directly
 - Codex stores MCP entries under `~/.codex/config.toml`; this helper delegates to the Codex CLI directly
 - Antigravity user scope writes `~/.gemini/antigravity/mcp_config.json` (top-level `mcpServers`); override with `ANTIGRAVITY_CONFIG`
-- Antigravity CLI user scope writes `~/.gemini/antigravity-cli/settings.json` (`mcp.servers`); override with `ANTIGRAVITY_CLI_CONFIG`
+- Antigravity CLI user scope writes `~/.gemini/config/mcp_config.json` (`mcpServers`); override with `ANTIGRAVITY_CLI_CONFIG`
 - For local-binary clients, `jirac mcp install` requires `jirac-mcp` on PATH. Install it with `cargo install jira-mcp`, download a release binary, or pass `--command /path/to/jirac-mcp`.

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -69,7 +69,7 @@ impl std::fmt::Display for McpClient {
                 "antigravity        (writes ~/.gemini/antigravity/mcp_config.json)"
             }
             McpClient::AntigravityCli => {
-                "antigravity-cli    (writes ~/.gemini/antigravity-cli/settings.json)"
+                "antigravity-cli    (writes ~/.gemini/config/mcp_config.json)"
             }
             McpClient::GenericJson => "generic-json       (print snippet only, no file changes)",
         };
@@ -390,23 +390,6 @@ fn server_spec(client: &McpClient, name: &str, command: &str, transport: &str) -
                 json_snippet,
             }
         }
-        McpClient::AntigravityCli => {
-            let file_entry = json!({
-                "command": command,
-                "args": ["serve", "--transport", transport]
-            });
-            let json_snippet = json!({
-                "mcp": {
-                    "servers": {
-                        name: file_entry.clone()
-                    }
-                }
-            });
-            ServerSpec {
-                file_entry,
-                json_snippet,
-            }
-        }
         _ => {
             let file_entry = json!({
                 "command": command,
@@ -462,9 +445,9 @@ fn install_target(client: &McpClient) -> Result<InstallTarget> {
             "antigravity-cli",
             config_path_from_env_or_default(
                 "ANTIGRAVITY_CLI_CONFIG",
-                home.join(".gemini/antigravity-cli/settings.json"),
+                home.join(".gemini/config/mcp_config.json"),
             ),
-            "mcp.servers",
+            "mcpServers",
         ),
     };
 
@@ -537,8 +520,8 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
             label: "antigravity-cli",
             path: install_target(client)
                 .map(|t| t.path)
-                .unwrap_or_else(|_| PathBuf::from("~/.gemini/antigravity-cli/settings.json")),
-            note: "Writes user-level config at ~/.gemini/antigravity-cli/settings.json (mcp.servers).",
+                .unwrap_or_else(|_| PathBuf::from("~/.gemini/config/mcp_config.json")),
+            note: "Writes user-level config at ~/.gemini/config/mcp_config.json (mcpServers).",
         },
     }
 }
@@ -1079,13 +1062,11 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_cli_install_target_uses_settings_json_mcp_servers() {
+    fn antigravity_cli_install_target_uses_shared_gemini_mcp_config() {
         let target = install_target(&McpClient::AntigravityCli).unwrap();
         assert_eq!(target.label, "antigravity-cli");
-        assert_eq!(target.top_level_key, "mcp.servers");
-        assert!(target
-            .path
-            .ends_with(".gemini/antigravity-cli/settings.json"));
+        assert_eq!(target.top_level_key, "mcpServers");
+        assert!(target.path.ends_with(".gemini/config/mcp_config.json"));
     }
 
     #[test]
@@ -1099,12 +1080,11 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_cli_snippet_uses_mcp_servers_shape() {
+    fn antigravity_cli_snippet_uses_standard_mcp_servers_shape() {
         let snippet =
             server_spec(&McpClient::AntigravityCli, "jira", "jirac-mcp", "stdio").json_snippet;
         let rendered = serde_json::to_string_pretty(&snippet).unwrap();
-        assert!(rendered.contains("\"mcp\""));
-        assert!(rendered.contains("\"servers\""));
+        assert!(rendered.contains("\"mcpServers\""));
         assert!(rendered.contains("\"jira\""));
         assert!(rendered.contains("\"jirac-mcp\""));
     }


### PR DESCRIPTION
## Description

Align the `antigravity-cli` MCP installer target with the config file and JSON shape the CLI appears to read in practice.

Based on the local runtime evidence from `~/.gemini/antigravity-cli/cli.log`, `antigravity-cli` is attempting to load MCP config from:

- `/Users/telkom/.gemini/config/mcp_config.json`

and expects a top-level `mcpServers` object there. Our current helper instead writes to:

- `~/.gemini/antigravity-cli/settings.json`
- nested `mcp.servers`

So even when `jirac mcp install --client antigravity-cli` succeeds, the generated config can land in the wrong place and wrong shape for the consuming CLI.

This PR updates the target path/shape, refreshes the install notes, and adds regression coverage around the target path and snippet structure.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

Validation run for this patch:

- `cargo test antigravity_cli --package jira-commands`
- `cargo test antigravity_install_target_uses_mcp_servers --package jira-commands`

One caveat: the path/shape change is grounded in observed runtime logs and the sample config that successfully unblocks local use, not yet in upstream antigravity-cli source/docs reviewed in this branch.
