### PR TITLE
fix: exclude clawhub wrapper changes from root releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,10 +13,12 @@ name: Release Please
 #    Routing is path-based, not scope-based:
 #      - commits touching only `crates/jira-mcp/**`, `packaging/npm-mcp/**`,
 #        and/or `Cargo.lock` are eligible for the jira-mcp Release PR.
-#      - the root `jira-commands` lane excludes those paths, but any commit that
-#        also touches another non-excluded file (for example `INSTALL.md` or
-#        `crates/jira/src/cli/mcp.rs`) will still be included in the root
-#        Release PR and can appear in its changelog.
+#      - ClawHub / Claude marketplace wrapper surfaces (`clawhub/**`, `plugin/**`,
+#        `.claude-plugin/**`, and their dedicated publish-workflow/docs files)
+#        are excluded from the root `jira-commands` lane.
+#      - the root `jira-commands` lane still includes other non-excluded files
+#        (for example `INSTALL.md` or `crates/jira/src/cli/mcp.rs`) and those
+#        changes can appear in the root Release PR changelog.
 #    Conventional commit scopes like `feat(mcp):` help the changelog read well,
 #    but they do not decide release lane ownership by themselves.
 # 3. When you (the owner) merge a Release PR:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,15 @@
       "exclude-paths": [
         "crates/jira-mcp",
         "packaging/npm-mcp",
-        "Cargo.lock"
+        "Cargo.lock",
+        "plugin",
+        ".claude-plugin",
+        "clawhub",
+        ".github/workflows/clawhub-publish-jirac.yml",
+        ".github/workflows/clawhub-publish-jirac-plugin.yml",
+        "CLAUDE.md",
+        "CONTRIBUTING.md",
+        "PLUGIN.md"
       ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },


### PR DESCRIPTION
## Description

Stop ClawHub / Claude wrapper-only changes from opening root `jira-commands` release-please PRs.

The merged ClawHub wrapper work touched non-crate files that were still inside the root lane, so release-please opened `chore(main): release 1.7.1` even though nothing in the crates/CLI release surface changed.

This PR excludes the ClawHub/Claude wrapper paths and their dedicated workflow/docs files from the root lane.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No crate files changed; this is a release-routing config fix.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- Current bad PR on `main`: #330
- Root cause: root lane only excluded MCP paths, so ClawHub wrapper changes still counted as `jira-commands` release work
- This PR only changes path routing + inline workflow docs