### PR TITLE
docs: separate integration surface entrypoints

### DIFF
--- a/CLAWHUB.md
+++ b/CLAWHUB.md
@@ -1,0 +1,21 @@
+# OpenClaw / ClawHub Skill
+
+The OpenClaw / ClawHub integration docs live under [`clawhub/jirac/`](clawhub/jirac/).
+
+Use that surface as the source of truth for:
+
+- the published `jirac` skill definition
+- agent-facing usage guidance
+- ClawHub/OpenClaw-specific references such as install and JQL recipes
+- the ClawHub release lane version file
+
+Entry points:
+
+- Skill definition: [`clawhub/jirac/SKILL.md`](clawhub/jirac/SKILL.md)
+- Install reference: [`clawhub/jirac/references/install.md`](clawhub/jirac/references/install.md)
+- JQL reference: [`clawhub/jirac/references/jql.md`](clawhub/jirac/references/jql.md)
+
+Related surfaces stay separate on purpose:
+
+- root [`README.md`](README.md) covers the CLI/TUI and repo overview
+- [`plugin/README.md`](plugin/README.md) covers the Claude Code plugin surface

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,36 +1,15 @@
 # Claude Code Plugin
 
-The `jirac` Claude Code plugin exposes Jira operations as slash commands inside Claude Code. The plugin namespace is `/jira:*`.
+The Claude Code plugin docs now live under [`plugin/README.md`](plugin/README.md).
 
-The plugin has its own release lane under `plugin/`, with dedicated `plugin/VERSION` and `plugin/CHANGELOG.md` files. ClawHub publishing uses a separate skill lane under `clawhub/jirac/`.
+Use that directory as the source of truth for:
 
-## Setup
+- plugin install/setup steps
+- slash-command skill coverage
+- plugin-specific release notes and versioning
+- Claude-only positioning and compatibility notes
 
-```bash
-# 1. Install the CLI that the plugin calls
-cargo install jira-commands
-jirac auth login
-```
+Related surfaces stay separate on purpose:
 
-```text
-# 2. In Claude Code
-/plugin marketplace add mulhamna/jira-commands
-/plugin install jira@jira-commands
-```
-
-## Available skills
-
-| Skill                   | Description                             |
-| ----------------------- | --------------------------------------- |
-| `/jira:list-issues`     | List issues by project or JQL           |
-| `/jira:view-issue`      | View full issue detail                  |
-| `/jira:create-issue`    | Create a new issue                      |
-| `/jira:update-issue`    | Update an existing issue                |
-| `/jira:transition`      | Transition an issue                     |
-| `/jira:comment`         | List comments or add a Markdown comment |
-| `/jira:worklog`         | List, add, or delete worklogs           |
-| `/jira:fields`          | Inspect available field metadata        |
-| `/jira:bulk-transition` | Bulk transition issues via JQL          |
-| `/jira:attach`          | Upload a file to an issue               |
-| `/jira:jql`             | Build and run a JQL query               |
-| `/jira:api`             | Raw REST API passthrough                |
+- root [`README.md`](README.md) covers the CLI/TUI and repo overview
+- [`CLAWHUB.md`](CLAWHUB.md) covers the OpenClaw / ClawHub skill surface

--- a/README.md
+++ b/README.md
@@ -7,11 +7,30 @@ Jira on the command line.
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12742/badge)](https://www.bestpractices.dev/projects/12742)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
-| `jirac` | `jira-mcp` | `plugin` | `clawhub` |
-| --- | --- | --- | --- |
-| [![crate jirac](https://img.shields.io/crates/v/jira-commands.svg?label=crate)](https://crates.io/crates/jira-commands)<br>[![npm jirac](https://img.shields.io/npm/v/%40mulham28%2Fjirac?label=npm)](https://www.npmjs.com/package/@mulham28/jirac)<br>[![homebrew jirac](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fhomebrew-tap%2Fmain%2FFormula%2Fjira-commands.rb&search=%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B&label=homebrew&color=fbb040)](https://github.com/mulhamna/homebrew-tap/blob/main/Formula/jira-commands.rb)<br>[![scoop jirac](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac.json&query=%24.version&label=scoop&color=00b4ff)](https://github.com/mulhamna/scoop-bucket/blob/main/bucket/jirac.json)<br>[![winget jirac](https://img.shields.io/github/v/release/mulhamna/jira-commands?filter=v*&label=winget&color=2b579a)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/mulhamna/jirac) | [![crate jira-mcp](https://img.shields.io/crates/v/jira-mcp.svg?label=crate)](https://crates.io/crates/jira-mcp)<br>[![npm jira-mcp](https://img.shields.io/npm/v/%40mulham28%2Fjirac-mcp?label=npm)](https://www.npmjs.com/package/@mulham28/jirac-mcp)<br>[![homebrew jira-mcp](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fhomebrew-tap%2Fmain%2FFormula%2Fjira-mcp.rb&search=%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B&label=homebrew&color=fbb040)](https://github.com/mulhamna/homebrew-tap/blob/main/Formula/jira-mcp.rb)<br>[![scoop jira-mcp](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fscoop-bucket%2Fmain%2Fbucket%2Fjirac-mcp.json&query=%24.version&label=scoop&color=00b4ff)](https://github.com/mulhamna/scoop-bucket/blob/main/bucket/jirac-mcp.json)<br>[![winget jira-mcp](https://img.shields.io/github/v/release/mulhamna/jira-commands?filter=jira-mcp-v*&label=winget&color=2b579a)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/mulhamna/jirac-mcp) | [![plugin jira](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fjira-commands%2Fmain%2Fplugin%2F.claude-plugin%2Fplugin.json&query=%24.version&label=plugin&color=7c3aed)](plugin/README.md) | [![clawhub jirac](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fjira-commands%2Fmain%2Fclawhub%2Fjirac%2FVERSION&search=%5B0-9.%5D%2B&label=clawhub&color=0f766e)](clawhub/jirac/SKILL.md) |
+[![crate jirac](https://img.shields.io/crates/v/jira-commands.svg?label=crate)](https://crates.io/crates/jira-commands)
+[![npm jirac](https://img.shields.io/npm/v/%40mulham28%2Fjirac?label=npm)](https://www.npmjs.com/package/@mulham28/jirac)
+[![crate jira-mcp](https://img.shields.io/crates/v/jira-mcp.svg?label=crate)](https://crates.io/crates/jira-mcp)
+[![npm jira-mcp](https://img.shields.io/npm/v/%40mulham28%2Fjirac-mcp?label=npm)](https://www.npmjs.com/package/@mulham28/jirac-mcp)
+[![plugin jira](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fjira-commands%2Fmain%2Fplugin%2F.claude-plugin%2Fplugin.json&query=%24.version&label=plugin&color=7c3aed)](plugin/README.md)
+[![clawhub jirac](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmulhamna%2Fjira-commands%2Fmain%2Fclawhub%2Fjirac%2FVERSION&search=%5B0-9.%5D%2B&label=clawhub&color=0f766e)](CLAWHUB.md)
 
 `jirac` is a Jira command-line client written in Rust. It ships as a single binary with no runtime dependencies and runs on macOS, Linux, and Windows. It supports Jira Cloud and Jira Data Center, stores multiple login profiles, and discovers custom fields at runtime so there is little to configure beyond your credentials.
+
+## Choose your surface
+
+### Core binaries
+
+- **`jirac`** — the main CLI + TUI for working with Jira directly from the terminal
+- **`jirac-mcp`** — the MCP server for editors, agents, and desktop clients
+- Install options for both live in [INSTALL.md](INSTALL.md)
+- MCP-specific setup lives in [crates/jira-mcp/README.md](crates/jira-mcp/README.md)
+
+### Integration surfaces
+
+- **Claude Code plugin** — isolated plugin docs, release lane, and skills live in [plugin/README.md](plugin/README.md)
+- **OpenClaw / ClawHub skill** — isolated agent-skill docs and references live in [CLAWHUB.md](CLAWHUB.md)
+
+This repo ships multiple Jira surfaces, but each one has its own packaging and docs entrypoint so user-facing instructions do not get mixed together.
 
 <table>
   <tr>


### PR DESCRIPTION
## Summary
- split the root README into clearer core-binary vs integration-surface entrypoints
- turn `PLUGIN.md` into a short redirect to the dedicated plugin docs
- add `CLAWHUB.md` as the top-level entrypoint for the OpenClaw / ClawHub surface

## Why
The repo currently mixes CLI/MCP, Claude plugin, and OpenClaw/ClawHub surface docs too closely at the top level. This makes it harder to know where to start for each integration. This PR keeps the surfaces in the same repo, but gives each one a cleaner docs entrypoint so they feel less blended together.

## Validation
- `git diff --check`
- manual docs sanity check for the touched Markdown files
