### PR TITLE
fix: publish clawhub wrapper from package root

### DIFF
--- a/.github/workflows/clawhub-publish-jirac-plugin.yml
+++ b/.github/workflows/clawhub-publish-jirac-plugin.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Dry-run package publish
         run: |
-          npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_MARKETPLACE" \
+          npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_ROOT" \
             --dry-run \
             --source-repo "https://github.com/${{ github.repository }}" \
             --source-commit "${{ github.sha }}" \
@@ -101,7 +101,7 @@ jobs:
           for attempt in 1 2 3; do
             echo "Publish attempt $attempt/3"
 
-            if npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_MARKETPLACE" \
+            if npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_ROOT" \
               --source-repo "https://github.com/${{ github.repository }}" \
               --source-commit "${{ github.sha }}" \
               --source-ref "${{ github.ref_name }}"; then


### PR DESCRIPTION
## Description

Fix the post-merge ClawHub wrapper workflow failure on `main`.

`clawhub package publish` was being called with `clawhub/jirac-plugin/marketplace.json`, but the CLI expects a package root directory for local publishes. This hotfix switches the workflow to publish from `clawhub/jirac-plugin/`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No Rust crate files changed; this is a workflow-only fix.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

Failed step on `main`:
- `ClawHub Publish jirac Plugin` → `Dry-run package publish`
- error: `ClawPack publish files must end in .tgz`

This PR changes only the publish target path from the wrapper metadata file to the wrapper package root.