### PR TITLE
fix: limit root release lane to jira and jira-core surfaces

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,14 +13,13 @@ name: Release Please
 #    Routing is path-based, not scope-based:
 #      - commits touching only `crates/jira-mcp/**`, `packaging/npm-mcp/**`,
 #        and/or `Cargo.lock` are eligible for the jira-mcp Release PR.
-#      - ClawHub / Claude marketplace wrapper surfaces (`clawhub/**`, `plugin/**`,
-#        `.claude-plugin/**`, and their dedicated publish-workflow/docs files)
-#        are excluded from the root `jira-commands` lane.
-#      - release-please routing/config maintenance files are also excluded so
-#        release-infra-only fixes do not mint a new CLI version.
-#      - the root `jira-commands` lane still includes other non-excluded files
-#        (for example `INSTALL.md` or `crates/jira/src/cli/mcp.rs`) and those
-#        changes can appear in the root Release PR changelog.
+#      - the root `jira-commands` lane uses explicit `include-paths`, so only
+#        real CLI/core release surfaces (root VERSION/docs/installers,
+#        `crates/jira/**`, `crates/jira-core/**`, and `packaging/npm/**`)
+#        contribute to a root release PR.
+#      - ClawHub / Claude wrapper work and release-infra-only maintenance stay
+#        outside the root lane unless they also touch one of those included
+#        release surfaces.
 #    Conventional commit scopes like `feat(mcp):` help the changelog read well,
 #    but they do not decide release lane ownership by themselves.
 # 3. When you (the owner) merge a Release PR:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,20 +8,17 @@
       "package-name": "jira-commands",
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
-      "exclude-paths": [
-        "crates/jira-mcp",
-        "packaging/npm-mcp",
-        "Cargo.lock",
-        "plugin",
-        ".claude-plugin",
-        "clawhub",
-        ".github/workflows/clawhub-publish-jirac.yml",
-        ".github/workflows/clawhub-publish-jirac-plugin.yml",
-        ".github/workflows/release-please.yml",
-        "release-please-config.json",
-        "CLAUDE.md",
-        "CONTRIBUTING.md",
-        "PLUGIN.md"
+      "include-paths": [
+        "Cargo.toml",
+        "VERSION",
+        "CHANGELOG.md",
+        "README.md",
+        "INSTALL.md",
+        "install.sh",
+        "install.ps1",
+        "crates/jira",
+        "crates/jira-core",
+        "packaging/npm"
       ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },


### PR DESCRIPTION
## Description

Keep `jirac-plugin` / ClawHub work out of the root `jira-commands` release lane **without** affecting normal release bumps for `jira` + `jira-core`.

This changes the root lane to use explicit `include-paths` for the real `jira-commands` release surface:
- `crates/jira/**`
- `crates/jira-core/**`
- root version/changelog/docs/installers that belong to `jira-commands`
- `packaging/npm/**`

So adding or iterating on `jirac-plugin` / `clawhub/**` will not mint a root release PR by itself, but normal `jira` / `jira-core` work still will.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [x] Crate changes include added or updated tests, or this PR explains why not
- [x] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

No crate files changed; this is release-routing maintenance only.

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [ ] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [x] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

- goal: `jirac-plugin` should not bump the root `jira-commands` release lane
- non-goal: changing `crates/jira/**` or `crates/jira-core/**` should still bump it
- this PR narrows the root lane to that intended surface explicitly