### PR TITLE
chore(packaging): refresh release docs and manifests for v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ Jira on the command line.
 ```bash
 # Homebrew (macOS / Linux)
 brew tap mulhamna/tap
-brew install jira-commands jira-mcp
+brew install jira-commands
+
+# Optional MCP server
+brew install jira-mcp
 
 # Cargo
 cargo install jira-commands
-cargo install jira-mcp
 
 # Windows (Scoop)
 scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket
@@ -89,7 +91,6 @@ scoop install mulhamna/jirac-mcp
 
 # Windows (winget)
 winget install mulhamna.jirac
-winget install mulhamna.jirac-mcp
 
 ```
 
@@ -367,7 +368,7 @@ packaging/     # release/install packaging
 
 Thanks to everyone helping shape `jirac`. This footer is refreshed automatically during the release lane.
 
-| <a href="https://github.com/mulhamna" title="@mulhamna"><img src="https://avatars.githubusercontent.com/u/97831705?v=4&s=72" width="36" height="36" alt="mulhamna" /></a> | <a href="https://github.com/apps/github-actions" title="@github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?v=4&s=72" width="36" height="36" alt="github-actions[bot]" /></a> | <a href="https://github.com/badrus123" title="@badrus123"><img src="https://avatars.githubusercontent.com/u/21188155?v=4&s=72" width="36" height="36" alt="badrus123" /></a> | <a href="https://github.com/chmdznr" title="@chmdznr"><img src="https://avatars.githubusercontent.com/u/6890365?v=4&s=72" width="36" height="36" alt="chmdznr" /></a> | <a href="https://github.com/EnrikoAviyantoPutra" title="@EnrikoAviyantoPutra"><img src="https://avatars.githubusercontent.com/u/71826526?v=4&s=72" width="36" height="36" alt="EnrikoAviyantoPutra" /></a> | <a href="https://github.com/apps/dependabot" title="@dependabot[bot]"><img src="https://avatars.githubusercontent.com/in/29110?v=4&s=72" width="36" height="36" alt="dependabot[bot]" /></a> |
+| <a href="https://github.com/mulhamna" title="@mulhamna"><img src="https://avatars.githubusercontent.com/u/97831705?v=4&s=72" width="36" height="36" alt="mulhamna" /></a> | <a href="https://github.com/apps/github-actions" title="@github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?v=4&s=72" width="36" height="36" alt="github-actions[bot]" /></a> | <a href="https://github.com/badrus123" title="@badrus123"><img src="https://avatars.githubusercontent.com/u/21188155?v=4&s=72" width="36" height="36" alt="badrus123" /></a> | <a href="https://github.com/apps/dependabot" title="@dependabot[bot]"><img src="https://avatars.githubusercontent.com/in/29110?v=4&s=72" width="36" height="36" alt="dependabot[bot]" /></a> | <a href="https://github.com/chmdznr" title="@chmdznr"><img src="https://avatars.githubusercontent.com/u/6890365?v=4&s=72" width="36" height="36" alt="chmdznr" /></a> | <a href="https://github.com/EnrikoAviyantoPutra" title="@EnrikoAviyantoPutra"><img src="https://avatars.githubusercontent.com/u/71826526?v=4&s=72" width="36" height="36" alt="EnrikoAviyantoPutra" /></a> |
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | <a href="https://github.com/resincode" title="@resincode"><img src="https://avatars.githubusercontent.com/u/5574999?v=4&s=72" width="36" height="36" alt="resincode" /></a> | <a href="https://github.com/ekacahya21" title="@ekacahya21"><img src="https://avatars.githubusercontent.com/u/15162377?v=4&s=72" width="36" height="36" alt="ekacahya21" /></a> | <a href="https://github.com/wahyuakbarwibowo" title="@wahyuakbarwibowo"><img src="https://avatars.githubusercontent.com/u/25057573?v=4&s=72" width="36" height="36" alt="wahyuakbarwibowo" /></a> |   |   |   |
 <!-- contributors:end -->

--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 1.6.0
+PackageVersion: 1.7.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
   - RelativeFilePath: jirac-windows-x86_64.exe
     PortableCommandAlias: jirac
-ReleaseDate: 2026-05-27
+ReleaseDate: 2026-06-02
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v1.6.0/jirac-windows-x86_64.zip
-    InstallerSha256: f15adc6598e561ac58de754109358e93f88be8ad32198bb95d91a620c1b1c1c5
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v1.7.0/jirac-windows-x86_64.zip
+    InstallerSha256: 7afdbdb5fbc7298ba41c64597658fafe4ed08ecf66fa782ad5a86aec31b30899
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 1.6.0
+PackageVersion: 1.7.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 1.6.0
+PackageVersion: 1.7.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh root README.md and INSTALL.md for the released version
- refresh contributor avatars in the README footer
- refresh in-repo Winget source manifests for v1.7.0

## Notes

- generated by the release workflow after publishing GitHub release assets
- Winget community submission remains a separate follow-up workflow