### PR TITLE
fix: self-trigger clawhub publish workflows

### DIFF
--- a/.github/workflows/clawhub-publish-jirac-plugin.yml
+++ b/.github/workflows/clawhub-publish-jirac-plugin.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'clawhub/jirac-plugin/**'
       - 'plugin/**'
+      - '.github/workflows/clawhub-publish-jirac-plugin.yml'
 
 concurrency:
   group: clawhub-publish-jirac-plugin

--- a/.github/workflows/clawhub-publish-jirac.yml
+++ b/.github/workflows/clawhub-publish-jirac.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'clawhub/jirac/**'
+      - '.github/workflows/clawhub-publish-jirac.yml'
 
 concurrency:
   group: clawhub-publish-jirac


### PR DESCRIPTION
## Description

Make the ClawHub publish workflows trigger when their own workflow files change.

Right now `ClawHub Publish jirac Plugin` only watches `clawhub/jirac-plugin/**` and `plugin/**`, so the merge that fixed the workflow itself (#329) did not retrigger it on `main`. This adds each workflow file to its own `paths:` filter.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No crate files changed; this is workflow trigger wiring only.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- current behavior: workflow fixes on `main` do not rerun the ClawHub publish jobs
- this PR only adds each workflow file to its own trigger path list