### PR TITLE
fix: isolate clawhub changes from root release lane

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,14 +13,13 @@ name: Release Please
 #    Routing is path-based, not scope-based:
 #      - commits touching only `crates/jira-mcp/**`, `packaging/npm-mcp/**`,
 #        and/or `Cargo.lock` are eligible for the jira-mcp Release PR.
-#      - ClawHub / Claude marketplace wrapper surfaces (`clawhub/**`, `plugin/**`,
-#        `.claude-plugin/**`, and their dedicated publish-workflow/docs files)
-#        are excluded from the root `jira-commands` lane.
-#      - release-please routing/config maintenance files are also excluded so
-#        release-infra-only fixes do not mint a new CLI version.
-#      - the root `jira-commands` lane still includes other non-excluded files
-#        (for example `INSTALL.md` or `crates/jira/src/cli/mcp.rs`) and those
-#        changes can appear in the root Release PR changelog.
+#      - the root `jira-commands` lane uses explicit `include-paths`, so only
+#        root release metadata plus real CLI/core package surfaces
+#        (`Cargo.toml`, `VERSION`, `crates/jira/**`, `crates/jira-core/**`,
+#        and `packaging/npm/**`) contribute to a root release PR.
+#      - ClawHub / Claude wrapper work and release-infra-only maintenance stay
+#        outside the root lane unless they also touch one of those included
+#        release surfaces.
 #    Conventional commit scopes like `feat(mcp):` help the changelog read well,
 #    but they do not decide release lane ownership by themselves.
 # 3. When you (the owner) merge a Release PR:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,20 +8,12 @@
       "package-name": "jira-commands",
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
-      "exclude-paths": [
-        "crates/jira-mcp",
-        "packaging/npm-mcp",
-        "Cargo.lock",
-        "plugin",
-        ".claude-plugin",
-        "clawhub",
-        ".github/workflows/clawhub-publish-jirac.yml",
-        ".github/workflows/clawhub-publish-jirac-plugin.yml",
-        ".github/workflows/release-please.yml",
-        "release-please-config.json",
-        "CLAUDE.md",
-        "CONTRIBUTING.md",
-        "PLUGIN.md"
+      "include-paths": [
+        "Cargo.toml",
+        "VERSION",
+        "crates/jira",
+        "crates/jira-core",
+        "packaging/npm"
       ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },


### PR DESCRIPTION
## Description

Keep `clawhub/jirac` and `clawhub/jirac-plugin` work out of the root `jira-commands` release lane.

This switches the root release-please package from a broad `exclude-paths` list to explicit `include-paths` for the real CLI/core release surface:
- `crates/jira/**`
- `crates/jira-core/**`
- root version/changelog/docs/installers
- `packaging/npm/**`

So ClawHub / plugin-only changes will not mint a root `jira-commands` release PR by themselves, while normal CLI/core work still will.

## Why

The current `exclude-paths` setup still allowed a PR intended to fix ClawHub release behavior to end up bumping the root release lane. This narrows the lane to the intended surfaces directly.

## Notes

- no crate/runtime code changed
- this is release-routing only
- `jira-mcp` lane remains separate and untouched
