### PR TITLE
fix(release): keep MCP lockfile-only commits out of root lane

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,12 +3,20 @@ name: Release Please
 # ── HOW THIS WORKS ────────────────────────────────────────────────────────────
 # 1. Every push to main is analyzed for Conventional Commits.
 # 2. release-please creates/updates two Release PRs (one per package):
-#      - `jira-commands` — covers jira-core + jira-commands (lockstep).
-#        Tag: vX.Y.Z. Source-of-truth: VERSION file at repo root.
-#      - `jira-mcp` — covers jira-mcp only.
-#        Tag: jira-mcp-vX.Y.Z. Source-of-truth: crates/jira-mcp/VERSION.
-#    Commit scopes determine which PR is bumped: `feat(mcp):`/`fix(mcp):` →
-#    jira-mcp; everything else → jira-commands.
+#      - `jira-commands` — covers the root release lane (`.`), which bumps
+#        jira-core + jira-commands in lockstep. Tag: vX.Y.Z.
+#        Source-of-truth: VERSION file at repo root.
+#      - `jira-mcp` — covers `crates/jira-mcp`. Tag: jira-mcp-vX.Y.Z.
+#        Source-of-truth: crates/jira-mcp/VERSION.
+#    Routing is path-based, not scope-based:
+#      - commits touching only `crates/jira-mcp/**`, `packaging/npm-mcp/**`,
+#        and/or `Cargo.lock` are eligible for the jira-mcp Release PR.
+#      - the root `jira-commands` lane excludes those paths, but any commit that
+#        also touches another non-excluded file (for example `INSTALL.md` or
+#        `crates/jira/src/cli/mcp.rs`) will still be included in the root
+#        Release PR and can appear in its changelog.
+#    Conventional commit scopes like `feat(mcp):` help the changelog read well,
+#    but they do not decide release lane ownership by themselves.
 # 3. When you (the owner) merge a Release PR:
 #      - release-please pushes the corresponding tag
 #      - vX.Y.Z         → release-tag.yml      (builds jirac, publishes jira-core + jira-commands)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
       "changelog-path": "CHANGELOG.md",
       "exclude-paths": [
         "crates/jira-mcp",
-        "packaging/npm-mcp"
+        "packaging/npm-mcp",
+        "Cargo.lock"
       ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },


### PR DESCRIPTION
## Summary
- add `Cargo.lock` to the root `jira-commands` release-please `exclude-paths`
- clarify that release-please lane ownership is path-based, not commit-scope-based
- document why MCP commits touching non-excluded files can still appear in the root release PR

## Why
The root release lane already excluded `crates/jira-mcp` and `packaging/npm-mcp`, but release-please only skips a commit when **all** changed files are excluded.

So MCP commits that also updated `Cargo.lock` were still eligible for the root `jira-commands` release PR changelog.

Adding `Cargo.lock` to the root excluded paths keeps pure MCP changes plus lockfile updates in the `jira-mcp` lane. Commits that touch real root/CLI files like `INSTALL.md` or `crates/jira/src/cli/mcp.rs` can still appear in the root lane, which is expected.
