### PR TITLE
fix: avoid clawhub republish on workflow-only pushes

### DIFF
--- a/.github/workflows/clawhub-publish-jirac-plugin.yml
+++ b/.github/workflows/clawhub-publish-jirac-plugin.yml
@@ -25,6 +25,7 @@ jobs:
       PACKAGE_MARKETPLACE: clawhub/jirac-plugin/marketplace.json
       PACKAGE_VERSION_FILE: clawhub/jirac-plugin/VERSION
       PLUGIN_MANIFEST: plugin/.claude-plugin/plugin.json
+      WORKFLOW_FILE: .github/workflows/clawhub-publish-jirac-plugin.yml
       DEFAULT_CHANGELOG: Update ClawHub jirac plugin wrapper metadata
     steps:
       - name: Checkout
@@ -64,6 +65,30 @@ jobs:
           test "$PACKAGE_VER" = "$MARKETPLACE_PLUGIN_VER"
           test "$MARKETPLACE_PLUGIN_PATH" = "../../plugin"
 
+      - name: Detect publish-worthy changes
+        id: trigger
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet HEAD~1 HEAD -- "$PACKAGE_ROOT" plugin; then
+            echo "source_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet HEAD~1 HEAD -- "$WORKFLOW_FILE"; then
+            echo "workflow_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve publish metadata
         id: publish_meta
         shell: bash
@@ -90,12 +115,14 @@ jobs:
       - name: Dry-run package publish
         run: |
           npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_ROOT" \
+            --family code-plugin \
             --dry-run \
             --source-repo "https://github.com/${{ github.repository }}" \
             --source-commit "${{ github.sha }}" \
             --source-ref "${{ github.ref_name }}"
 
       - name: Publish package
+        if: steps.trigger.outputs.source_changed == 'true'
         run: |
           set -euo pipefail
 
@@ -103,6 +130,7 @@ jobs:
             echo "Publish attempt $attempt/3"
 
             if npx --prefix .github/clawhub-cli clawhub package publish "$PACKAGE_ROOT" \
+              --family code-plugin \
               --source-repo "https://github.com/${{ github.repository }}" \
               --source-commit "${{ github.sha }}" \
               --source-ref "${{ github.ref_name }}"; then
@@ -119,3 +147,7 @@ jobs:
 
           echo "Publish failed after 3 attempts."
           exit 1
+
+      - name: Skip publish when only workflow wiring changed
+        if: steps.trigger.outputs.source_changed != 'true' && steps.trigger.outputs.workflow_changed == 'true'
+        run: echo "Skipping publish because only workflow wiring changed; no package version bump was requested."

--- a/.github/workflows/clawhub-publish-jirac.yml
+++ b/.github/workflows/clawhub-publish-jirac.yml
@@ -24,6 +24,7 @@ jobs:
       SKILL_SLUG: jirac
       SKILL_NAME: jirac
       SKILL_VERSION_FILE: clawhub/jirac/VERSION
+      WORKFLOW_FILE: .github/workflows/clawhub-publish-jirac.yml
       DEFAULT_CHANGELOG: Update ClawHub jirac skill metadata and docs
     steps:
       - name: Checkout
@@ -50,6 +51,30 @@ jobs:
           test -d "$SKILL_PATH"
           test -f "$SKILL_PATH/SKILL.md"
           test -f "$SKILL_VERSION_FILE"
+
+      - name: Detect publish-worthy changes
+        id: trigger
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet HEAD~1 HEAD -- "$SKILL_PATH"; then
+            echo "source_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet HEAD~1 HEAD -- "$WORKFLOW_FILE"; then
+            echo "workflow_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Dry-run sync
         run: npx --prefix .github/clawhub-cli clawhub sync --dry-run --all --root "$SKILL_PATH"
@@ -87,6 +112,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish skill
+        if: steps.trigger.outputs.source_changed == 'true'
         run: |
           set -euo pipefail
 
@@ -111,3 +137,7 @@ jobs:
 
           echo "Publish failed after 3 attempts."
           exit 1
+
+      - name: Skip publish when only workflow wiring changed
+        if: steps.trigger.outputs.source_changed != 'true' && steps.trigger.outputs.workflow_changed == 'true'
+        run: echo "Skipping publish because only workflow wiring changed; no skill version bump was requested."


### PR DESCRIPTION
## Description

Follow up the new ClawHub publish wiring so merges that only touch the workflow files do not try to republish an already-published version.

This also fixes the plugin package command by passing the required `--family code-plugin` flag.

## What changed

- detect whether a push changed publishable source content vs only the workflow file itself
- skip the actual publish step on workflow-only pushes
- keep validation and dry-run checks in place
- add `--family code-plugin` to the plugin package publish commands

## Why

After #334 merged on `main`:
- `ClawHub Publish jirac` retriggered itself and failed with `Version already exists`
- `ClawHub Publish jirac Plugin` failed dry-run with `Could not detect package family. Use --family.`

This PR addresses both failures directly.
