### PR TITLE
fix: ignore release infra in root release lane

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,8 @@ name: Release Please
 #      - ClawHub / Claude marketplace wrapper surfaces (`clawhub/**`, `plugin/**`,
 #        `.claude-plugin/**`, and their dedicated publish-workflow/docs files)
 #        are excluded from the root `jira-commands` lane.
+#      - release-please routing/config maintenance files are also excluded so
+#        release-infra-only fixes do not mint a new CLI version.
 #      - the root `jira-commands` lane still includes other non-excluded files
 #        (for example `INSTALL.md` or `crates/jira/src/cli/mcp.rs`) and those
 #        changes can appear in the root Release PR changelog.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,8 @@
         "clawhub",
         ".github/workflows/clawhub-publish-jirac.yml",
         ".github/workflows/clawhub-publish-jirac-plugin.yml",
+        ".github/workflows/release-please.yml",
+        "release-please-config.json",
         "CLAUDE.md",
         "CONTRIBUTING.md",
         "PLUGIN.md"


### PR DESCRIPTION
## Description

Exclude release-please maintenance files from the root `jira-commands` lane.

PR #331 fixed ClawHub/Claude wrapper path routing, but that fix itself touched `release-please-config.json` and `.github/workflows/release-please.yml`, which were still counted as root-lane files. Because the merge commit was `fix:`, release-please opened another CLI bump PR even though this was still release-infra-only work.

This PR excludes those release-infra files too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No crate files changed; this is release-routing maintenance only.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- bad release PR reopened as #332 because PR #331 itself touched release infra files
- this PR closes that last routing leak for root-lane auto releases