### PR TITLE
chore(packaging): refresh jira-mcp Winget manifests for v2.1.0

### DIFF
--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.0.1
+PackageVersion: 2.1.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: jirac-mcp-windows-x86_64.exe
     PortableCommandAlias: jirac-mcp
-ReleaseDate: 2026-05-24
+ReleaseDate: 2026-06-02
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.0.1/jirac-mcp-windows-x86_64.zip
-    InstallerSha256: 437888c51fb8b3a3f92e3b4a1fbe835ca54f0b3eb0d5a8fdfd178d26755223db
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.1.0/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: d85d7e58b8a42ad078f65e055dd5ec58cda626f056f3e61d007a559bcd2ad9e4
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
+++ b/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.0.1
+PackageVersion: 2.1.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget-mcp/jirac-mcp.yaml
+++ b/packaging/winget-mcp/jirac-mcp.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.0.1
+PackageVersion: 2.1.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for jira-mcp v2.1.0

## Notes

- generated by the jira-mcp release workflow after publishing GitHub release assets
- Winget community submission remains handled by the separate `Winget Submit jira-mcp` workflow