### PR TITLE
feat(mcp): add jira issue clone tool

### DIFF
--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -75,6 +75,7 @@ The MCP server includes tools for:
 
 - Current focus is tools, not prompts/resources/UI.
 - Destructive operations require `confirm: true`.
+- `jira_issue_clone` can optionally delete the source issue with `move_original: true`, but only when `confirm: true` is also set.
 - Attachment uploads support local file paths or inline base64 payloads.
 
 ## Client install helper

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -21,9 +21,9 @@ use crate::{
     error::{AppError, AppResult},
     models::{
         ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BulkTransitionArgs,
-        BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs,
-        IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs,
-        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
+        BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs,
+        IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs,
+        IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
         ProjectVersionCreateArgs, ProjectVersionUpdateArgs, RemoteLinkAddArgs,
         RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs,
         SprintListArgs, SprintUpdateArgs, WorklogAddArgs, WorklogDeleteArgs,
@@ -430,6 +430,83 @@ impl JiraApp {
         Ok(json!({
             "key": args.key,
             "deleted": true
+        }))
+    }
+
+    pub async fn issue_clone(&self, args: IssueCloneArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let source = client.get_issue(&args.key).await?;
+        let target_project = args
+            .project_key
+            .unwrap_or_else(|| source.project_key.clone());
+        let summary = args.summary.unwrap_or_else(|| source.summary.clone());
+
+        let labels: Vec<String> = source
+            .fields
+            .get("labels")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let components: Vec<String> = source
+            .fields
+            .get("components")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|c| c.get("name").and_then(|n| n.as_str()))
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let fix_versions: Vec<String> = source
+            .fields
+            .get("fixVersions")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let cloned = client
+            .create_issue_v2(CreateIssueRequestV2 {
+                project_key: target_project,
+                summary,
+                description: None,
+                description_adf: source.description.clone(),
+                issue_type: source.issue_type.clone(),
+                assignee: args.assignee,
+                priority: source.priority.clone(),
+                labels,
+                components,
+                parent: None,
+                fix_versions,
+                custom_fields: HashMap::new(),
+            })
+            .await?;
+
+        let move_original = args.move_original.unwrap_or(false);
+        let mut deleted_original = false;
+        if move_original {
+            require_confirm(args.confirm)?;
+            client.delete_issue(&args.key).await?;
+            deleted_original = true;
+        }
+
+        Ok(json!({
+            "source_key": args.key,
+            "move_original": move_original,
+            "deleted_original": deleted_original,
+            "issue": cloned
         }))
     }
 

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -172,6 +172,16 @@ pub struct IssueDeleteArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IssueCloneArgs {
+    pub key: String,
+    pub project_key: Option<String>,
+    pub summary: Option<String>,
+    pub assignee: Option<String>,
+    pub move_original: Option<bool>,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IssueTransitionArgs {
     pub key: String,
     pub transition: String,

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -18,12 +18,12 @@ use crate::{
     error::AppResult,
     models::{
         ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BulkTransitionArgs, BulkUpdateArgs,
-        CommentAddArgs, IssueAttachArgs, IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs,
-        IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs, IssueTransitionArgs,
-        IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs, ProjectVersionCreateArgs,
-        ProjectVersionUpdateArgs, RemoteLinkAddArgs, RemoteLinkDeleteArgs, SprintAddIssueArgs,
-        SprintCreateArgs, SprintDeleteArgs, SprintListArgs, SprintUpdateArgs, ToolResponse,
-        WorklogAddArgs, WorklogDeleteArgs,
+        CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs, IssueDeleteArgs,
+        IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs,
+        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
+        ProjectVersionCreateArgs, ProjectVersionUpdateArgs, RemoteLinkAddArgs,
+        RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs,
+        SprintListArgs, SprintUpdateArgs, ToolResponse, WorklogAddArgs, WorklogDeleteArgs,
     },
 };
 
@@ -280,6 +280,17 @@ impl JiraMcpServer {
         Parameters(args): Parameters<IssueDeleteArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.issue_delete(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_clone",
+        description = "Clone a Jira issue into the same or another project; deleting the original requires move_original=true and confirm=true"
+    )]
+    pub async fn jira_issue_clone(
+        &self,
+        Parameters(args): Parameters<IssueCloneArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_clone(args).await)
     }
 
     #[tool(
@@ -587,6 +598,7 @@ mod tests {
         let client = TestClient.serve(client_transport).await?;
         let tools = client.list_all_tools().await?;
         assert!(tools.iter().any(|tool| tool.name == "jira_auth_status"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_clone"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))


### PR DESCRIPTION
## Description

Adds `jira_issue_clone` to `jirac-mcp` so MCP clients can clone an issue into the same project or a different target project.

This wires the existing clone behavior into the MCP layer with typed arguments and the same core defaults as the CLI:
- copy summary by default (with optional override)
- copy description, issue type, priority, labels, components, and fix versions
- do not copy assignee unless explicitly provided
- optionally delete the original only when `move_original=true` and `confirm=true`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- `jira-mcp` README already claimed clone coverage; this PR makes the MCP tool surface match that claim.
- Validated locally with `cargo test -p jira-mcp` and `cargo clippy -p jira-mcp --all-targets -- -D warnings`.
