### PR TITLE
feat(mcp): add bulk comment and batch tools

### DIFF
--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -63,11 +63,12 @@ jirac auth use work-cloud
 
 The MCP server includes tools for:
 - auth status and credential updates
-- issue list, view, create, update, delete, and clone
+- issue list, view, create, update, delete, clone, and batch flows
 - field and transition discovery
+- comments (single + bulk)
 - attachment upload
 - worklog operations
-- bulk transition, bulk update, batch, and archive flows
+- bulk transition, bulk update, and archive flows
 - plans
 - raw Jira REST API requests
 

--- a/crates/jira-mcp/src/app.rs
+++ b/crates/jira-mcp/src/app.rs
@@ -20,7 +20,8 @@ use url::form_urlencoded;
 use crate::{
     error::{AppError, AppResult},
     models::{
-        ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BulkTransitionArgs,
+        ApiRequestArgs, ArchiveArgs, AttachmentInput, AuthSetCredentialsArgs, BatchArgs,
+        BatchCreateOp, BatchOperation, BatchUpdateOp, BulkCommentArgs, BulkTransitionArgs,
         BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs,
         IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs,
         IssueListArgs, IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
@@ -361,20 +362,7 @@ impl JiraApp {
     pub async fn issue_create(&self, args: IssueCreateArgs) -> AppResult<Value> {
         let client = self.build_client()?;
         let issue = client
-            .create_issue_v2(CreateIssueRequestV2 {
-                project_key: args.project_key,
-                summary: args.summary,
-                description: args.description,
-                description_adf: args.description_adf,
-                issue_type: args.issue_type,
-                assignee: args.assignee,
-                priority: args.priority,
-                labels: args.labels.unwrap_or_default(),
-                components: args.components.unwrap_or_default(),
-                parent: args.parent,
-                fix_versions: args.fix_versions.unwrap_or_default(),
-                custom_fields: map_custom_fields(args.custom_fields),
-            })
+            .create_issue_v2(create_issue_request_from_issue(args))
             .await?;
 
         to_value(issue)
@@ -382,45 +370,191 @@ impl JiraApp {
 
     pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {
         let client = self.build_client()?;
-        let custom_fields = map_custom_fields(args.custom_fields);
-        let has_changes = args.summary.is_some()
-            || args.description.is_some()
-            || args.description_adf.is_some()
-            || args.assignee.is_some()
-            || args.priority.is_some()
-            || args.labels.is_some()
-            || args.components.is_some()
-            || args.parent.is_some()
-            || args.fix_versions.is_some()
-            || !custom_fields.is_empty();
+        let key = args.key.clone();
+        let request = build_update_issue_request_from_issue(args)?;
 
-        if !has_changes {
+        client.update_issue(&key, request).await?;
+        let issue = client.get_issue(&key).await?;
+        to_value(issue)
+    }
+
+    pub async fn issue_bulk_comment(&self, args: BulkCommentArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+        if args.body.trim().is_empty() {
+            return Err(AppError::validation("Comment body cannot be empty"));
+        }
+        if args.jql.is_none() && args.keys.as_ref().is_none_or(|keys| keys.is_empty()) {
             return Err(AppError::validation(
-                "Provide at least one field to update on the issue",
+                "Provide jql or at least one issue key to target",
             ));
         }
 
-        let key = args.key;
-        client
-            .update_issue(
-                &key,
-                UpdateIssueRequest {
-                    summary: args.summary,
-                    description: args.description,
-                    description_adf: args.description_adf,
-                    assignee: args.assignee,
-                    priority: args.priority,
-                    labels: args.labels,
-                    components: args.components,
-                    fix_versions: args.fix_versions,
-                    parent: args.parent,
-                    custom_fields,
-                    ..Default::default()
-                },
-            )
-            .await?;
-        let issue = client.get_issue(&key).await?;
-        to_value(issue)
+        let client = self.build_client()?;
+        let target_keys = if let Some(jql) = args.jql.as_deref() {
+            client
+                .get_all_issues(jql)
+                .await?
+                .into_iter()
+                .map(|issue| issue.key)
+                .collect::<Vec<_>>()
+        } else {
+            normalize_issue_keys(args.keys.unwrap_or_default())
+        };
+
+        if target_keys.is_empty() {
+            return Err(AppError::validation(
+                "Provide jql or at least one issue key to target",
+            ));
+        }
+
+        let mut succeeded = Vec::new();
+        let mut failed = Vec::new();
+        for key in &target_keys {
+            match client.add_comment(key, &args.body).await {
+                Ok(comment) => succeeded.push(json!({"key": key, "comment_id": comment.id})),
+                Err(err) => failed.push(json!({"key": key, "error": err.to_string()})),
+            }
+        }
+
+        Ok(json!({
+            "targets": target_keys,
+            "total": succeeded.len() + failed.len(),
+            "succeeded": succeeded,
+            "failed": failed,
+        }))
+    }
+
+    pub async fn issue_batch(&self, args: BatchArgs) -> AppResult<Value> {
+        require_confirm(args.confirm)?;
+
+        if args.operations.is_empty() {
+            return Ok(json!({
+                "total": 0,
+                "succeeded": 0,
+                "failed_count": 0,
+                "results": []
+            }));
+        }
+
+        let client = self.build_client()?;
+
+        let total = args.operations.len();
+        let mut results = Vec::new();
+        let mut succeeded = 0usize;
+
+        for operation in args.operations {
+            let result = match operation {
+                BatchOperation::Create(entry) => {
+                    let summary = entry.summary.clone();
+                    match client
+                        .create_issue_v2(create_issue_request_from_batch_create(entry))
+                        .await
+                    {
+                        Ok(issue) => {
+                            succeeded += 1;
+                            json!({
+                                "op": "create",
+                                "key": issue.key,
+                                "status": "created",
+                                "issue": issue
+                            })
+                        }
+                        Err(err) => json!({
+                            "op": "create",
+                            "summary": summary,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Update(entry) => {
+                    let key = entry.key.clone();
+                    match build_update_issue_request_from_batch(entry) {
+                        Ok(request) => match client.update_issue(&key, request).await {
+                            Ok(_) => {
+                                succeeded += 1;
+                                json!({
+                                    "op": "update",
+                                    "key": key,
+                                    "status": "updated"
+                                })
+                            }
+                            Err(err) => json!({
+                                "op": "update",
+                                "key": key,
+                                "status": "failed",
+                                "error": err.to_string()
+                            }),
+                        },
+                        Err(err) => json!({
+                            "op": "update",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Transition(entry) => {
+                    let key = entry.key.clone();
+                    let transition = entry.transition.clone();
+                    match resolve_transition(&client, &key, &transition).await {
+                        Ok(resolved) => match client.transition_issue(&key, &resolved.id).await {
+                            Ok(_) => {
+                                succeeded += 1;
+                                json!({
+                                    "op": "transition",
+                                    "key": key,
+                                    "status": "transitioned",
+                                    "transition": {
+                                        "id": resolved.id,
+                                        "name": resolved.name
+                                    }
+                                })
+                            }
+                            Err(err) => json!({
+                                "op": "transition",
+                                "key": key,
+                                "status": "failed",
+                                "error": err.to_string()
+                            }),
+                        },
+                        Err(err) => json!({
+                            "op": "transition",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+                BatchOperation::Archive(entry) => {
+                    let key = entry.key;
+                    match client.archive_issues(std::slice::from_ref(&key)).await {
+                        Ok(_) => {
+                            succeeded += 1;
+                            json!({
+                                "op": "archive",
+                                "key": key,
+                                "status": "archived"
+                            })
+                        }
+                        Err(err) => json!({
+                            "op": "archive",
+                            "key": key,
+                            "status": "failed",
+                            "error": err.to_string()
+                        }),
+                    }
+                }
+            };
+            results.push(result);
+        }
+
+        Ok(json!({
+            "total": total,
+            "succeeded": succeeded,
+            "failed_count": total - succeeded,
+            "results": results
+        }))
     }
 
     pub async fn issue_delete(&self, args: IssueDeleteArgs) -> AppResult<Value> {
@@ -879,6 +1013,108 @@ fn map_custom_fields(
         .collect()
 }
 
+fn create_issue_request_from_issue(args: IssueCreateArgs) -> CreateIssueRequestV2 {
+    CreateIssueRequestV2 {
+        project_key: args.project_key,
+        summary: args.summary,
+        description: args.description,
+        description_adf: args.description_adf,
+        issue_type: args.issue_type,
+        assignee: args.assignee,
+        priority: args.priority,
+        labels: args.labels.unwrap_or_default(),
+        components: args.components.unwrap_or_default(),
+        parent: args.parent,
+        fix_versions: args.fix_versions.unwrap_or_default(),
+        custom_fields: map_custom_fields(args.custom_fields),
+    }
+}
+
+fn create_issue_request_from_batch_create(entry: BatchCreateOp) -> CreateIssueRequestV2 {
+    CreateIssueRequestV2 {
+        project_key: entry.project_key,
+        summary: entry.summary,
+        description: entry.description,
+        description_adf: entry.description_adf,
+        issue_type: entry.issue_type.unwrap_or_else(|| "Task".to_string()),
+        assignee: entry.assignee,
+        priority: entry.priority,
+        labels: entry.labels.unwrap_or_default(),
+        components: entry.components.unwrap_or_default(),
+        parent: entry.parent,
+        fix_versions: entry.fix_versions.unwrap_or_default(),
+        custom_fields: map_custom_fields(entry.custom_fields),
+    }
+}
+
+fn build_update_issue_request_from_issue(args: IssueUpdateArgs) -> AppResult<UpdateIssueRequest> {
+    let custom_fields = map_custom_fields(args.custom_fields);
+    let has_changes = args.summary.is_some()
+        || args.description.is_some()
+        || args.description_adf.is_some()
+        || args.assignee.is_some()
+        || args.priority.is_some()
+        || args.labels.is_some()
+        || args.components.is_some()
+        || args.parent.is_some()
+        || args.fix_versions.is_some()
+        || !custom_fields.is_empty();
+
+    if !has_changes {
+        return Err(AppError::validation(
+            "Provide at least one field to update on the issue",
+        ));
+    }
+
+    Ok(UpdateIssueRequest {
+        summary: args.summary,
+        description: args.description,
+        description_adf: args.description_adf,
+        assignee: args.assignee,
+        priority: args.priority,
+        labels: args.labels,
+        components: args.components,
+        fix_versions: args.fix_versions,
+        parent: args.parent,
+        custom_fields,
+        ..Default::default()
+    })
+}
+
+fn build_update_issue_request_from_batch(entry: BatchUpdateOp) -> AppResult<UpdateIssueRequest> {
+    let custom_fields = map_custom_fields(entry.custom_fields);
+    let has_changes = entry.summary.is_some()
+        || entry.description.is_some()
+        || entry.description_adf.is_some()
+        || entry.assignee.is_some()
+        || entry.priority.is_some()
+        || entry.labels.is_some()
+        || entry.components.is_some()
+        || entry.parent.is_some()
+        || entry.fix_versions.is_some()
+        || !custom_fields.is_empty();
+
+    if !has_changes {
+        return Err(AppError::validation(
+            "Provide at least one field to update on the issue",
+        ));
+    }
+
+    Ok(UpdateIssueRequest {
+        summary: entry.summary,
+        description: entry.description,
+        description_adf: entry.description_adf,
+        assignee: entry.assignee,
+        priority: entry.priority,
+        labels: entry.labels,
+        components: entry.components,
+        fix_versions: entry.fix_versions,
+        parent: entry.parent,
+        custom_fields,
+        ..Default::default()
+    })
+}
+
 fn require_confirm(confirm: Option<bool>) -> AppResult<()> {
     if confirm == Some(true) {
         Ok(())
@@ -954,6 +1190,22 @@ fn value_or_null(value: String) -> Value {
     } else {
         Value::String(value)
     }
+}
+
+fn normalize_issue_keys(raw_keys: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in raw_keys {
+        for key in raw
+            .split(|c: char| c == ',' || c.is_whitespace())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            if !out.iter().any(|existing| existing == key) {
+                out.push(key.to_string());
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -1038,6 +1290,49 @@ mod tests {
             .expect_err("missing confirm should fail");
 
         assert_eq!(err.to_mcp().message, "unsafe_operation");
+
+        let err = JiraApp
+            .issue_bulk_comment(BulkCommentArgs {
+                jql: Some("project = PROJ".into()),
+                keys: None,
+                body: "hello".into(),
+                confirm: None,
+            })
+            .await
+            .expect_err("missing confirm should fail");
+
+        assert_eq!(err.to_mcp().message, "unsafe_operation");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn bulk_comment_requires_targets() {
+        let err = JiraApp
+            .issue_bulk_comment(BulkCommentArgs {
+                jql: None,
+                keys: None,
+                body: "hello".into(),
+                confirm: Some(true),
+            })
+            .await
+            .expect_err("missing targets should fail");
+
+        assert_eq!(err.to_mcp().message, "validation_error");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn issue_batch_allows_empty_operations() {
+        let result = JiraApp
+            .issue_batch(BatchArgs {
+                operations: Vec::new(),
+                confirm: Some(true),
+            })
+            .await
+            .expect("empty batch should succeed");
+
+        assert_eq!(result["total"], Value::from(0));
+        assert_eq!(result["results"].as_array().map(Vec::len), Some(0));
     }
 
     #[tokio::test]

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -213,6 +213,14 @@ pub struct CommentAddArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BulkCommentArgs {
+    pub jql: Option<String>,
+    pub keys: Option<Vec<String>>,
+    pub body: String,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IssueLinkCreateArgs {
     pub outward_key: String,
     pub inward_key: String,
@@ -272,6 +280,71 @@ pub struct BulkUpdateArgs {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ArchiveArgs {
     pub jql: String,
+    pub confirm: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchCreateOp {
+    pub project_key: String,
+    pub summary: String,
+    pub issue_type: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
+    pub description_adf: Option<Value>,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub components: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
+    pub custom_fields: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchUpdateOp {
+    pub key: String,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object")]
+    pub description_adf: Option<Value>,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    pub components: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub fix_versions: Option<Vec<String>>,
+    #[serde(default)]
+    #[schemars(schema_with = "any_json_object_map")]
+    pub custom_fields: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchTransitionOp {
+    pub key: String,
+    pub transition: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchArchiveOp {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum BatchOperation {
+    Create(BatchCreateOp),
+    Update(BatchUpdateOp),
+    Transition(BatchTransitionOp),
+    Archive(BatchArchiveOp),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BatchArgs {
+    pub operations: Vec<BatchOperation>,
     pub confirm: Option<bool>,
 }
 

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -17,13 +17,14 @@ use crate::{
     app::JiraApp,
     error::AppResult,
     models::{
-        ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BulkTransitionArgs, BulkUpdateArgs,
-        CommentAddArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs, IssueDeleteArgs,
-        IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs, IssueLinkDeleteArgs, IssueListArgs,
-        IssueTransitionArgs, IssueTypesListArgs, IssueUpdateArgs, ProjectKeyArgs,
-        ProjectVersionCreateArgs, ProjectVersionUpdateArgs, RemoteLinkAddArgs,
-        RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs,
-        SprintListArgs, SprintUpdateArgs, ToolResponse, WorklogAddArgs, WorklogDeleteArgs,
+        ApiRequestArgs, ArchiveArgs, AuthSetCredentialsArgs, BatchArgs, BulkCommentArgs,
+        BulkTransitionArgs, BulkUpdateArgs, CommentAddArgs, IssueAttachArgs, IssueCloneArgs,
+        IssueCreateArgs, IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueLinkCreateArgs,
+        IssueLinkDeleteArgs, IssueListArgs, IssueTransitionArgs, IssueTypesListArgs,
+        IssueUpdateArgs, ProjectKeyArgs, ProjectVersionCreateArgs, ProjectVersionUpdateArgs,
+        RemoteLinkAddArgs, RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs,
+        SprintDeleteArgs, SprintListArgs, SprintUpdateArgs, ToolResponse, WorklogAddArgs,
+        WorklogDeleteArgs,
     },
 };
 
@@ -338,6 +339,17 @@ impl JiraMcpServer {
     }
 
     #[tool(
+        name = "jira_issue_bulk_comment",
+        description = "Add the same comment to multiple Jira issues selected by JQL or explicit keys; requires confirm=true"
+    )]
+    pub async fn jira_issue_bulk_comment(
+        &self,
+        Parameters(args): Parameters<BulkCommentArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_bulk_comment(args).await)
+    }
+
+    #[tool(
         name = "jira_issue_link_types_list",
         description = "List available Jira issue link types such as blocks, relates to, and duplicates"
     )]
@@ -453,6 +465,17 @@ impl JiraMcpServer {
         Parameters(args): Parameters<BulkUpdateArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.issue_bulk_update(args).await)
+    }
+
+    #[tool(
+        name = "jira_issue_batch",
+        description = "Run typed create, update, transition, and archive issue operations in sequence; requires confirm=true"
+    )]
+    pub async fn jira_issue_batch(
+        &self,
+        Parameters(args): Parameters<BatchArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.issue_batch(args).await)
     }
 
     #[tool(
@@ -599,6 +622,10 @@ mod tests {
         let tools = client.list_all_tools().await?;
         assert!(tools.iter().any(|tool| tool.name == "jira_auth_status"));
         assert!(tools.iter().any(|tool| tool.name == "jira_issue_clone"));
+        assert!(tools
+            .iter()
+            .any(|tool| tool.name == "jira_issue_bulk_comment"));
+        assert!(tools.iter().any(|tool| tool.name == "jira_issue_batch"));
 
         client
             .call_tool(CallToolRequestParams::new("jira_auth_status"))


### PR DESCRIPTION
## Description

Adds the next missing MCP workflow batch for `jirac-mcp`:
- `jira_issue_bulk_comment` for posting the same comment to many issues by JQL or explicit keys
- `jira_issue_batch` for typed create/update/transition/archive sequences in one confirmed call

This keeps the MCP surface aligned with existing CLI workflows without falling back to shell execution.

Highlights:
- bulk comment requires `confirm=true`
- batch flow requires `confirm=true`
- batch create/update use the same typed field shapes as the existing single-issue tools
- batch returns per-operation results instead of failing the whole run on the first error
- README tool coverage now matches the actual MCP surface

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- Validated locally with `cargo test -p jira-mcp` and `cargo clippy -p jira-mcp --all-targets -- -D warnings`.
- Bulk comment validates `body` and target selection before trying to hit Jira.
- Empty batch input returns a typed empty result instead of a transport/auth failure.
