### PR TITLE
feat(docs): refresh GitHub Pages landing page

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,408 @@
+/* jirac landing — interactivity */
+(function () {
+  const D = window.JIRAC;
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const el = (tag, cls, html) => {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (html != null) n.innerHTML = html;
+    return n;
+  };
+
+  /* ---------------- Theme (light/dark) ---------------- */
+  function syncThemeToggle() {
+    const dark = document.documentElement.classList.contains("dark");
+    const t = $("#theme-toggle");
+    if (t) t.setAttribute("aria-pressed", String(dark));
+    $$("[data-theme-sun]").forEach((s) => (s.style.display = dark ? "block" : "none"));
+    $$("[data-theme-moon]").forEach((s) => (s.style.display = dark ? "none" : "block"));
+  }
+  function initThemeToggle() {
+    syncThemeToggle();
+    const t = $("#theme-toggle");
+    if (!t) return;
+    t.addEventListener("click", () => {
+      const root = document.documentElement;
+      root.classList.toggle("dark");
+      localStorage.setItem("theme", root.classList.contains("dark") ? "dark" : "light");
+      syncThemeToggle();
+    });
+  }
+
+  /* ---------------- Hero direction switcher ---------------- */
+  function initHeroSwitch() {
+    const saved = localStorage.getItem("jirac-hero") || "spotlight";
+    apply(saved);
+    $$("[data-hero-pick]").forEach((b) => {
+      b.addEventListener("click", () => apply(b.dataset.heroPick));
+    });
+    function apply(name) {
+      document.body.setAttribute("data-hero", name);
+      localStorage.setItem("jirac-hero", name);
+      $$("[data-hero-pick]").forEach((b) =>
+        b.setAttribute("aria-pressed", String(b.dataset.heroPick === name))
+      );
+      // (re)start typing animation when terminal hero becomes visible
+      if (name === "terminal") startTyping();
+    }
+  }
+
+  /* ---------------- Copy buttons (event delegation) ---------------- */
+  function initCopy() {
+    document.addEventListener("click", async (e) => {
+      const btn = e.target.closest("[data-copy]");
+      if (!btn) return;
+      let text = btn.getAttribute("data-copy");
+      if (text === "@target") {
+        const sel = btn.getAttribute("data-copy-target");
+        const node = sel ? document.getElementById(sel) : null;
+        text = node ? ("value" in node && node.value !== undefined ? node.value : node.textContent) : "";
+      }
+      try {
+        await navigator.clipboard.writeText((text || "").trim());
+        flash(btn);
+      } catch (_) {
+        flash(btn, true);
+      }
+    });
+  }
+  function flash(btn, fail) {
+    const label = btn.querySelector("[data-copy-label]") || btn;
+    const prev = label.textContent;
+    btn.classList.add("is-copied");
+    label.textContent = fail ? "Failed" : "Copied";
+    setTimeout(() => {
+      label.textContent = prev;
+      btn.classList.remove("is-copied");
+    }, 1300);
+  }
+
+  /* ---------------- Tabbed installer ---------------- */
+  function detectOS() {
+    const p = (navigator.platform || "") + " " + (navigator.userAgent || "");
+    if (/Win/i.test(p)) return "windows";
+    if (/Linux|X11/i.test(p) && !/Android/i.test(p)) return "linux";
+    return "macos";
+  }
+  function initInstaller() {
+    const osWrap = $("#install-os");
+    const methodWrap = $("#install-methods");
+    const out = $("#install-cmd");
+    if (!osWrap || !methodWrap || !out) return;
+    let os = detectOS();
+    let method = null;
+
+    function renderMethods() {
+      methodWrap.innerHTML = "";
+      const list = D.install[os];
+      if (!list.find((m) => m.id === method)) method = (list.find((m) => m.recommended) || list[0]).id;
+      list.forEach((m) => {
+        const b = el("button", "install-pill", "");
+        b.type = "button";
+        b.textContent = m.label;
+        if (m.recommended) {
+          const dot = el("span", "install-pill__star", "★");
+          b.appendChild(dot);
+        }
+        b.setAttribute("aria-pressed", String(m.id === method));
+        b.addEventListener("click", () => {
+          method = m.id;
+          renderMethods();
+          renderCmd();
+        });
+        methodWrap.appendChild(b);
+      });
+    }
+    function renderCmd() {
+      const m = D.install[os].find((x) => x.id === method);
+      const cmd = m ? m.cmd : "";
+      out.querySelector("[data-cmd]").textContent = cmd;
+      const mirror = document.getElementById("install-cmd-text");
+      if (mirror) mirror.value = cmd;
+    }
+    $$("[data-os]", osWrap).forEach((b) => {
+      b.setAttribute("aria-pressed", String(b.dataset.os === os));
+      b.addEventListener("click", () => {
+        os = b.dataset.os;
+        $$("[data-os]", osWrap).forEach((x) => x.setAttribute("aria-pressed", String(x.dataset.os === os)));
+        renderMethods();
+        renderCmd();
+      });
+    });
+    renderMethods();
+    renderCmd();
+
+    // claw row
+    const claw = $("#install-claw");
+    if (claw) {
+      D.clawhub.forEach((c) => {
+        const row = el("div", "claw-row");
+        row.innerHTML = `<span class="claw-row__label">${c.label}</span><code>${c.cmd}</code>`;
+        const cp = el("button", "copy-mini", '<span data-copy-label>Copy</span>');
+        cp.type = "button";
+        cp.setAttribute("data-copy", c.cmd);
+        row.appendChild(cp);
+        claw.appendChild(row);
+      });
+    }
+  }
+
+  /* ---------------- Command explorer ---------------- */
+  function initCommands() {
+    const listWrap = $("#cmd-list");
+    const search = $("#cmd-search");
+    const filterWrap = $("#cmd-filters");
+    const count = $("#cmd-count");
+    if (!listWrap) return;
+    const groups = ["All", ...Array.from(new Set(D.commands.map((c) => c.group)))];
+    let active = "All";
+    let q = "";
+
+    groups.forEach((g) => {
+      const b = el("button", "chip", g);
+      b.type = "button";
+      b.setAttribute("aria-pressed", String(g === active));
+      b.addEventListener("click", () => {
+        active = g;
+        $$("button", filterWrap).forEach((x) => x.setAttribute("aria-pressed", String(x.textContent === active)));
+        render();
+      });
+      filterWrap.appendChild(b);
+    });
+
+    function render() {
+      const ql = q.toLowerCase();
+      const rows = D.commands.filter((c) => {
+        const okG = active === "All" || c.group === active;
+        const okQ = !ql || (c.use + " " + c.cmd + " " + c.group).toLowerCase().includes(ql);
+        return okG && okQ;
+      });
+      listWrap.innerHTML = "";
+      if (!rows.length) {
+        listWrap.appendChild(el("p", "cmd-empty", "No commands match — try a different term."));
+      }
+      rows.forEach((c) => {
+        const row = el("div", "cmd-row");
+        const left = el("div", "cmd-row__meta");
+        left.innerHTML = `<span class="cmd-row__group">${c.group}</span><span class="cmd-row__use">${hl(c.use, ql)}</span>`;
+        const right = el("div", "cmd-row__cmd");
+        const code = el("code", "", hl(escapeHtml(c.cmd), ql));
+        right.appendChild(code);
+        const cp = el("button", "copy-mini", '<span data-copy-label>Copy</span>');
+        cp.type = "button";
+        cp.setAttribute("data-copy", c.cmd);
+        right.appendChild(cp);
+        row.appendChild(left);
+        row.appendChild(right);
+        listWrap.appendChild(row);
+      });
+      if (count) count.textContent = rows.length + " command" + (rows.length === 1 ? "" : "s");
+    }
+    function hl(str, ql) {
+      if (!ql) return str;
+      const i = str.toLowerCase().indexOf(ql);
+      if (i < 0) return str;
+      return str.slice(0, i) + '<mark>' + str.slice(i, i + ql.length) + "</mark>" + str.slice(i + ql.length);
+    }
+    if (search) {
+      search.addEventListener("input", () => {
+        q = search.value;
+        render();
+      });
+    }
+    render();
+  }
+
+  function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  /* ---------------- TUI shortcuts ---------------- */
+  function initShortcuts() {
+    const wrap = $("#sc-grid");
+    if (!wrap) return;
+    const groups = ["Navigate", "Act", "View"];
+    const labels = { Navigate: "Navigate", Act: "Take action", View: "Switch views" };
+    groups.forEach((g) => {
+      const col = el("div", "sc-col");
+      col.appendChild(el("h3", "sc-col__title", labels[g]));
+      const ul = el("div", "sc-col__list");
+      D.shortcuts.filter((s) => s.group === g).forEach((s) => {
+        const row = el("div", "sc-item");
+        const keys = el("div", "sc-keys");
+        s.keys.forEach((k, i) => {
+          if (i) keys.appendChild(el("span", "sc-sep", "/"));
+          keys.appendChild(el("kbd", "keycap", k));
+        });
+        row.appendChild(keys);
+        row.appendChild(el("span", "sc-desc", s.desc));
+        ul.appendChild(row);
+      });
+      col.appendChild(ul);
+      wrap.appendChild(col);
+    });
+  }
+
+  /* ---------------- Live theme switcher + faux TUI ---------------- */
+  function initTuiTheme() {
+    const stage = $("#tui-stage");
+    const picker = $("#theme-picker");
+    if (!stage || !picker) return;
+
+    // build rows once
+    const list = $("#tui-rows", stage);
+    D.tuiRows.forEach((r, i) => {
+      const row = el("div", "ftui-row" + (i === 0 ? " is-sel" : ""));
+      row.innerHTML =
+        `<span class="ftui-key">${r.key}</span>` +
+        `<span class="ftui-badge ftui-badge--${r.st}">${r.status}</span>` +
+        `<span class="ftui-sum">${r.summary}</span>`;
+      list.appendChild(row);
+    });
+
+    function apply(t) {
+      const c = t.c;
+      Object.entries(c).forEach(([k, v]) => stage.style.setProperty("--t-" + k, v));
+      stage.setAttribute("data-light", t.id === "github-light" ? "1" : "0");
+    }
+    let activeId = D.themes[0].id;
+    D.themes.forEach((t) => {
+      const b = el("button", "theme-swatch", "");
+      b.type = "button";
+      b.innerHTML =
+        `<span class="theme-swatch__dots"><i style="background:${t.c.accent}"></i><i style="background:${t.c.green}"></i><i style="background:${t.c.yellow}"></i><i style="background:${t.c.red}"></i></span>` +
+        `<span class="theme-swatch__name">${t.name}</span>`;
+      b.setAttribute("aria-pressed", String(t.id === activeId));
+      b.addEventListener("click", () => {
+        activeId = t.id;
+        apply(t);
+        $$("button", picker).forEach((x, idx) => x.setAttribute("aria-pressed", String(D.themes[idx].id === activeId)));
+      });
+      picker.appendChild(b);
+    });
+    apply(D.themes[0]);
+  }
+
+  /* ---------------- Typing animation (terminal hero) ---------------- */
+  let typingTimer = null;
+  function startTyping() {
+    const out = $("#type-out");
+    if (!out) return;
+    clearTimeout(typingTimer);
+    const lines = [
+      { t: "$ jirac issue list --project CORE", cls: "tl-cmd", speed: 28 },
+      { t: "CORE-183  In Progress  Refactor auth error handling", cls: "tl-out" },
+      { t: "CORE-177  To Do        Add MCP transition confirmation", cls: "tl-out" },
+      { t: "CORE-171  Done         Improve TUI detail renderer", cls: "tl-out" },
+      { t: "$ jirac issue transition CORE-183 --to Done", cls: "tl-cmd", speed: 28 },
+      { t: "✓ CORE-183 moved to Done", cls: "tl-ok" },
+    ];
+    out.innerHTML = "";
+    let li = 0;
+    function nextLine() {
+      if (li >= lines.length) {
+        typingTimer = setTimeout(() => startTyping(), 4200);
+        return;
+      }
+      const spec = lines[li];
+      const lineEl = el("div", "tl " + spec.cls, "");
+      out.appendChild(lineEl);
+      if (spec.speed) {
+        let ci = 0;
+        (function type() {
+          lineEl.textContent = spec.t.slice(0, ci);
+          if (ci <= spec.t.length) {
+            ci++;
+            typingTimer = setTimeout(type, spec.speed);
+          } else {
+            li++;
+            typingTimer = setTimeout(nextLine, 260);
+          }
+        })();
+      } else {
+        lineEl.textContent = spec.t;
+        li++;
+        typingTimer = setTimeout(nextLine, 90);
+      }
+    }
+    nextLine();
+  }
+
+  /* ---------------- Scroll reveal ---------------- */
+  function initReveal() {
+    const els = $$("[data-reveal]");
+    if (!("IntersectionObserver" in window) || matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      els.forEach((e) => e.classList.add("is-in"));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((en) => {
+          if (en.isIntersecting) {
+            en.target.classList.add("is-in");
+            io.unobserve(en.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: "0px 0px -8% 0px" }
+    );
+    els.forEach((e) => io.observe(e));
+  }
+
+  /* ---------------- Scrollspy nav ---------------- */
+  function initSpy() {
+    const links = $$("[data-spy]");
+    const map = new Map();
+    links.forEach((l) => {
+      const id = l.getAttribute("href").slice(1);
+      const sec = document.getElementById(id);
+      if (sec) map.set(sec, l);
+    });
+    if (!map.size) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((en) => {
+          if (en.isIntersecting) {
+            links.forEach((l) => l.classList.remove("is-active"));
+            const l = map.get(en.target);
+            if (l) l.classList.add("is-active");
+          }
+        });
+      },
+      { rootMargin: "-45% 0px -50% 0px" }
+    );
+    map.forEach((_, sec) => io.observe(sec));
+  }
+
+  /* ---------------- Mobile nav ---------------- */
+  function initMobileNav() {
+    const btn = $("#nav-toggle");
+    const panel = $("#mobile-nav");
+    if (!btn || !panel) return;
+    btn.addEventListener("click", () => {
+      const open = panel.classList.toggle("is-open");
+      btn.setAttribute("aria-expanded", String(open));
+    });
+    $$("a", panel).forEach((a) =>
+      a.addEventListener("click", () => {
+        panel.classList.remove("is-open");
+        btn.setAttribute("aria-expanded", "false");
+      })
+    );
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initThemeToggle();
+    initHeroSwitch();
+    initCopy();
+    initInstaller();
+    initCommands();
+    initShortcuts();
+    initTuiTheme();
+    initReveal();
+    initSpy();
+    initMobileNav();
+    startTyping();
+  });
+})();

--- a/docs/data.js
+++ b/docs/data.js
@@ -1,0 +1,114 @@
+/* jirac landing — content data (install methods, commands, shortcuts, TUI themes) */
+window.JIRAC = (function () {
+  const REPO = "https://github.com/mulhamna/jira-commands";
+  const RAW = "https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme";
+
+  // ---- Install matrix: OS -> ordered methods, each a single copy-paste command ----
+  const install = {
+    macos: [
+      { id: "brew", label: "Homebrew", recommended: true, cmd: "brew tap mulhamna/tap && brew install jira-commands jira-mcp" },
+      { id: "shell", label: "Shell script", cmd: "curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | bash" },
+      { id: "cargo", label: "Cargo", cmd: "cargo install jira-commands jira-mcp" },
+      { id: "npm", label: "npm", cmd: "npm install -g @mulham28/jirac @mulham28/jirac-mcp" },
+      { id: "source", label: "From source", cmd: "git clone https://github.com/mulhamna/jira-commands && cd jira-commands && cargo install --path crates/jira --locked" },
+    ],
+    linux: [
+      { id: "shell", label: "Shell script", recommended: true, cmd: "curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | bash" },
+      { id: "cargo", label: "Cargo", cmd: "cargo install jira-commands jira-mcp" },
+      { id: "npm", label: "npm", cmd: "npm install -g @mulham28/jirac @mulham28/jirac-mcp" },
+      { id: "source", label: "From source", cmd: "git clone https://github.com/mulhamna/jira-commands && cd jira-commands && cargo install --path crates/jira --locked" },
+    ],
+    windows: [
+      { id: "winget", label: "Winget", recommended: true, cmd: "winget install mulhamna.jirac mulhamna.jirac-mcp" },
+      { id: "scoop", label: "Scoop", cmd: "scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket && scoop install mulhamna/jirac mulhamna/jirac-mcp" },
+      { id: "powershell", label: "PowerShell", cmd: "powershell -ExecutionPolicy Bypass -Command \"& ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))\"" },
+      { id: "npm", label: "npm", cmd: "npm install -g @mulham28/jirac @mulham28/jirac-mcp" },
+      { id: "cargo", label: "Cargo", cmd: "cargo install jira-commands jira-mcp" },
+    ],
+  };
+
+  // ClawHub / OpenClaw extras (shown as a small footnote row)
+  const clawhub = [
+    { label: "ClawHub skill", cmd: "openclaw skills install jirac" },
+    { label: "ClawHub plugin", cmd: "openclaw plugins install clawhub:jirac-plugin" },
+  ];
+
+  // ---- Command explorer ----
+  const commands = [
+    { group: "Issues", use: "List issues assigned to you", cmd: "jirac issue list" },
+    { group: "Issues", use: "List issues by project", cmd: "jirac issue list --project MYPROJ" },
+    { group: "Issues", use: "View one issue in detail", cmd: "jirac issue view MYPROJ-123" },
+    { group: "Issues", use: "Create a new issue", cmd: "jirac issue create --project MYPROJ" },
+    { group: "Issues", use: "Move an issue to another status", cmd: "jirac issue transition MYPROJ-123 --to Done" },
+    { group: "Issues", use: "Change an issue's type (native)", cmd: "jirac issue change-type MYPROJ-123 Story" },
+    { group: "Issues", use: "Move an issue to another project (native)", cmd: "jirac issue move MYPROJ-123 OTHER" },
+    { group: "Issues", use: "Upload an attachment", cmd: "jirac issue attach MYPROJ-123 ./screenshot.png" },
+    { group: "Reports", use: "Daily standup summary", cmd: "jirac issue standup" },
+    { group: "Reports", use: "Current sprint summary", cmd: "jirac issue sprint-summary --project MYPROJ" },
+    { group: "Reports", use: "Mention notifications", cmd: "jirac issue notifications --since 7d" },
+    { group: "Versions", use: "Browse project fix versions", cmd: "jirac issue versions --project MYPROJ" },
+    { group: "Versions", use: "Preview backlog for one fix version", cmd: "jirac issue versions --project MYPROJ --version \"v1.2.0\"" },
+    { group: "Versions", use: "Create a project version", cmd: "jirac issue versions --project MYPROJ --create --version \"v1.3.0\"" },
+    { group: "Versions", use: "Set a release date on a version", cmd: "jirac issue versions --project MYPROJ --version \"v1.2.0\" --set-release-date 2026-06-30 --released" },
+    { group: "Worklog", use: "Add a worklog", cmd: "jirac issue worklog add MYPROJ-123 --time 2h --comment \"Worked on API\"" },
+    { group: "Worklog", use: "Add a worklog with a custom start time", cmd: "jirac issue worklog add MYPROJ-123 --time 2h --date 2026-04-21 --start 09:30 --comment \"Backfilled\"" },
+    { group: "Worklog", use: "Backfill worklogs across a date range", cmd: "jirac issue worklog add MYPROJ-123 --time 2h --from 2026-04-21 --to 2026-04-25 --exclude-weekends" },
+    { group: "Bulk", use: "Bulk comment by JQL", cmd: "jirac issue bulk-comment --jql 'project = MYPROJ AND sprint = openSprints()' --body \"Status before standup\"" },
+    { group: "Bulk", use: "Bulk comment by explicit keys", cmd: "jirac issue bulk-comment --keys MYPROJ-123 MYPROJ-456 --file note.md" },
+    { group: "Bulk", use: "Bulk transition by JQL", cmd: "jirac issue bulk-transition --jql 'project = MYPROJ AND status = \"To Do\"' --to \"In Progress\"" },
+    { group: "Bulk", use: "Bulk update a field", cmd: "jirac issue bulk-update --jql 'project = MYPROJ AND assignee = EMPTY' --assignee me" },
+    { group: "Bulk", use: "Bulk create from a manifest", cmd: "jirac issue bulk-create --manifest issues.json" },
+    { group: "Search", use: "Interactive JQL builder", cmd: "jirac issue jql" },
+    { group: "Auth", use: "Log in for the first time", cmd: "jirac auth login" },
+    { group: "Auth", use: "Check connection status", cmd: "jirac auth status" },
+    { group: "Auth", use: "Switch between profiles", cmd: "jirac auth use work-cloud" },
+    { group: "TUI", use: "Launch the interactive TUI", cmd: "jirac tui -p MYPROJ" },
+    { group: "API", use: "Make a raw API call", cmd: "jirac api get /rest/api/3/serverInfo" },
+  ];
+
+  // ---- TUI keyboard shortcuts ----
+  const shortcuts = [
+    { keys: ["↑", "k"], desc: "Move to the issue above", group: "Navigate" },
+    { keys: ["↓", "j"], desc: "Move to the issue below", group: "Navigate" },
+    { keys: ["Enter"], desc: "Open details for the selected issue", group: "Navigate" },
+    { keys: ["?"], desc: "Show shortcut help", group: "Navigate" },
+    { keys: ["c"], desc: "Create a new issue", group: "Act" },
+    { keys: ["e"], desc: "Edit the selected issue", group: "Act" },
+    { keys: ["t"], desc: "Change status (transition)", group: "Act" },
+    { keys: ["y"], desc: "Change backlog item type in a modal", group: "Act" },
+    { keys: ["M"], desc: "Move item to another project", group: "Act" },
+    { keys: ["s"], desc: "Assign the issue to a sprint", group: "Act" },
+    { keys: ["u"], desc: "Upload an attachment", group: "Act" },
+    { keys: [";"], desc: "Add one comment to the selected issue", group: "Act" },
+    { keys: [":"], desc: "Bulk-comment many issues by JQL or keys", group: "Act" },
+    { keys: ["w"], desc: "Add a single worklog", group: "Act" },
+    { keys: ["b"], desc: "Add bulk worklogs across a date range", group: "Act" },
+    { keys: ["v"], desc: "Edit fix versions", group: "Act" },
+    { keys: ["n"], desc: "Scan and open mention notifications", group: "View" },
+    { keys: ["R"], desc: "Mark the selected notification as read", group: "View" },
+    { keys: ["V"], desc: "Browse project fix versions + backlog", group: "View" },
+    { keys: ["p"], desc: "Open saved JQL queries", group: "View" },
+    { keys: ["C"], desc: "Choose visible table columns (persisted)", group: "View" },
+    { keys: ["T"], desc: "Open the theme picker", group: "View" },
+  ];
+
+  // ---- Faux-TUI theme presets (for the live preview) ----
+  const themes = [
+    { id: "default", name: "Default Dark", c: { bg: "#0b1220", panel: "#0e1626", border: "#1e2a44", text: "#cdd6f4", dim: "#7d8db0", accent: "#4e97ff", sel: "#13294d", green: "#34d058", yellow: "#e3b341", red: "#ff6b6b" } },
+    { id: "github-light", name: "GitHub Light", c: { bg: "#ffffff", panel: "#f6f8fa", border: "#d0d7de", text: "#1f2328", dim: "#656d76", accent: "#0969da", sel: "#ddf4ff", green: "#1a7f37", yellow: "#9a6700", red: "#cf222e" } },
+    { id: "kanagawa", name: "Kanagawa Wave", c: { bg: "#1f1f28", panel: "#2a2a37", border: "#363646", text: "#dcd7ba", dim: "#727169", accent: "#7e9cd8", sel: "#363646", green: "#98bb6c", yellow: "#e6c384", red: "#e46876" } },
+    { id: "tokyonight", name: "Tokyo Night", c: { bg: "#1a1b26", panel: "#1f2335", border: "#2f334d", text: "#c0caf5", dim: "#565f89", accent: "#7aa2f7", sel: "#283457", green: "#9ece6a", yellow: "#e0af68", red: "#f7768e" } },
+    { id: "gruvbox", name: "Gruvbox", c: { bg: "#282828", panel: "#32302f", border: "#504945", text: "#ebdbb2", dim: "#a89984", accent: "#83a598", sel: "#3c3836", green: "#b8bb26", yellow: "#fabd2f", red: "#fb4934" } },
+  ];
+
+  // Sample rows for the faux-TUI
+  const tuiRows = [
+    { key: "CORE-183", status: "In Progress", st: "prog", summary: "Refactor auth error handling" },
+    { key: "CORE-177", status: "To Do", st: "todo", summary: "Add MCP transition confirmation" },
+    { key: "CORE-171", status: "Done", st: "done", summary: "Improve TUI issue detail renderer" },
+    { key: "CORE-168", status: "In Review", st: "rev", summary: "Cursor pagination for /search/jql" },
+    { key: "CORE-160", status: "To Do", st: "todo", summary: "Backfill worklog date-range flow" },
+  ];
+
+  return { REPO, RAW, install, clawhub, commands, shortcuts, themes, tuiRows };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,563 +1,331 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
 <head>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LFHBF9XWMJ"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-LFHBF9XWMJ');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="jirac is a Jira CLI and terminal UI for Jira issue management, JQL search, fix versions, worklogs, MCP integration, and automation-friendly workflows." />
-  <meta name="keywords" content="jira cli,jira command line,jira terminal,jira tui,jql cli,jira mcp,jira automation,jira-commands,jirac" />
+  <title>jirac — a fast Jira CLI, TUI & MCP server for the terminal</title>
+  <meta name="description" content="jirac is an open-source Jira CLI with a full terminal UI, JQL search, fix-version management, worklogs, and MCP integration for AI-assisted workflows." />
   <link rel="canonical" href="https://mulhamna.github.io/jira-commands/" />
   <meta property="og:title" content="jirac — Jira CLI, terminal UI, and MCP tooling" />
   <meta property="og:description" content="Open-source Jira CLI for terminal-first teams: search Jira, browse issues, manage fix versions, log work, and run Jira through TUI or MCP." />
   <meta property="og:image" content="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" />
-  <meta property="og:url" content="https://mulhamna.github.io/jira-commands/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="jirac — Jira CLI, terminal UI, and MCP tooling" />
-  <meta name="twitter:description" content="A modern Jira CLI for issue management, JQL, worklogs, fix versions, and terminal-first workflows." />
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23124ee5'/%3E%3Ctext x='32' y='41' font-size='26' font-weight='700' text-anchor='middle' fill='white' font-family='Arial, sans-serif'%3Ejc%3C/text%3E%3C/svg%3E" />
-  <title>Jira CLI for Terminal, TUI, and MCP | jirac Docs</title>
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "jirac",
-      "alternateName": ["jira-commands", "Jira CLI"],
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "macOS, Linux, Windows",
-      "description": "Open-source Jira CLI with terminal UI, JQL search, fix-version management, worklogs, and MCP integration.",
-      "url": "https://mulhamna.github.io/jira-commands/",
-      "downloadUrl": "https://github.com/mulhamna/jira-commands",
-      "softwareHelp": "https://mulhamna.github.io/jira-commands/",
-      "image": "https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg",
-      "license": "https://github.com/mulhamna/jira-commands/blob/main/LICENSE"
-    }
-  </script>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='15' fill='%231f6dff'/%3E%3Ctext x='32' y='42' font-size='27' font-weight='800' text-anchor='middle' fill='white' font-family='monospace'%3Ejc%3C/text%3E%3C/svg%3E" />
   <script>
     (function () {
-      const saved = localStorage.getItem('theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (saved === 'dark' || (!saved && prefersDark)) {
-        document.documentElement.classList.add('dark');
-      }
+      var saved = localStorage.getItem("theme");
+      var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (saved === "dark" || (!saved && prefersDark)) document.documentElement.classList.add("dark");
     })();
   </script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      darkMode: 'class',
-      theme: {
-        extend: {
-          colors: {
-            brand: {
-              50: '#f2f8ff',
-              100: '#d9ebff',
-              200: '#b7d8ff',
-              300: '#84bcff',
-              400: '#4e97ff',
-              500: '#266fff',
-              600: '#124ee5',
-              700: '#113fb6',
-              800: '#153a8f',
-              900: '#183477'
-            }
-          },
-          fontFamily: {
-            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif'],
-            mono: ['JetBrains Mono', 'SFMono-Regular', 'Menlo', 'Monaco', 'Cascadia Code', 'Consolas', 'Liberation Mono', 'monospace']
-          },
-          boxShadow: {
-            soft: '0 8px 30px rgba(15, 23, 42, 0.08)'
-          }
-        }
-      }
-    }
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"SoftwareApplication","name":"jirac","alternateName":["jira-commands","Jira CLI"],"applicationCategory":"DeveloperApplication","operatingSystem":"macOS, Linux, Windows","description":"Open-source Jira CLI with terminal UI, JQL search, fix-version management, worklogs, and MCP integration.","url":"https://mulhamna.github.io/jira-commands/","downloadUrl":"https://github.com/mulhamna/jira-commands"}
   </script>
-  <style>
-    .bg-grid {
-      background-image: linear-gradient(to right, rgba(37, 99, 235, 0.08) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(37, 99, 235, 0.08) 1px, transparent 1px);
-      background-size: 26px 26px;
-    }
-    .dark .bg-grid {
-      background-image: linear-gradient(to right, rgba(148, 163, 184, 0.12) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
-    }
-    .command-row {
-      border: 1px solid rgba(148, 163, 184, 0.28);
-      background: linear-gradient(180deg, rgba(15, 23, 42, 0.98) 0%, rgba(2, 6, 23, 0.98) 100%);
-      transition: border-color .2s ease, transform .2s ease, box-shadow .2s ease;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 8px 24px rgba(2, 6, 23, 0.18);
-    }
-    .command-row:hover {
-      border-color: rgba(96, 165, 250, 0.7);
-      transform: translateY(-1px);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 14px 30px rgba(2, 6, 23, 0.28);
-    }
-    .command-row code,
-    pre code,
-    .command-code {
-      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
-      font-size: 0.95em;
-      line-height: 1.7;
-      font-weight: 500;
-      -webkit-font-smoothing: auto;
-      text-rendering: optimizeLegibility;
-    }
-    p code,
-    li code,
-    td code,
-    .inline-code {
-      display: inline-block;
-      padding: 0.14rem 0.42rem;
-      border-radius: 0.5rem;
-      border: 1px solid rgba(148, 163, 184, 0.32);
-      background: rgba(241, 245, 249, 0.95);
-      color: rgb(15, 23, 42);
-      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
-      font-size: 0.9em;
-      font-weight: 600;
-      line-height: 1.35;
-      vertical-align: baseline;
-      word-break: break-word;
-    }
-    .keycap {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 2rem;
-      padding: 0.2rem 0.5rem;
-      border-radius: 0.6rem;
-      border: 1px solid rgba(148, 163, 184, 0.38);
-      background: linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(241,245,249,0.98) 100%);
-      box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.22), 0 1px 2px rgba(15, 23, 42, 0.08);
-      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, 'Cascadia Code', Consolas, 'Liberation Mono', monospace;
-      font-size: 0.85em;
-      font-weight: 700;
-      color: rgb(15, 23, 42);
-    }
-    .mini-command {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      margin-top: 0.8rem;
-      padding: 0.7rem 0.9rem;
-      border-radius: 0.75rem;
-      border: 1px solid rgba(51, 65, 85, 0.12);
-      background: rgba(15, 23, 42, 0.96);
-      color: rgb(248, 250, 252);
-      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
-    }
-    .mini-command-label {
-      font-size: 0.72rem;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: rgb(147, 197, 253);
-    }
-    .command-cell code {
-      display: inline-block;
-      max-width: 100%;
-      padding: 0.28rem 0.56rem;
-      border-radius: 0.6rem;
-      border: 1px solid rgba(148, 163, 184, 0.28);
-      background: rgba(248, 250, 252, 0.96);
-      color: rgb(15, 23, 42);
-      font-size: 0.88em;
-      font-weight: 600;
-    }
-    .dark .doc-card {
-      background: linear-gradient(180deg, rgba(15, 23, 42, 0.9) 0%, rgba(2, 6, 23, 0.92) 100%);
-      border-color: rgba(71, 85, 105, 0.65);
-      box-shadow: 0 14px 40px rgba(2, 6, 23, 0.45);
-    }
-    .dark p code,
-    .dark li code,
-    .dark td code,
-    .dark .inline-code,
-    .dark .command-cell code {
-      border-color: rgba(71, 85, 105, 0.75);
-      background: rgba(15, 23, 42, 0.92);
-      color: rgb(241, 245, 249);
-    }
-    .dark .keycap {
-      border-color: rgba(100, 116, 139, 0.72);
-      background: linear-gradient(180deg, rgba(30,41,59,0.98) 0%, rgba(15,23,42,0.98) 100%);
-      box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.18), 0 1px 2px rgba(2, 6, 23, 0.35);
-      color: rgb(241, 245, 249);
-    }
-    .dark .mini-command {
-      border-color: rgba(71, 85, 105, 0.72);
-      background: linear-gradient(180deg, rgba(15,23,42,0.96) 0%, rgba(2,6,23,0.98) 100%);
-      box-shadow: 0 14px 28px rgba(2, 6, 23, 0.4);
-    }
-    .dark .copy-btn {
-      border-color: rgba(100, 116, 139, 0.7);
-      background: rgba(15, 23, 42, 0.75);
-      color: rgb(226, 232, 240);
-    }
-    .dark .copy-btn:hover {
-      border-color: rgba(96, 165, 250, 0.9);
-      color: #fff;
-      background: rgba(30, 41, 59, 0.95);
-    }
-  </style>
 </head>
-<body class="bg-slate-50 dark:bg-slate-950 text-slate-800 dark:text-slate-200 antialiased">
-  <header class="sticky top-0 z-50 border-b border-slate-200 dark:border-slate-700 bg-white/90 dark:bg-slate-900/90 backdrop-blur">
-    <div class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
-      <a href="#top" class="flex items-center gap-2 font-semibold text-slate-900 dark:text-slate-100">
-        <span class="inline-flex h-8 w-8 items-center justify-center rounded bg-brand-600 text-xs font-bold text-white">jc</span>
-        <span>jirac docs</span>
+<body data-hero="spotlight">
+  <!-- ===================== HEADER ===================== -->
+  <header class="site-header">
+    <div class="wrap site-header__row">
+      <a href="#top" class="brand" aria-label="jirac home">
+        <span class="brand__mark">jc</span>
+        <span class="brand__name"><b>jirac</b></span>
       </a>
-      <nav class="hidden items-center gap-5 text-sm md:flex">
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#why">Why</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#screenshots">Screenshots</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#quickstart">Quickstart</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#commands">Commands</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#mcp">MCP</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#contributing">Contributing</a>
-        <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded-sm" href="#faq">FAQ</a>
+      <nav class="nav" aria-label="Primary">
+        <a href="#install" data-spy>Install</a>
+        <a href="#features" data-spy>Features</a>
+        <a href="#commands" data-spy>Commands</a>
+        <a href="#tui" data-spy>TUI</a>
+        <a href="#mcp" data-spy>MCP</a>
+        <a href="#faq" data-spy>FAQ</a>
       </nav>
-      <div class="flex items-center gap-2">
-        <button id="theme-toggle" type="button" class="inline-flex items-center gap-2 rounded-md border border-slate-300 dark:border-slate-600 px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300 hover:border-brand-300 hover:text-brand-700 dark:hover:text-brand-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" aria-label="Toggle theme">
-          <span id="theme-icon" aria-hidden="true">🌙</span>
-          <span id="theme-label">Dark</span>
+      <div class="header-actions">
+        <button id="theme-toggle" class="icon-btn" type="button" aria-label="Toggle dark mode" aria-pressed="false">
+          <svg data-theme-moon viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/></svg>
+          <svg data-theme-sun viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
         </button>
-        <a href="https://github.com/mulhamna/jira-commands" class="rounded-md border border-slate-300 dark:border-slate-600 px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300 hover:border-brand-300 hover:text-brand-700 dark:hover:text-brand-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400">GitHub</a>
+        <a href="https://github.com/mulhamna/jira-commands" class="gh-cta" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12a11.5 11.5 0 0 0 7.9 10.9c.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.7.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.4 11.4 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6A11.5 11.5 0 0 0 23.5 12C23.5 5.7 18.3.5 12 .5Z"/></svg>
+          <span class="gh-cta__text">Star on GitHub</span>
+        </a>
+        <button id="nav-toggle" class="icon-btn" type="button" aria-label="Open menu" aria-expanded="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
       </div>
     </div>
-    <nav class="md:hidden border-t border-slate-200 dark:border-slate-700 px-4 py-2 overflow-x-auto whitespace-nowrap text-sm">
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#why">Why</a>
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#screenshots">Screenshots</a>
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#quickstart">Quickstart</a>
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#commands">Commands</a>
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#mcp">MCP</a>
-      <a class="mr-4 text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#contributing">Contributing</a>
-      <a class="text-slate-600 dark:text-slate-400 hover:text-brand-700" href="#faq">FAQ</a>
-    </nav>
+    <div class="mobile-nav" id="mobile-nav">
+      <a href="#install">Install</a>
+      <a href="#features">Features</a>
+      <a href="#commands">Commands</a>
+      <a href="#tui">TUI</a>
+      <a href="#mcp">MCP</a>
+      <a href="#faq">FAQ</a>
+    </div>
   </header>
 
   <main id="top">
-    <section class="relative overflow-hidden border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="absolute inset-0 bg-grid"></div>
-      <div class="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:flex lg:items-center lg:justify-between lg:gap-12 lg:px-8 lg:py-20">
-        <div class="max-w-2xl">
-          <p class="mb-3 inline-flex rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700">Jira CLI + terminal UI + MCP</p>
-          <h1 class="text-4xl font-extrabold tracking-tight text-slate-900 dark:text-slate-100 sm:text-5xl">A modern <span class="text-brand-700">Jira CLI</span> for terminal-first teams</h1>
-          <p class="mt-5 text-lg leading-relaxed text-slate-600 dark:text-slate-400">jirac is an open-source Jira command-line tool with a full TUI, JQL search, fix-version management, worklogs, attachments, backlog moves, and MCP integration for AI-assisted workflows.</p>
-          <div class="mt-8 flex flex-wrap gap-3">
-            <a href="#quickstart" class="rounded-md bg-brand-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-700">Get Started</a>
-            <a href="#non-tech" class="rounded-md border border-slate-300 bg-white dark:bg-slate-900 px-5 py-2.5 text-sm font-medium text-slate-700 dark:text-slate-300 hover:border-brand-300 hover:text-brand-700">For Non-Tech Users</a>
+    <!-- ===================== HERO ===================== -->
+    <section class="hero">
+      <div class="hero__glow"></div>
+      <svg class="hero__holo" viewBox="0 0 1440 860" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false">
+        <defs>
+          <linearGradient id="holo" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#4e97ff"/>
+            <stop offset="0.34" stop-color="#7c5cff"/>
+            <stop offset="0.62" stop-color="#33d6e7"/>
+            <stop offset="1" stop-color="#4e97ff"/>
+          </linearGradient>
+          <g id="rustGear">
+            <path fill="url(#holo)" fill-rule="evenodd" d="M-7.70 -91.68L-8.79 -111.65L8.79 -111.65L7.70 -91.68L16.29 -90.55L20.41 -110.12L37.39 -105.58L31.16 -86.56L39.17 -83.24L48.22 -101.09L63.44 -92.30L52.51 -75.55L59.38 -70.27L72.74 -85.17L85.17 -72.74L70.27 -59.38L75.55 -52.51L92.30 -63.44L101.09 -48.22L83.24 -39.17L86.56 -31.16L105.58 -37.39L110.12 -20.41L90.55 -16.29L91.68 -7.70L111.65 -8.79L111.65 8.79L91.68 7.70L90.55 16.29L110.12 20.41L105.58 37.39L86.56 31.16L83.24 39.17L101.09 48.22L92.30 63.44L75.55 52.51L70.27 59.38L85.17 72.74L72.74 85.17L59.38 70.27L52.51 75.55L63.44 92.30L48.22 101.09L39.17 83.24L31.16 86.56L37.39 105.58L20.41 110.12L16.29 90.55L7.70 91.68L8.79 111.65L-8.79 111.65L-7.70 91.68L-16.29 90.55L-20.41 110.12L-37.39 105.58L-31.16 86.56L-39.17 83.24L-48.22 101.09L-63.44 92.30L-52.51 75.55L-59.38 70.27L-72.74 85.17L-85.17 72.74L-70.27 59.38L-75.55 52.51L-92.30 63.44L-101.09 48.22L-83.24 39.17L-86.56 31.16L-105.58 37.39L-110.12 20.41L-90.55 16.29L-91.68 7.70L-111.65 8.79L-111.65 -8.79L-91.68 -7.70L-90.55 -16.29L-110.12 -20.41L-105.58 -37.39L-86.56 -31.16L-83.24 -39.17L-101.09 -48.22L-92.30 -63.44L-75.55 -52.51L-70.27 -59.38L-85.17 -72.74L-72.74 -85.17L-59.38 -70.27L-52.51 -75.55L-63.44 -92.30L-48.22 -101.09L-39.17 -83.24L-31.16 -86.56L-37.39 -105.58L-20.41 -110.12L-16.29 -90.55ZM60 0A60 60 0 1 1 -60 0A60 60 0 1 1 60 0Z"/>
+            <text x="0" y="42" text-anchor="middle" font-family="'JetBrains Mono',ui-monospace,monospace" font-weight="700" font-size="116" fill="url(#holo)">R</text>
+          </g>
+        </defs>
+        <use href="#rustGear" transform="translate(120 150) scale(1.55) rotate(9)" opacity="0.13"/>
+        <use href="#rustGear" transform="translate(1340 300) scale(2.15) rotate(-13)" opacity="0.12"/>
+        <use href="#rustGear" transform="translate(190 760) scale(1.0) rotate(22)" opacity="0.07"/>
+        <use href="#rustGear" transform="translate(1230 70) scale(0.62) rotate(-6)" opacity="0.11"/>
+        <use href="#rustGear" transform="translate(740 820) scale(2.5) rotate(4)" opacity="0.05"/>
+      </svg>
+      <div class="hero__grid"></div>
+      <div class="wrap">
+        <div style="display:flex;justify-content:center;margin-bottom:36px" data-reveal>
+          <div class="dir-switch" role="group" aria-label="Hero style">
+            <span class="dir-switch__label">Style</span>
+            <button type="button" data-hero-pick="spotlight" aria-pressed="true">Spotlight</button>
+            <button type="button" data-hero-pick="split" aria-pressed="false">Split</button>
+            <button type="button" data-hero-pick="terminal" aria-pressed="false">Terminal</button>
           </div>
-          <p class="mt-4 text-xs text-slate-500 dark:text-slate-400">Not affiliated with, endorsed by, or sponsored by Atlassian.</p>
         </div>
-        <div class="mt-10 w-full max-w-xl rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-900 p-3 text-slate-100 shadow-soft lg:mt-0">
-          <p class="mb-2 text-xs uppercase tracking-wide text-slate-400">Split master-detail TUI</p>
-          <img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" alt="jirac split-pane TUI showing issue list with detail panel" class="w-full rounded-lg border border-slate-700" loading="lazy" />
-          <pre class="mt-3 overflow-x-auto text-sm leading-6"><code>$ jirac issue list --project CORE
-CORE-183  In Progress  Refactor auth error handling
-CORE-177  To Do        Add MCP transition confirmation
-CORE-171  Done         Improve TUI issue detail renderer
 
-$ jirac issue transition CORE-183 --to Done
-✓ CORE-183 moved to Done</code></pre>
+        <!-- Variant A: Spotlight -->
+        <div class="hero-variant hero-variant--spotlight">
+          <span class="badge-pill" data-reveal><span class="badge-pill__tag">v3 API</span> <b>CLI</b> · TUI · MCP server</span>
+          <h1 data-reveal data-reveal-delay="1">Run Jira from the <span class="grad">terminal.</span></h1>
+          <p class="hero__sub" data-reveal data-reveal-delay="2">jirac is an open-source Jira CLI with a full keyboard-driven TUI, JQL search, worklogs, fix-version management, and an MCP server for AI-assisted workflows — without living in the web UI.</p>
+          <div class="hero__cta" data-reveal data-reveal-delay="2">
+            <a href="#install" class="btn btn-primary">Install jirac</a>
+            <a href="#commands" class="btn btn-ghost">Browse commands</a>
+          </div>
+          <p class="hero__note" data-reveal data-reveal-delay="3">Not affiliated with, endorsed by, or sponsored by Atlassian.</p>
+          <div class="hero-stage" data-reveal data-reveal-delay="2">
+            <div class="win">
+              <div class="win__bar"><span class="win__dot win__dot--r"></span><span class="win__dot win__dot--y"></span><span class="win__dot win__dot--g"></span><span class="win__title">~/code/core — jirac</span></div>
+              <div class="win__body"><div class="term" id="type-out"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Variant B: Split -->
+        <div class="hero-variant hero-variant--split">
+          <div class="hero__inner">
+            <span class="badge-pill"><span class="badge-pill__tag">v3 API</span> <b>CLI</b> · TUI · MCP server</span>
+            <h1>The Jira CLI for <span class="grad">terminal-first</span> teams.</h1>
+            <p class="hero__sub">Browse, update, and automate Jira from your shell. Full TUI, JQL search, worklogs, fix versions, bulk actions, and an MCP server for agents.</p>
+            <div class="hero__cta">
+              <a href="#install" class="btn btn-primary">Install jirac</a>
+              <a href="https://github.com/mulhamna/jira-commands" target="_blank" rel="noopener" class="btn btn-ghost">View source</a>
+            </div>
+            <p class="hero__note">Not affiliated with, endorsed by, or sponsored by Atlassian.</p>
+          </div>
+          <div class="hero__inner">
+            <div class="hero-screenshot">
+              <img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" alt="jirac split-pane TUI showing an issue list with a detail panel" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Variant C: Terminal -->
+        <div class="hero-variant hero-variant--terminal">
+          <div class="hero__inner" style="margin-inline:auto;text-align:center">
+            <span class="badge-pill" style="margin-inline:auto"><span class="badge-pill__tag">v3 API</span> <b>CLI</b> · TUI · MCP server</span>
+            <h1>Your backlog, <span class="grad">one keystroke</span> away.</h1>
+            <p class="hero__sub" style="margin-inline:auto;text-align:center">A daily-driver Jira CLI that lives where you already work — the terminal.</p>
+          </div>
+          <div class="hero-stage hero-stage--big">
+            <div class="win">
+              <div class="win__bar"><span class="win__dot win__dot--r"></span><span class="win__dot win__dot--y"></span><span class="win__dot win__dot--g"></span><span class="win__title">jirac — live</span></div>
+              <div class="win__body"><div class="term" id="type-out"></div></div>
+            </div>
+            <div class="hero__cta" style="justify-content:center">
+              <a href="#install" class="btn btn-primary">Install jirac</a>
+              <a href="#tui" class="btn btn-ghost">See the TUI</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>
 
-    <section id="why" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-      <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Why jirac</h2>
-      <p class="mt-2 max-w-3xl text-sm text-slate-600 dark:text-slate-400">If you searched for a Jira CLI, Jira command line tool, or terminal client for Jira, this page is the quick answer: <strong>jirac</strong> is built for browsing, updating, and automating Jira without living in the web UI.</p>
-      <div class="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Latest Jira API v3</h3>
-          <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Uses modern endpoints like <code>/search/jql</code> with cursor pagination.</p>
-        </article>
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Custom fields supported</h3>
-          <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Runtime field introspection without manual YAML mapping.</p>
-        </article>
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Terminal + TUI + MCP</h3>
-          <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Works for direct CLI, keyboard-driven TUI, mention inboxes, and agent workflows.</p>
-        </article>
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Cross-platform</h3>
-          <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">macOS, Linux, and Windows releases with focused CLI binaries for terminal and MCP workflows.</p>
-        </article>
+    <!-- ===================== INSTALL ===================== -->
+    <section class="section section--tight" id="install">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">Install</span>
+          <h2>Pick your platform, copy one line.</h2>
+          <p>Choose your OS and package manager — we’ll show the single command you need. Everything installs both <code class="mono">jirac</code> and the <code class="mono">jirac-mcp</code> server.</p>
+        </div>
+        <div class="installer" data-reveal data-reveal-delay="1">
+          <div class="installer__os" id="install-os" role="tablist" aria-label="Operating system">
+            <button class="os-tab" type="button" data-os="macos">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M16.7 12.7c0-2.3 1.9-3.4 2-3.5-1.1-1.6-2.8-1.8-3.4-1.8-1.4-.1-2.8.9-3.5.9s-1.8-.8-3-.8C7.2 7.5 5.7 8.4 5 9.9c-1.6 2.8-.4 7 1.2 9.3.8 1.1 1.7 2.4 2.9 2.3 1.2-.1 1.6-.8 3-.8s1.8.8 3 .7c1.2 0 2-1.1 2.8-2.3.6-.8.8-1.3 1.3-2.3-3.4-1.3-3.5-5-3.5-6.1ZM14.5 5.6c.6-.8 1-1.9.9-3-.9 0-2 .6-2.7 1.4-.6.7-1.1 1.8-.9 2.9 1 .1 2-.5 2.7-1.3Z"/></svg>
+              macOS
+            </button>
+            <button class="os-tab" type="button" data-os="linux">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2c-1.7 0-3 1.6-3 3.5 0 1 .2 1.6.2 2.4 0 .9-.7 1.6-1.4 2.7C6.8 12 6 13.4 6 15c0 .6-.5 1-.9 1.6-.4.5-.6 1-.3 1.6.2.5.8.6 1.4.7.7.1 1.3.3 1.8.8.4.4.9.7 1.6.7.5 0 1-.2 1.4-.5.4.3.9.5 1.4.5.7 0 1.2-.3 1.6-.7.5-.5 1.1-.7 1.8-.8.6-.1 1.2-.2 1.4-.7.3-.6.1-1.1-.3-1.6-.4-.6-.9-1-.9-1.6 0-1.6-.8-3-1.8-4.4-.7-1.1-1.4-1.8-1.4-2.7 0-.8.2-1.4.2-2.4C15 3.6 13.7 2 12 2Zm-1.4 4.1c.3 0 .5.3.5.7s-.2.7-.5.7-.5-.3-.5-.7.2-.7.5-.7Zm2.8 0c.3 0 .5.3.5.7s-.2.7-.5.7-.5-.3-.5-.7.2-.7.5-.7Z"/></svg>
+              Linux
+            </button>
+            <button class="os-tab" type="button" data-os="windows">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 5.7 10.5 4.7V11.5H3V5.7ZM10.5 12.5V19.3L3 18.3V12.5H10.5ZM11.5 4.6 21 3.2V11.5H11.5V4.6ZM21 12.5V20.8L11.5 19.4V12.5H21Z"/></svg>
+              Windows
+            </button>
+          </div>
+          <div class="installer__body">
+            <div class="install-methods" id="install-methods"></div>
+            <div class="install-cmd" id="install-cmd">
+              <code class="mono"><span class="prompt">$</span><span data-cmd></span></code>
+              <button class="copy-mini" type="button" data-copy="@target" data-copy-target="install-cmd-text"><span data-copy-label>Copy</span></button>
+            </div>
+            <p class="install-hint">Need the full matrix or the standalone MCP binary? See <a class="link" href="https://github.com/mulhamna/jira-commands/blob/main/INSTALL.md" target="_blank" rel="noopener">INSTALL.md</a>. OpenClaw users can grab the published skill or plugin:</p>
+            <div class="claw" id="install-claw"></div>
+          </div>
+        </div>
       </div>
     </section>
 
-    <section class="border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">What makes this Jira CLI different?</h2>
-        <div class="mt-6 grid gap-4 lg:grid-cols-3">
-          <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-            <h3 class="font-semibold">More than a thin wrapper</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">jirac is not just a couple of REST helpers. It ships a daily-driver Jira CLI, interactive TUI, MCP server, saved JQL flows, version browsing, and native-style issue move/type actions.</p>
+    <!-- ===================== FEATURES ===================== -->
+    <section class="section" id="features" style="background:var(--bg-sunken);border-block:1px solid var(--line)">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">Why jirac</span>
+          <h2>More than a thin REST wrapper.</h2>
+          <p>A daily-driver toolkit for the people who live in a terminal — and the agents that work alongside them.</p>
+        </div>
+        <div class="feat-grid">
+          <article class="feat-card" data-reveal>
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m4 17 6-6-6-6M12 19h8"/></svg></div>
+            <h3>CLI · TUI · MCP</h3>
+            <p>One tool, three surfaces: scriptable CLI, a keyboard-driven TUI, and an <code>jirac-mcp</code> server for AI agents.</p>
           </article>
-          <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-            <h3 class="font-semibold">Built for real Jira workflows</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use it to list assigned issues, generate daily standups and sprint summaries, search with JQL, update assignees, log work, preview fix-version backlog, manage project versions, and handle mention notifications from the terminal.</p>
+          <article class="feat-card" data-reveal data-reveal-delay="1">
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg></div>
+            <h3>JQL, the easy way</h3>
+            <p>Interactive query builder by project, status, and assignee — plus saved JQL flows you can re-run instantly.</p>
           </article>
-          <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-            <h3 class="font-semibold">Good fit for humans and agents</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Terminal users get keyboard speed; automation stacks get CLI composability; AI tooling gets <code>jirac-mcp</code> for MCP-based Jira access.</p>
+          <article class="feat-card" data-reveal data-reveal-delay="2">
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m7 14 4-4 3 3 5-6"/></svg></div>
+            <h3>Reports in seconds</h3>
+            <p>Daily standups, sprint summaries, worklog backfills across date ranges, and mention notifications — straight to the terminal.</p>
+          </article>
+          <article class="feat-card" data-reveal>
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18M5 8l7-5 7 5M5 16l7 5 7-5"/></svg></div>
+            <h3>Native bulk + moves</h3>
+            <p>Change issue type, move across projects with native semantics, and bulk-comment, -transition, -update, or -create.</p>
+          </article>
+          <article class="feat-card" data-reveal data-reveal-delay="1">
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5M12 22V12"/></svg></div>
+            <h3>Custom fields, auto-mapped</h3>
+            <p>Runtime field introspection per project — no manual YAML mapping to maintain. Built on the latest Jira API v3.</p>
+          </article>
+          <article class="feat-card" data-reveal data-reveal-delay="2">
+            <div class="feat-card__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m6 9 3 3-3 3M13 15h4"/></svg></div>
+            <h3>Cross-platform &amp; fast</h3>
+            <p>A single Rust binary for macOS, Linux, and Windows. Quick to install, quicker to run.</p>
           </article>
         </div>
       </div>
     </section>
 
-    <section id="screenshots" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-      <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Screenshots</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Issue browser, split master-detail layout, and interactive JQL builder — presented as three focused preview cards.</p>
-      <div class="mt-6 grid gap-5 md:grid-cols-3">
-        <figure class="flex h-full flex-col rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 shadow-soft">
-          <div class="aspect-video overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-950">
-            <img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui.jpeg" alt="jirac TUI issue list" class="h-full w-full object-cover" loading="lazy" />
+    <!-- ===================== COMMANDS ===================== -->
+    <section class="section" id="commands">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">Command reference</span>
+          <h2>Every command, one search box.</h2>
+          <p>Filter by category or type what you’re trying to do — then copy the command. <code class="mono">jirac --help</code> always has the full story.</p>
+        </div>
+        <div data-reveal data-reveal-delay="1">
+          <div class="cmd-toolbar">
+            <label class="cmd-search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+              <input id="cmd-search" type="search" placeholder="Search commands — e.g. worklog, transition, sprint…" aria-label="Search commands" />
+            </label>
+            <span class="cmd-count" id="cmd-count"></span>
           </div>
-          <figcaption class="mt-3 text-sm font-semibold text-slate-700 dark:text-slate-300">TUI issue list</figcaption>
-          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Browse, search, and filter backlog items in a sortable table.</p>
-        </figure>
-        <figure class="flex h-full flex-col rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 shadow-soft">
-          <div class="aspect-video overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-950">
-            <img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" alt="jirac TUI split master-detail view" class="h-full w-full object-cover" loading="lazy" />
-          </div>
-          <figcaption class="mt-3 text-sm font-semibold text-slate-700 dark:text-slate-300">Split master-detail</figcaption>
-          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Keep list visible while inspecting summary, comments, worklog, attachments, links.</p>
-        </figure>
-        <figure class="flex h-full flex-col rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 shadow-soft">
-          <div class="aspect-video overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-950">
-            <img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample-jql.jpeg" alt="jirac interactive JQL builder" class="h-full w-full object-cover" loading="lazy" />
-          </div>
-          <figcaption class="mt-3 text-sm font-semibold text-slate-700 dark:text-slate-300">Interactive JQL builder</figcaption>
-          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Build queries by project, status, and assignee without memorizing JQL syntax.</p>
-        </figure>
-      </div>
-    </section>
-
-    <section id="non-tech" class="border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Quick Guide for Non-Tech Users</h2>
-        <ol class="mt-6 grid gap-4 md:grid-cols-2">
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">1. Install</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use the installer that matches your machine. Windows users can choose PowerShell, Winget, or Scoop; macOS and Linux can use the shell installer or package managers.</p><div class="mini-command"><span class="mini-command-label">Tool</span><code>jirac</code></div></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">2. Login</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use your Jira URL, email, and API token to connect your account the first time.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac auth login</code></div></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">3. View your tasks</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">See issues assigned to you in a simple terminal list.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac issue list</code></div></li>
-          <li class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5"><span class="font-semibold">4. Move issue status</span><p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Select an issue and move it to the next status when work changes.</p><div class="mini-command"><span class="mini-command-label">Run</span><code>jirac issue transition PROJ-123</code></div></li>
-        </ol>
-      </div>
-    </section>
-
-    <section id="quickstart" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-      <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Quickstart (Tech Users)</h2>
-      <div class="mt-6 grid gap-6 lg:grid-cols-2">
-        <article class="doc-card rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Installation options</h3>
-          <div class="mt-3 space-y-3 text-sm">
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-curl" class="break-all">curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | bash</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-curl">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-powershell" class="break-all">powershell -ExecutionPolicy Bypass -Command "&amp; ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))"</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-powershell">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-brew" class="break-all">brew tap mulhamna/tap && brew install jira-commands jira-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-brew">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-cargo" class="break-all">cargo install jira-commands</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-cargo">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-cargo-mcp" class="break-all">cargo install jira-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-cargo-mcp">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-npm" class="break-all">npm install -g @mulham28/jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-npm">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-npm-mcp" class="break-all">npm install -g @mulham28/jirac-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-npm-mcp">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-scoop" class="break-all">scoop bucket add mulhamna https://github.com/mulhamna/scoop-bucket && scoop install mulhamna/jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-scoop">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-scoop-mcp" class="break-all">scoop install mulhamna/jirac-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-scoop-mcp">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-winget" class="break-all">winget install mulhamna.jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-winget">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-winget-mcp" class="break-all">winget install mulhamna.jirac-mcp</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-winget-mcp">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-source" class="break-all">git clone https://github.com/mulhamna/jira-commands &amp;&amp; cd jira-commands &amp;&amp; cargo install --path crates/jira --locked</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-source">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-clawhub-skill" class="break-all">openclaw skills install jirac</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-clawhub-skill">Copy</button></div>
-            <div class="command-row rounded-md bg-slate-900 p-3 text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-install-clawhub-plugin" class="break-all">openclaw plugins install clawhub:jirac-plugin</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-install-clawhub-plugin">Copy</button></div>
-          </div>
-          <p class="mt-4 text-xs text-slate-500 dark:text-slate-400">Pick one. Homebrew, Cargo, npm, Scoop, and Winget all expose <code>jirac</code> and <code>jirac-mcp</code> as separate install targets now, while the shell and PowerShell installers can fetch the release binaries directly. OpenClaw users can also install the published <a class="text-brand-700 hover:underline" href="https://clawhub.ai/mulhamna/jirac">ClawHub skill</a> or the <a class="text-brand-700 hover:underline" href="https://clawhub.ai/plugins/jirac-plugin">ClawHub Claude-compatible plugin bundle</a>. Contributors tracking <code>main</code> can install from a local checkout via <code>cargo install --path</code>. See <a class="text-brand-700 hover:underline" href="https://github.com/mulhamna/jira-commands/blob/main/INSTALL.md">INSTALL.md</a> for the full matrix.</p>
-        </article>
-        <article class="doc-card rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">First login</h3>
-          <div class="command-row mt-3 rounded-md bg-slate-900 p-3 text-sm text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-auth-login" class="break-all">jirac auth login</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-auth-login">Copy</button></div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">Config file path: <code>~/.config/jira/config.toml</code> (permission 600).</p>
-          <div class="command-row mt-3 rounded-md bg-slate-900 p-3 text-sm text-slate-100 flex flex-col sm:flex-row sm:items-center justify-between gap-3"><code id="cmd-auth-status" class="break-all">jirac auth status</code><button type="button" class="copy-btn self-end sm:self-auto rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400" data-copy-target="cmd-auth-status">Copy</button></div>
-        </article>
-      </div>
-    </section>
-
-    <section id="commands" class="border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Command Reference</h2>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Common commands for daily workflow. Releases ship <code>jirac</code> and <code>jirac-mcp</code>; Windows installs for both binaries are available via PowerShell, Scoop, Winget, npm, or Cargo.</p>
-        <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
-          <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
-            <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
-              <tr>
-                <th class="px-4 py-3 font-semibold">Use case</th>
-                <th class="px-4 py-3 font-semibold">Command</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-              <tr><td class="px-4 py-3">List assigned issues</td><td class="px-4 py-3 command-cell"><code>jirac issue list</code></td></tr>
-              <tr><td class="px-4 py-3">List by project</td><td class="px-4 py-3 command-cell"><code>jirac issue list --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">Daily standup summary</td><td class="px-4 py-3 command-cell"><code>jirac issue standup</code></td></tr>
-              <tr><td class="px-4 py-3">Current sprint summary</td><td class="px-4 py-3 command-cell"><code>jirac issue sprint-summary --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">View issue detail</td><td class="px-4 py-3 command-cell"><code>jirac issue view MYPROJ-123</code></td></tr>
-              <tr><td class="px-4 py-3">View issue detail with fix-version backlog preview</td><td class="px-4 py-3 command-cell"><code>jirac issue view MYPROJ-123 --versions</code></td></tr>
-              <tr><td class="px-4 py-3">Browse project fix versions</td><td class="px-4 py-3 command-cell"><code>jirac issue versions --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">Preview backlog for one fix version</td><td class="px-4 py-3 command-cell"><code>jirac issue versions --project MYPROJ --version "v1.2.0"</code></td></tr>
-              <tr><td class="px-4 py-3">Create a project version</td><td class="px-4 py-3 command-cell"><code>jirac issue versions --project MYPROJ --create --version "v1.3.0"</code></td></tr>
-              <tr><td class="px-4 py-3">Set release date on a version</td><td class="px-4 py-3 command-cell"><code>jirac issue versions --project MYPROJ --version "v1.2.0" --set-release-date 2026-06-30 --released</code></td></tr>
-              <tr><td class="px-4 py-3">Create issue</td><td class="px-4 py-3 command-cell"><code>jirac issue create --project MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">Transition issue</td><td class="px-4 py-3 command-cell"><code>jirac issue transition MYPROJ-123 --to Done</code></td></tr>
-              <tr><td class="px-4 py-3">Add worklog</td><td class="px-4 py-3 command-cell"><code>jirac issue worklog add MYPROJ-123 --time 2h --comment "Worked on API"</code></td></tr>
-              <tr><td class="px-4 py-3">Add worklog with custom started time</td><td class="px-4 py-3 command-cell"><code>jirac issue worklog add MYPROJ-123 --time 2h --date 2026-04-21 --start 09:30 --comment "Backfilled worklog"</code></td></tr>
-              <tr><td class="px-4 py-3">Backfill worklog across a date range</td><td class="px-4 py-3 command-cell"><code>jirac issue worklog add MYPROJ-123 --time 2h --from 2026-04-21 --to 2026-04-25 --exclude-weekends --comment "Backfill week"</code></td></tr>
-              <tr><td class="px-4 py-3">Upload attachment</td><td class="px-4 py-3 command-cell"><code>jirac issue attach MYPROJ-123 ./screenshot.png</code></td></tr>
-              <tr><td class="px-4 py-3">Change backlog type natively</td><td class="px-4 py-3 command-cell"><code>jirac issue change-type MYPROJ-123 Story</code></td></tr>
-              <tr><td class="px-4 py-3">Move backlog to another project natively</td><td class="px-4 py-3 command-cell"><code>jirac issue move MYPROJ-123 OTHER</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk comment by JQL</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-comment --jql 'project = MYPROJ AND sprint = openSprints()' --body "Please post status before standup"</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk comment by explicit keys</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-comment --keys MYPROJ-123 MYPROJ-456 --file note.md</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk transition</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-transition --jql 'project = MYPROJ AND status = "To Do"' --to "In Progress"</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk update field</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-update --jql 'project = MYPROJ AND assignee = EMPTY' --assignee me</code></td></tr>
-              <tr><td class="px-4 py-3">Bulk create from manifest</td><td class="px-4 py-3 command-cell"><code>jirac issue bulk-create --manifest issues.json</code></td></tr>
-              <tr><td class="px-4 py-3">Interactive JQL builder</td><td class="px-4 py-3 command-cell"><code>jirac issue jql</code></td></tr>
-              <tr><td class="px-4 py-3">Mention notifications</td><td class="px-4 py-3 command-cell"><code>jirac issue notifications --since 7d</code></td></tr>
-              <tr><td class="px-4 py-3">Switch profile</td><td class="px-4 py-3 command-cell"><code>jirac auth use work-cloud</code></td></tr>
-              <tr><td class="px-4 py-3">Launch TUI</td><td class="px-4 py-3 command-cell"><code>jirac tui -p MYPROJ</code></td></tr>
-              <tr><td class="px-4 py-3">Raw API call</td><td class="px-4 py-3 command-cell"><code>jirac api get /rest/api/3/serverInfo</code></td></tr>
-            </tbody>
-          </table>
+          <div class="cmd-filters" id="cmd-filters" role="group" aria-label="Filter by category"></div>
+          <div class="cmd-list" id="cmd-list"></div>
         </div>
       </div>
     </section>
 
-    <section id="tui" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-      <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Interactive TUI</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Launch with <code>jirac tui</code> for keyboard- and mouse-driven issue management, including a project-level fix-version browser via <code>V</code>, modal-based backlog type changes, direct project moves, mention notifications, saved JQLs, light and dark themes (including <code>GitHub Light</code>), single worklog entry via <code>w</code>, bulk date-range worklogs via <code>b</code>, and bulk comments via <code>:</code> with confirmation. Click rows, detail tabs, and picker options; double-click to open detail; scroll the wheel to navigate; click outside any popup to dismiss it.</p>
-      <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
-        <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
-          <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
-            <tr>
-              <th class="px-4 py-3 font-semibold">Keyboard</th>
-              <th class="px-4 py-3 font-semibold">Description</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-            <tr><td class="px-4 py-3"><span class="keycap">↑ / k</span></td><td class="px-4 py-3">Move to the issue above.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">↓ / j</span></td><td class="px-4 py-3">Move to the issue below.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">Enter</span></td><td class="px-4 py-3">Open details for the selected issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">n</span></td><td class="px-4 py-3">Scan and open Jira mention notifications.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">R</span></td><td class="px-4 py-3">Mark the selected notification issue as read.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">c</span></td><td class="px-4 py-3">Create a new issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">e</span></td><td class="px-4 py-3">Edit the selected issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">y</span></td><td class="px-4 py-3">Change the selected backlog item type in a modal, without leaving the TUI.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">M</span></td><td class="px-4 py-3">Move the selected backlog item to another project in a modal, using Jira native move semantics.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">t</span></td><td class="px-4 py-3">Change issue status (transition).</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">C</span></td><td class="px-4 py-3">Choose which table columns stay visible and persist that preference.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">T</span></td><td class="px-4 py-3">Open the theme picker, including Kanagawa Wave.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">p</span></td><td class="px-4 py-3">Open saved JQL queries.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">V</span></td><td class="px-4 py-3">Browse project fix versions and preview backlog for the selected version.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">;</span></td><td class="px-4 py-3">Add one comment to the selected issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">:</span></td><td class="px-4 py-3">Bulk-comment many issues by current/custom JQL or explicit issue keys.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">w</span></td><td class="px-4 py-3">Add a single worklog to the issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">b</span></td><td class="px-4 py-3">Add bulk worklogs across a date range, with confirmation before submit.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">v</span></td><td class="px-4 py-3">Edit fix versions.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">s</span></td><td class="px-4 py-3">Assign the issue to a sprint.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">u</span></td><td class="px-4 py-3">Upload an attachment to the issue.</td></tr>
-            <tr><td class="px-4 py-3"><span class="keycap">?</span></td><td class="px-4 py-3">Show shortcut help.</td></tr>
-          </tbody>
-        </table>
+    <!-- ===================== TUI ===================== -->
+    <section class="section" id="tui" style="background:var(--bg-sunken);border-block:1px solid var(--line)">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">Terminal UI</span>
+          <h2>A real interface, in your terminal.</h2>
+          <p>Launch with <code class="mono">jirac tui</code> for keyboard- and mouse-driven issue management — browse, edit, transition, log work, and more without leaving the terminal. Ships with multiple themes, including GitHub Light and Kanagawa Wave.</p>
+        </div>
+
+        <div class="feat-grid" data-reveal data-reveal-delay="1">
+          <figure class="feat-card" style="padding:14px" data-reveal>
+            <div class="hero-screenshot"><img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui.jpeg" alt="jirac TUI issue list" loading="lazy" /></div>
+            <figcaption style="font-size:13.5px;color:var(--ink-soft);margin-top:12px;padding:0 4px">Sortable issue list — browse and filter the backlog.</figcaption>
+          </figure>
+          <figure class="feat-card" style="padding:14px" data-reveal data-reveal-delay="1">
+            <div class="hero-screenshot"><img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample_tui_split.jpeg" alt="jirac split master-detail view" loading="lazy" /></div>
+            <figcaption style="font-size:13.5px;color:var(--ink-soft);margin-top:12px;padding:0 4px">Split master-detail — list plus comments, worklog, links.</figcaption>
+          </figure>
+          <figure class="feat-card" style="padding:14px" data-reveal data-reveal-delay="2">
+            <div class="hero-screenshot"><img src="https://raw.githubusercontent.com/mulhamna/jira-commands/main/assets/readme/sample-jql.jpeg" alt="jirac interactive JQL builder" loading="lazy" /></div>
+            <figcaption style="font-size:13.5px;color:var(--ink-soft);margin-top:12px;padding:0 4px">Interactive JQL builder — query without memorizing syntax.</figcaption>
+          </figure>
+        </div>
+
+        <div class="section-head" style="margin-top:64px;margin-bottom:28px" data-reveal>
+          <h2 style="font-size:22px">Keyboard shortcuts</h2>
+        </div>
+        <div class="sc-grid" id="sc-grid" data-reveal data-reveal-delay="1"></div>
       </div>
-      <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
-        <table class="min-w-full bg-white dark:bg-slate-900 text-sm">
-          <thead class="bg-slate-100 dark:bg-slate-800 text-left text-slate-700 dark:text-slate-300">
-            <tr>
-              <th class="px-4 py-3 font-semibold">Mouse</th>
-              <th class="px-4 py-3 font-semibold">Description</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-            <tr><td class="px-4 py-3">Click issue row</td><td class="px-4 py-3">Select that row.</td></tr>
-            <tr><td class="px-4 py-3">Double-click issue row</td><td class="px-4 py-3">Open the split detail view (same as <span class="keycap">Enter</span>).</td></tr>
-            <tr><td class="px-4 py-3">Click detail tab</td><td class="px-4 py-3">Switch to that tab; comments, worklog, and links lazy-load.</td></tr>
-            <tr><td class="px-4 py-3">Click detail pane</td><td class="px-4 py-3">Switch focus to detail when currently on the issue list.</td></tr>
-            <tr><td class="px-4 py-3">Click picker option</td><td class="px-4 py-3">Apply for single-select pickers (transition, assignee, sprint, saved JQL, theme, project versions); toggle for multi-select pickers (components, fix versions, columns).</td></tr>
-            <tr><td class="px-4 py-3">Click outside popup</td><td class="px-4 py-3">Close popup (equivalent to <span class="keycap">Esc</span>). Form modals are exempt to protect in-flight input.</td></tr>
-            <tr><td class="px-4 py-3">Scroll wheel on list</td><td class="px-4 py-3">Previous / next issue.</td></tr>
-            <tr><td class="px-4 py-3">Scroll wheel on picker</td><td class="px-4 py-3">Move picker selection up / down.</td></tr>
-          </tbody>
-        </table>
-      </div>
-      <p class="mt-3 text-xs text-slate-500 dark:text-slate-400">To copy terminal text while the TUI is running, hold <span class="keycap">Shift</span> (iTerm2 / most Linux terminals) or <span class="keycap">Option</span> (Terminal.app) while selecting. Under tmux, set <code>set -g mouse on</code> so events reach the TUI.</p>
     </section>
 
-    <section id="mcp" class="border-y border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">MCP Server</h2>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use <code>jirac-mcp</code> to expose Jira tools to MCP clients. Install it with Homebrew, Cargo, npm/release binaries, or the platform installer flow, depending on your environment.</p>
-        <div class="mt-4 grid gap-6 lg:grid-cols-2">
-          <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-            <h3 class="font-semibold">Install and run</h3>
-            <div class="mt-3">
-              <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
-                <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-install-run">Copy</button>
-              </div>
-              <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="cmd-mcp-install-run">brew tap mulhamna/tap && brew install jira-mcp
-cargo install jira-mcp
-# macOS / Linux: curl -sSL https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.sh | BINARY=jirac-mcp bash
-# Windows: winget install mulhamna.jirac-mcp
-# Windows alt: powershell -ExecutionPolicy Bypass -Command "&amp; ([scriptblock]::Create((Invoke-WebRequest 'https://raw.githubusercontent.com/mulhamna/jira-commands/main/install.ps1').Content))" -Binary jirac-mcp
+    <!-- ===================== MCP ===================== -->
+    <section class="section" id="mcp">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">MCP server</span>
+          <h2>Give your agent Jira access.</h2>
+          <p>Expose Jira tools to any MCP client with <code class="mono">jirac-mcp</code>. <code class="mono">jirac</code> can even register it into your client config for you.</p>
+        </div>
+        <div class="mcp-grid">
+          <div data-reveal>
+            <div class="code-card">
+              <div class="code-card__bar"><span class="code-card__name">install &amp; run</span><button class="copy-mini" type="button" data-copy="@target" data-copy-target="mcp-run"><span data-copy-label>Copy</span></button></div>
+              <pre><code class="mono" id="mcp-run">cargo install jira-mcp
 jirac-mcp serve --transport stdio</code></pre>
             </div>
-          </article>
-          <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-            <h3 class="font-semibold">One-command client install</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400"><code>jirac</code> can register <code>jirac-mcp</code> into supported client configs for you. Run with no arguments for an interactive picker; pass <code>--client</code> for scripts.</p>
-            <div class="mt-3">
-              <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
-                <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-install-interactive">Copy</button>
-              </div>
-              <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="cmd-mcp-install-interactive">jirac mcp install
-# verifies prereqs, then shows a picker</code></pre>
+            <div class="code-card" style="margin-top:16px">
+              <div class="code-card__bar"><span class="code-card__name">one-command client install</span><button class="copy-mini" type="button" data-copy="@target" data-copy-target="mcp-install"><span data-copy-label>Copy</span></button></div>
+              <pre><code class="mono" id="mcp-install">jirac mcp install
+# interactive picker, or pass --client</code></pre>
             </div>
-            <div class="mt-3">
-              <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
-                <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-install-clients">Copy</button>
-              </div>
-              <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="cmd-mcp-install-clients">jirac mcp install --client claude-code
-jirac mcp install --client claude-desktop
-jirac mcp install --client cursor
-jirac mcp install --client gemini-cli
-jirac mcp install --client codex
-jirac mcp install --client opencode
-jirac mcp install --client generic-json
-jirac mcp install --client antigravity
-jirac mcp install --client antigravity-cli</code></pre>
+            <div class="mcp-clients" aria-label="Supported MCP clients">
+              <span class="mcp-client">claude-code</span>
+              <span class="mcp-client">claude-desktop</span>
+              <span class="mcp-client">cursor</span>
+              <span class="mcp-client">gemini-cli</span>
+              <span class="mcp-client">codex</span>
+              <span class="mcp-client">opencode</span>
+              <span class="mcp-client">antigravity</span>
+              <span class="mcp-client">generic-json</span>
             </div>
-            <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-600 dark:text-slate-400">
-              <li><code>claude-code</code> writes user-level <code>~/.claude.json</code> (<code>mcpServers</code>); the project-scoped <code>&lt;repo&gt;/.mcp.json</code> is not written by this helper.</li>
-              <li><code>claude-desktop</code> writes the platform support dir (<code>claude_desktop_config.json</code>) on macOS, Windows, or Linux.</li>
-              <li><code>generic-json</code> prints a portable JSON snippet instead of writing a file.</li>
-              <li><code>gemini-cli</code> and <code>codex</code> delegate to their native <code>mcp add</code> commands.</li>
-              <li><code>opencode</code> writes <code>~/.config/opencode/opencode.jsonc</code> directly because its CLI flow is interactive.</li>
-              <li>Use <code>--print</code> to show the JSON snippet or delegated client command first.</li>
-              <li>Use <code>--dry-run</code> to preview without writing.</li>
-              <li>Use <code>--force</code> to overwrite an existing entry with the same name.</li>
-              <li>Install helpers use the active Jira profile by default; if you only have one Jira login configured, that is the profile the MCP server will use.</li>
-            </ul>
-          </article>
-        </div>
-        <div class="mt-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5">
-          <h3 class="font-semibold">Portable JSON snippet</h3>
-          <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">If your MCP client is not supported yet, use <code>jirac mcp install --client generic-json</code> and paste the output into your client config.</p>
-          <div class="mt-3">
-            <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
-              <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="cmd-mcp-config">Copy</button>
-            </div>
-            <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="cmd-mcp-config">{
+          </div>
+          <div data-reveal data-reveal-delay="1">
+            <div class="code-card">
+              <div class="code-card__bar"><span class="code-card__name">portable JSON snippet</span><button class="copy-mini" type="button" data-copy="@target" data-copy-target="mcp-json"><span data-copy-label>Copy</span></button></div>
+              <pre><code class="mono" id="mcp-json">{
   "mcpServers": {
     "jira": {
       "command": "jirac-mcp",
@@ -565,140 +333,67 @@ jirac mcp install --client antigravity-cli</code></pre>
     }
   }
 }</code></pre>
+            </div>
+            <p class="install-hint">Flags: <code class="mono">--print</code> shows the snippet, <code class="mono">--dry-run</code> previews without writing, <code class="mono">--force</code> overwrites an existing entry. Install helpers use your active Jira profile by default.</p>
           </div>
         </div>
       </div>
     </section>
 
-    <section id="contributing" class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-      <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Contributing</h2>
-      <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Contributions are welcome for bug fixes, docs improvements, tests, release automation follow-through, and new features.</p>
-      <div class="mt-6 grid gap-6 lg:grid-cols-2">
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Quick contribution flow</h3>
-          <ol class="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-600 dark:text-slate-400">
-            <li>Fork and clone the repository.</li>
-            <li>Create a branch for your change.</li>
-            <li>Implement your update with tests/docs when relevant.</li>
-            <li>Run quality checks locally.</li>
-            <li>Open a pull request with a clear description.</li>
-          </ol>
-        </article>
-        <article class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-          <h3 class="font-semibold">Local checks before PR</h3>
-          <pre class="mt-3 overflow-x-auto rounded bg-slate-900 p-3 text-sm text-slate-100"><code>cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all
-cargo build --all</code></pre>
-        </article>
-      </div>
-      <div class="mt-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950 p-5 text-sm text-slate-600 dark:text-slate-400">
-        <p><strong>Commit style:</strong> use Conventional Commits (for example: <code>feat:</code>, <code>fix:</code>, <code>docs:</code>, <code>refactor:</code>, <code>test:</code>).</p>
-        <p class="mt-2"><strong>Important:</strong> check <code>CLAUDE.md</code>, <code>AGENTS.md</code>, and existing project patterns before submitting major changes.</p>
-      </div>
-      <article class="mt-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 shadow-soft">
-        <h3 class="font-semibold">PR Checklist Template</h3>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Use this checklist in your pull request description:</p>
-        <div class="mt-3">
-          <div class="flex items-center justify-end rounded-t bg-slate-800 px-3 py-2">
-            <button type="button" class="copy-btn rounded border border-slate-600 px-2.5 py-1 text-xs text-slate-200 hover:border-brand-300 hover:text-white" data-copy-target="pr-checklist-code">Copy</button>
-          </div>
-          <pre class="overflow-x-auto rounded-b bg-slate-900 p-3 text-sm text-slate-100"><code id="pr-checklist-code">## Summary
-- What changed:
-- Why this change is needed:
-
-## Validation
-- [ ] cargo fmt --all -- --check
-- [ ] cargo clippy --all-targets --all-features -- -D warnings
-- [ ] cargo test --all
-- [ ] cargo build --all
-
-## Scope & Risk
-- [ ] No breaking changes
-- [ ] Breaking changes documented
-- [ ] Docs updated (if needed)
-- [ ] Added/updated tests (if needed)
-
-## Notes
-- Jira issue / context:
-- Follow-up tasks (if any):</code></pre>
+    <!-- ===================== FAQ ===================== -->
+    <section class="section" id="faq" style="background:var(--bg-sunken);border-block:1px solid var(--line)">
+      <div class="wrap">
+        <div class="section-head" data-reveal>
+          <span class="eyebrow">FAQ</span>
+          <h2>Good to know.</h2>
         </div>
-      </article>
+        <div class="faq" data-reveal data-reveal-delay="1">
+          <details open><summary>Where do I get a Jira API token?</summary><p>From your Atlassian account security settings, under “API tokens”. Run <code class="mono">jirac auth login</code> and paste your Jira URL, email, and token — it’s stored in <code class="mono">~/.config/jira/config.toml</code> with 600 permissions.</p></details>
+          <details><summary>Is this replacing the Jira web UI?</summary><p>No. jirac complements the web UI for terminal-first and automation workflows — browsing, JQL, worklogs, transitions, versions, and MCP/agent access.</p></details>
+          <details><summary>Does it support custom fields?</summary><p>Yes. Custom fields are discovered dynamically per project at runtime, so there’s no manual field mapping to maintain.</p></details>
+          <details><summary>Can I use jirac as my main Jira CLI?</summary><p>Absolutely — it’s built to be a daily driver covering issue browsing, JQL search, worklogs, transitions, fix versions, project versions, bulk actions, and MCP workflows.</p></details>
+          <details><summary>How do I copy text out of the TUI?</summary><p>Hold <span class="keycap">Shift</span> (iTerm2 / most Linux terminals) or <span class="keycap">Option</span> (Terminal.app) while selecting. Under tmux, set <code class="mono">set -g mouse on</code> so events reach the TUI.</p></details>
+        </div>
+      </div>
     </section>
 
-    <section id="faq" class="border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-      <div class="mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100">FAQ</h2>
-        <div class="mt-6 space-y-4">
-          <details class="rounded border border-slate-200 dark:border-slate-700 p-4" open>
-            <summary class="cursor-pointer font-semibold">Where do I get Jira API token?</summary>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">From Atlassian account security settings under API tokens.</p>
-          </details>
-          <details class="rounded border border-slate-200 dark:border-slate-700 p-4">
-            <summary class="cursor-pointer font-semibold">Is this replacing Jira web UI?</summary>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">No. It complements Jira UI for terminal-first and automation workflows.</p>
-          </details>
-          <details class="rounded border border-slate-200 dark:border-slate-700 p-4">
-            <summary class="cursor-pointer font-semibold">Does it support custom fields?</summary>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Yes, custom fields are discovered dynamically per project.</p>
-          </details>
-          <details class="rounded border border-slate-200 dark:border-slate-700 p-4">
-            <summary class="cursor-pointer font-semibold">Can I use jirac as my main Jira CLI?</summary>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Yes. jirac covers day-to-day Jira command-line work like issue browsing, JQL search, worklogs, transitions, fix versions, project versions, and MCP/automation workflows.</p>
-          </details>
+    <!-- ===================== CTA ===================== -->
+    <section class="section section--tight">
+      <div class="wrap">
+        <div class="cta-band" data-reveal>
+          <div class="cta-band__glow"></div>
+          <h2>Stop context-switching to Jira.</h2>
+          <p>Install jirac and run your backlog from the terminal in under a minute.</p>
+          <div class="hero__cta">
+            <a href="#install" class="btn btn-primary">Install jirac</a>
+            <a href="https://github.com/mulhamna/jira-commands" target="_blank" rel="noopener" class="btn btn-ghost">Star on GitHub</a>
+          </div>
         </div>
       </div>
     </section>
   </main>
 
-  <footer class="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-950">
-    <div class="mx-auto max-w-7xl px-4 py-8 text-sm text-slate-600 dark:text-slate-400 sm:px-6 lg:px-8">
-      <p><strong>jirac / jira-commands</strong> - Rust CLI for Jira ecosystem.</p>
-      <p class="mt-1">Repository: <a class="text-brand-700 hover:underline" href="https://github.com/mulhamna/jira-commands">github.com/mulhamna/jira-commands</a></p>
-      <p class="mt-1">License: MIT OR Apache-2.0</p>
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="site-footer">
+    <div class="wrap site-footer__row">
+      <div>
+        <a href="#top" class="brand"><span class="brand__mark">jc</span><span class="brand__name"><b>jirac</b></span></a>
+        <p>A Rust CLI, TUI &amp; MCP server for the Jira ecosystem.</p>
+        <p>MIT OR Apache-2.0 · Not affiliated with Atlassian.</p>
+      </div>
+      <div class="site-footer__links">
+        <a href="https://github.com/mulhamna/jira-commands" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/mulhamna/jira-commands/blob/main/INSTALL.md" target="_blank" rel="noopener">Install guide</a>
+        <a href="#commands">Commands</a>
+        <a href="#mcp">MCP</a>
+      </div>
     </div>
   </footer>
-  <script>
-    function syncThemeToggle() {
-      const isDark = document.documentElement.classList.contains('dark');
-      const icon = document.getElementById('theme-icon');
-      const label = document.getElementById('theme-label');
-      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
-      if (label) label.textContent = isDark ? 'Light' : 'Dark';
-    }
 
-    syncThemeToggle();
+  <!-- mirror of install command for copy-by-id -->
+  <textarea id="install-cmd-text" style="position:absolute;left:-9999px;top:0" aria-hidden="true"></textarea>
 
-    const toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      toggle.addEventListener('click', function () {
-        const root = document.documentElement;
-        root.classList.toggle('dark');
-        localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
-        syncThemeToggle();
-      });
-    }
-
-    document.querySelectorAll('.copy-btn').forEach(function (button) {
-      button.addEventListener('click', async function () {
-        const targetId = button.getAttribute('data-copy-target');
-        const target = targetId ? document.getElementById(targetId) : null;
-        if (!target) return;
-        try {
-          await navigator.clipboard.writeText(target.textContent || '');
-          const oldText = button.textContent;
-          button.textContent = 'Copied';
-          setTimeout(function () {
-            button.textContent = oldText || 'Copy';
-          }, 1200);
-        } catch (_) {
-          button.textContent = 'Failed';
-          setTimeout(function () {
-            button.textContent = 'Copy';
-          }, 1200);
-        }
-      });
-    });
-  </script>
+  <script src="data.js"></script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,470 @@
+/* jirac landing — design system + components */
+
+:root {
+  --bg: #f7f8fa;
+  --bg-elev: #ffffff;
+  --bg-sunken: #eef1f5;
+  --ink: #0c1322;
+  --ink-soft: #424b5e;
+  --ink-dim: #6b7488;
+  --line: #e4e8ef;
+  --line-soft: #eef1f5;
+  --brand: #1f6dff;
+  --brand-strong: #124ee5;
+  --brand-tint: #eaf1ff;
+  --brand-ink: #0f43c9;
+  --code-bg: #0c1322;
+  --code-ink: #e7ecf5;
+  --glow: rgba(31, 109, 255, 0.16);
+  --shadow: 0 1px 2px rgba(12, 19, 34, 0.05), 0 12px 32px -12px rgba(12, 19, 34, 0.14);
+}
+
+html.dark {
+  --bg: #070a12;
+  --bg-elev: #0d1220;
+  --bg-sunken: #0a0e1a;
+  --ink: #eef2fb;
+  --ink-soft: #b3bdd2;
+  --ink-dim: #7c879e;
+  --line: #1b2335;
+  --line-soft: #141b2b;
+  --brand: #4e97ff;
+  --brand-strong: #2f7bff;
+  --brand-tint: rgba(78, 151, 255, 0.12);
+  --brand-ink: #9cc2ff;
+  --code-bg: #070b15;
+  --code-ink: #e7ecf5;
+  --glow: rgba(78, 151, 255, 0.22);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 18px 50px -18px rgba(0, 0, 0, 0.7);
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; scroll-padding-top: 84px; }
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", ui-sans-serif, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+.wrap { max-width: 1120px; margin: 0 auto; padding-inline: 24px; }
+@media (max-width: 640px) { .wrap { padding-inline: 18px; } }
+
+.eyebrow {
+  font: 600 12px/1 "JetBrains Mono", monospace;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brand-ink);
+}
+
+a { color: inherit; }
+.link { color: var(--brand-ink); text-decoration: none; }
+.link:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* ---------------- Buttons ---------------- */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 20px; border-radius: 11px;
+  font-size: 14.5px; font-weight: 600; line-height: 1;
+  border: 1px solid transparent; cursor: pointer;
+  transition: transform .15s ease, background .15s ease, border-color .15s ease, box-shadow .15s ease;
+  text-decoration: none; white-space: nowrap;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--brand); color: #fff; box-shadow: 0 8px 22px -8px var(--glow); }
+.btn-primary:hover { background: var(--brand-strong); box-shadow: 0 12px 26px -8px var(--glow); }
+.btn-ghost { background: var(--bg-elev); color: var(--ink); border-color: var(--line); }
+.btn-ghost:hover { border-color: var(--brand); color: var(--brand-ink); }
+.btn-sm { padding: 8px 13px; font-size: 13px; border-radius: 9px; }
+
+/* ---------------- Header ---------------- */
+.site-header {
+  position: sticky; top: 0; z-index: 60;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: saturate(1.4) blur(14px);
+  border-bottom: 1px solid var(--line);
+}
+.site-header__row { display: flex; align-items: center; justify-content: space-between; height: 64px; gap: 16px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 700; text-decoration: none; color: var(--ink); }
+.brand__mark {
+  width: 34px; height: 34px; border-radius: 10px; display: grid; place-items: center;
+  background: linear-gradient(150deg, var(--brand), var(--brand-strong));
+  color: #fff; font: 800 14px/1 "JetBrains Mono", monospace; letter-spacing: -0.02em;
+  box-shadow: 0 6px 16px -6px var(--glow);
+}
+.brand__name { font-size: 16px; letter-spacing: -0.01em; }
+.brand__name b { font-weight: 800; }
+.nav { display: flex; align-items: center; gap: 4px; }
+.nav a {
+  padding: 8px 12px; border-radius: 9px; font-size: 14px; font-weight: 500;
+  color: var(--ink-soft); text-decoration: none; transition: color .15s, background .15s;
+}
+.nav a:hover { color: var(--ink); background: var(--bg-sunken); }
+.nav a.is-active { color: var(--brand-ink); }
+.header-actions { display: flex; align-items: center; gap: 10px; }
+.icon-btn {
+  width: 38px; height: 38px; border-radius: 10px; display: grid; place-items: center;
+  border: 1px solid var(--line); background: var(--bg-elev); color: var(--ink-soft); cursor: pointer;
+  transition: border-color .15s, color .15s;
+}
+.icon-btn:hover { border-color: var(--brand); color: var(--brand-ink); }
+.icon-btn svg { width: 18px; height: 18px; }
+#nav-toggle { display: none; }
+
+.gh-cta {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px; border-radius: 10px; font-size: 14px; font-weight: 600;
+  border: 1px solid var(--line); background: var(--bg-elev); color: var(--ink); text-decoration: none;
+  transition: border-color .15s, color .15s;
+}
+.gh-cta:hover { border-color: var(--brand); color: var(--brand-ink); }
+.gh-cta svg { width: 17px; height: 17px; }
+
+.mobile-nav { display: none; }
+.mobile-nav.is-open { display: block; }
+.mobile-nav { border-bottom: 1px solid var(--line); background: var(--bg-elev); }
+.mobile-nav a { display: block; padding: 12px 24px; color: var(--ink-soft); text-decoration: none; font-weight: 500; border-bottom: 1px solid var(--line-soft); }
+
+@media (max-width: 860px) {
+  .nav { display: none; }
+  .gh-cta__text { display: none; }
+  #nav-toggle { display: grid; }
+}
+
+/* ---------------- Sections ---------------- */
+.section { padding-block: 96px; }
+.section--tight { padding-block: 68px; }
+.section-head { max-width: 660px; margin-bottom: 40px; }
+.section-head h2 { font-size: clamp(28px, 4vw, 40px); font-weight: 800; letter-spacing: -0.025em; line-height: 1.05; margin: 12px 0 0; }
+.section-head p { margin: 14px 0 0; color: var(--ink-soft); font-size: 17px; line-height: 1.6; }
+.divider { border: 0; border-top: 1px solid var(--line); }
+
+/* ---------------- Hero ---------------- */
+.hero { position: relative; overflow: hidden; padding-top: 72px; padding-bottom: 96px; }
+.hero__glow {
+  position: absolute; inset: -200px 0 auto 0; height: 620px; pointer-events: none; z-index: 0;
+  background:
+    radial-gradient(620px 360px at 50% -40px, var(--glow), transparent 70%),
+    radial-gradient(440px 300px at 14% 0, color-mix(in srgb, var(--brand) 18%, transparent), transparent 70%);
+}
+.hero__grid {
+  position: absolute; inset: 0; z-index: 0; pointer-events: none; opacity: .5;
+  -webkit-mask-image: radial-gradient(720px 420px at 50% 8%, #000, transparent 75%);
+  mask-image: radial-gradient(720px 420px at 50% 8%, #000, transparent 75%);
+  background-image: linear-gradient(var(--line) 1px, transparent 1px), linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 34px 34px;
+}
+.hero .wrap { position: relative; z-index: 1; }
+
+.hero__holo {
+  position: absolute; inset: 0; width: 100%; height: 100%; z-index: 0; pointer-events: none;
+  -webkit-mask-image: radial-gradient(120% 90% at 50% 38%, transparent 0%, transparent 30%, #000 64%);
+  mask-image: radial-gradient(120% 90% at 50% 38%, transparent 0%, transparent 30%, #000 64%);
+  filter: drop-shadow(0 0 22px var(--glow));
+  animation: holo-drift 26s ease-in-out infinite alternate;
+}
+.hero__holo use { mix-blend-mode: screen; }
+html:not(.dark) .hero__holo use { mix-blend-mode: multiply; }
+@keyframes holo-drift {
+  0% { transform: translate3d(0, 0, 0) scale(1); }
+  100% { transform: translate3d(0, -14px, 0) scale(1.03); }
+}
+@media (prefers-reduced-motion: reduce) { .hero__holo { animation: none; } }
+
+.badge-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 8px; border-radius: 999px;
+  background: var(--bg-elev); border: 1px solid var(--line); color: var(--ink-soft);
+  font-size: 12.5px; font-weight: 600; box-shadow: var(--shadow);
+}
+.badge-pill b { color: var(--ink); }
+.badge-pill__tag {
+  font: 700 10px/1 "JetBrains Mono", monospace; letter-spacing: .08em; text-transform: uppercase;
+  background: var(--brand-tint); color: var(--brand-ink); padding: 4px 7px; border-radius: 999px;
+}
+
+.hero h1 {
+  font-size: clamp(38px, 6.4vw, 70px); font-weight: 800; letter-spacing: -0.035em; line-height: 1.0; margin: 22px 0 0;
+  text-wrap: balance;
+}
+.hero h1 .grad {
+  background: linear-gradient(110deg, var(--brand), color-mix(in srgb, var(--brand) 55%, #a78bfa));
+  -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+}
+.hero__sub { margin: 22px 0 0; font-size: clamp(17px, 2vw, 20px); line-height: 1.6; color: var(--ink-soft); max-width: 600px; text-wrap: pretty; }
+.hero__cta { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }
+.hero__note { margin-top: 18px; font-size: 12.5px; color: var(--ink-dim); }
+
+/* hero variants share these; visibility toggled by [data-hero] */
+.hero-variant { display: none; }
+body[data-hero="spotlight"] .hero-variant--spotlight { display: block; }
+body[data-hero="split"] .hero-variant--split { display: grid; }
+body[data-hero="terminal"] .hero-variant--terminal { display: block; }
+
+/* spotlight */
+.hero-variant--spotlight { text-align: center; }
+.hero-variant--spotlight .badge-pill,
+.hero-variant--spotlight .hero__sub { margin-inline: auto; }
+.hero-variant--spotlight .hero__cta { justify-content: center; }
+.hero-variant--spotlight .hero__sub { text-align: center; }
+.hero-stage {
+  margin: 52px auto 0; max-width: 900px;
+}
+
+/* split */
+.hero-variant--split { grid-template-columns: 1.05fr 1fr; gap: 56px; align-items: center; }
+@media (max-width: 920px) { .hero-variant--split { grid-template-columns: 1fr; gap: 40px; } }
+
+/* terminal */
+.hero-variant--terminal { display: none; }
+.hero-variant--terminal .hero__inner { max-width: 720px; }
+.hero-stage--big { margin-top: 44px; }
+
+/* window chrome */
+.win {
+  border-radius: 14px; border: 1px solid var(--line);
+  background: var(--code-bg); box-shadow: var(--shadow); overflow: hidden;
+}
+.win__bar { display: flex; align-items: center; gap: 8px; padding: 12px 14px; border-bottom: 1px solid rgba(255,255,255,.06); background: rgba(255,255,255,.02); }
+.win__dot { width: 11px; height: 11px; border-radius: 999px; }
+.win__dot--r { background: #ff5f57; } .win__dot--y { background: #febc2e; } .win__dot--g { background: #28c840; }
+.win__title { margin-left: 8px; font: 500 12px/1 "JetBrains Mono", monospace; color: #8b97b0; }
+.win__body { padding: 18px 18px 20px; }
+.win__body pre, .win__body .term { margin: 0; color: var(--code-ink); font: 500 13.5px/1.75 "JetBrains Mono", monospace; overflow-x: auto; }
+.term { min-height: 188px; }
+.tl { white-space: pre; }
+.tl-cmd { color: #cdd6f4; }
+.tl-cmd::before { content: ""; }
+.tl-out { color: #8b97b0; }
+.tl-ok { color: #34d058; }
+.term-cursor { display: inline-block; width: 8px; height: 16px; background: var(--brand); vertical-align: -3px; animation: blink 1s steps(1) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+
+.hero-screenshot { border-radius: 14px; overflow: hidden; border: 1px solid var(--line); box-shadow: var(--shadow); background: #0b1220; }
+.hero-screenshot img { display: block; width: 100%; }
+
+/* hero direction switcher */
+.dir-switch {
+  display: inline-flex; align-items: center; gap: 2px; padding: 4px; border-radius: 12px;
+  background: var(--bg-sunken); border: 1px solid var(--line); margin-bottom: 4px;
+}
+.dir-switch__label { font: 600 11px/1 "JetBrains Mono", monospace; letter-spacing: .1em; text-transform: uppercase; color: var(--ink-dim); padding: 0 10px 0 8px; }
+.dir-switch button {
+  border: 0; background: transparent; cursor: pointer; padding: 7px 13px; border-radius: 9px;
+  font-size: 13px; font-weight: 600; color: var(--ink-soft); transition: background .15s, color .15s;
+}
+.dir-switch button[aria-pressed="true"] { background: var(--bg-elev); color: var(--ink); box-shadow: var(--shadow); }
+
+/* ---------------- Feature cards ---------------- */
+.feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+@media (max-width: 900px) { .feat-grid { grid-template-columns: 1fr; } }
+.feat-card {
+  padding: 26px 24px; border-radius: 16px; border: 1px solid var(--line); background: var(--bg-elev);
+  box-shadow: var(--shadow); position: relative; overflow: hidden;
+}
+.feat-card__icon { width: 42px; height: 42px; border-radius: 11px; display: grid; place-items: center; background: var(--brand-tint); color: var(--brand-ink); margin-bottom: 16px; }
+.feat-card__icon svg { width: 21px; height: 21px; }
+.feat-card h3 { font-size: 17px; font-weight: 700; margin: 0 0 8px; letter-spacing: -0.01em; }
+.feat-card p { margin: 0; color: var(--ink-soft); font-size: 14.5px; line-height: 1.6; }
+.feat-card code { font-family: "JetBrains Mono", monospace; font-size: .9em; background: var(--bg-sunken); padding: 1px 6px; border-radius: 6px; color: var(--brand-ink); }
+
+/* ---------------- Installer ---------------- */
+.installer { border: 1px solid var(--line); border-radius: 18px; background: var(--bg-elev); box-shadow: var(--shadow); overflow: hidden; }
+.installer__os { display: flex; gap: 4px; padding: 14px 16px; border-bottom: 1px solid var(--line); flex-wrap: wrap; }
+.os-tab {
+  display: inline-flex; align-items: center; gap: 8px; padding: 9px 16px; border-radius: 10px;
+  border: 1px solid transparent; background: transparent; cursor: pointer; font-size: 14px; font-weight: 600; color: var(--ink-soft);
+  transition: background .15s, color .15s, border-color .15s;
+}
+.os-tab svg { width: 16px; height: 16px; }
+.os-tab:hover { color: var(--ink); }
+.os-tab[aria-pressed="true"] { background: var(--brand-tint); color: var(--brand-ink); }
+.installer__body { padding: 22px 24px 24px; }
+.install-methods { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+.install-pill {
+  display: inline-flex; align-items: center; gap: 6px; padding: 7px 14px; border-radius: 999px;
+  border: 1px solid var(--line); background: var(--bg); cursor: pointer; font-size: 13.5px; font-weight: 600; color: var(--ink-soft);
+  transition: border-color .15s, color .15s, background .15s;
+}
+.install-pill:hover { border-color: var(--brand); color: var(--brand-ink); }
+.install-pill[aria-pressed="true"] { background: var(--brand); border-color: var(--brand); color: #fff; }
+.install-pill__star { font-size: 10px; opacity: .9; }
+.install-cmd {
+  display: flex; align-items: center; gap: 12px; justify-content: space-between;
+  background: var(--code-bg); border-radius: 12px; padding: 16px 16px 16px 18px; border: 1px solid var(--line);
+}
+.install-cmd code { font-family: "JetBrains Mono", monospace; font-size: 13.5px; line-height: 1.6; color: var(--code-ink); word-break: break-word; }
+.install-cmd .prompt { color: var(--brand); margin-right: 8px; user-select: none; }
+.install-hint { margin-top: 16px; font-size: 13px; color: var(--ink-dim); line-height: 1.6; }
+.claw { margin-top: 16px; display: grid; gap: 8px; }
+.claw-row { display: flex; align-items: center; gap: 12px; background: var(--bg-sunken); border: 1px solid var(--line); border-radius: 10px; padding: 9px 10px 9px 14px; }
+.claw-row__label { font-size: 12.5px; font-weight: 700; color: var(--ink); min-width: 110px; }
+.claw-row code { font-family: "JetBrains Mono", monospace; font-size: 12.5px; color: var(--ink-soft); flex: 1; word-break: break-all; }
+
+/* copy buttons */
+.copy-mini {
+  display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px; border-radius: 9px;
+  border: 1px solid var(--line); background: var(--bg-elev); color: var(--ink-soft); cursor: pointer;
+  font-size: 12.5px; font-weight: 600; white-space: nowrap; transition: border-color .15s, color .15s;
+}
+.copy-mini:hover { border-color: var(--brand); color: var(--brand-ink); }
+.install-cmd .copy-mini { background: rgba(255,255,255,.06); border-color: rgba(255,255,255,.12); color: #cdd6f4; }
+.install-cmd .copy-mini:hover { border-color: var(--brand); color: #fff; }
+.copy-mini.is-copied { border-color: #34d058; color: #34d058; }
+
+/* ---------------- Step rail (quickstart) ---------------- */
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+@media (max-width: 820px) { .steps { grid-template-columns: 1fr; } }
+.step { padding: 22px; border-radius: 14px; border: 1px solid var(--line); background: var(--bg-elev); box-shadow: var(--shadow); }
+.step__num { width: 30px; height: 30px; border-radius: 9px; display: grid; place-items: center; background: var(--brand); color: #fff; font: 800 14px/1 "JetBrains Mono", monospace; margin-bottom: 14px; }
+.step h3 { margin: 0 0 6px; font-size: 16px; font-weight: 700; }
+.step p { margin: 0 0 12px; color: var(--ink-soft); font-size: 14px; line-height: 1.55; }
+.step__cmd { display: flex; align-items: center; gap: 8px; background: var(--code-bg); border-radius: 9px; padding: 9px 10px 9px 12px; }
+.step__cmd code { font-family: "JetBrains Mono", monospace; font-size: 12.5px; color: var(--code-ink); flex: 1; }
+
+/* ---------------- Command explorer ---------------- */
+.cmd-toolbar { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-bottom: 18px; }
+.cmd-search { position: relative; flex: 1; min-width: 240px; }
+.cmd-search svg { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); width: 17px; height: 17px; color: var(--ink-dim); }
+.cmd-search input {
+  width: 100%; padding: 12px 14px 12px 42px; border-radius: 11px; border: 1px solid var(--line);
+  background: var(--bg-elev); color: var(--ink); font-size: 14.5px; outline: none; transition: border-color .15s, box-shadow .15s;
+}
+.cmd-search input:focus { border-color: var(--brand); box-shadow: 0 0 0 4px var(--brand-tint); }
+.cmd-search input::placeholder { color: var(--ink-dim); }
+.cmd-count { font-size: 12.5px; color: var(--ink-dim); font-family: "JetBrains Mono", monospace; }
+.cmd-filters { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 16px; }
+.chip {
+  padding: 6px 13px; border-radius: 999px; border: 1px solid var(--line); background: var(--bg-elev);
+  cursor: pointer; font-size: 13px; font-weight: 600; color: var(--ink-soft); transition: border-color .15s, color .15s, background .15s;
+}
+.chip:hover { border-color: var(--brand); color: var(--brand-ink); }
+.chip[aria-pressed="true"] { background: var(--ink); border-color: var(--ink); color: var(--bg-elev); }
+html.dark .chip[aria-pressed="true"] { background: var(--brand); border-color: var(--brand); color: #fff; }
+
+.cmd-list { display: grid; gap: 8px; }
+.cmd-row {
+  display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 16px;
+  padding: 13px 14px 13px 18px; border-radius: 12px; border: 1px solid var(--line); background: var(--bg-elev);
+  transition: border-color .15s, transform .12s, box-shadow .15s;
+}
+.cmd-row:hover { border-color: color-mix(in srgb, var(--brand) 45%, var(--line)); box-shadow: var(--shadow); }
+.cmd-row__meta { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.cmd-row__group { font: 700 10px/1 "JetBrains Mono", monospace; letter-spacing: .08em; text-transform: uppercase; color: var(--brand-ink); background: var(--brand-tint); padding: 5px 8px; border-radius: 6px; white-space: nowrap; }
+.cmd-row__use { font-size: 14.5px; color: var(--ink); font-weight: 500; }
+.cmd-row__cmd { display: flex; align-items: center; gap: 10px; }
+.cmd-row__cmd code { font-family: "JetBrains Mono", monospace; font-size: 13px; color: var(--ink-soft); background: var(--bg-sunken); padding: 6px 10px; border-radius: 8px; white-space: nowrap; max-width: 46ch; overflow: hidden; text-overflow: ellipsis; }
+.cmd-row mark { background: color-mix(in srgb, var(--brand) 30%, transparent); color: inherit; border-radius: 3px; padding: 0 1px; }
+.cmd-empty { padding: 28px; text-align: center; color: var(--ink-dim); }
+@media (max-width: 760px) {
+  .cmd-row { grid-template-columns: 1fr; gap: 10px; }
+  .cmd-row__cmd code { max-width: none; white-space: normal; word-break: break-all; }
+}
+
+/* ---------------- Shortcuts ---------------- */
+.sc-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+@media (max-width: 900px) { .sc-grid { grid-template-columns: 1fr; } }
+.sc-col { border: 1px solid var(--line); border-radius: 16px; background: var(--bg-elev); padding: 22px; box-shadow: var(--shadow); }
+.sc-col__title { margin: 0 0 16px; font-size: 13px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--ink-dim); }
+.sc-col__list { display: grid; gap: 11px; }
+.sc-item { display: flex; align-items: center; gap: 12px; }
+.sc-keys { display: inline-flex; align-items: center; gap: 5px; min-width: 78px; }
+.sc-sep { color: var(--ink-dim); font-size: 12px; }
+.sc-desc { font-size: 14px; color: var(--ink-soft); }
+.keycap {
+  display: inline-flex; align-items: center; justify-content: center; min-width: 26px; height: 26px; padding: 0 7px;
+  border-radius: 7px; border: 1px solid var(--line); background: var(--bg);
+  box-shadow: inset 0 -2px 0 var(--line); font: 700 12px/1 "JetBrains Mono", monospace; color: var(--ink);
+}
+
+/* ---------------- Faux TUI + theme switcher ---------------- */
+.tui-block { display: grid; grid-template-columns: 260px 1fr; gap: 24px; align-items: start; }
+@media (max-width: 900px) { .tui-block { grid-template-columns: 1fr; } }
+.theme-picker { display: grid; gap: 8px; }
+.theme-swatch {
+  display: flex; align-items: center; gap: 12px; padding: 11px 13px; border-radius: 12px;
+  border: 1px solid var(--line); background: var(--bg-elev); cursor: pointer; text-align: left; width: 100%;
+  transition: border-color .15s, background .15s;
+}
+.theme-swatch:hover { border-color: var(--brand); }
+.theme-swatch[aria-pressed="true"] { border-color: var(--brand); background: var(--brand-tint); }
+.theme-swatch__dots { display: inline-flex; gap: 4px; }
+.theme-swatch__dots i { width: 11px; height: 11px; border-radius: 999px; display: block; }
+.theme-swatch__name { font-size: 13.5px; font-weight: 600; color: var(--ink); }
+
+.ftui {
+  --t-bg:#0b1220; --t-panel:#0e1626; --t-border:#1e2a44; --t-text:#cdd6f4; --t-dim:#7d8db0;
+  --t-accent:#4e97ff; --t-sel:#13294d; --t-green:#34d058; --t-yellow:#e3b341; --t-red:#ff6b6b;
+}
+.ftui__screen { background: var(--t-bg); color: var(--t-text); font-family: "JetBrains Mono", monospace; font-size: 13px; }
+.ftui__top { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; border-bottom: 1px solid var(--t-border); color: var(--t-dim); }
+.ftui__top b { color: var(--t-accent); }
+.ftui__cols { display: grid; grid-template-columns: 24px 92px 1fr; gap: 10px; padding: 8px 14px; color: var(--t-dim); border-bottom: 1px solid var(--t-border); font-size: 11px; letter-spacing: .04em; text-transform: uppercase; }
+.ftui-row { display: grid; grid-template-columns: 96px 110px 1fr; gap: 10px; align-items: center; padding: 9px 14px; border-bottom: 1px solid color-mix(in srgb, var(--t-border) 60%, transparent); }
+.ftui-row.is-sel { background: var(--t-sel); }
+.ftui-row.is-sel::before { content: "›"; position: absolute; margin-left: -12px; color: var(--t-accent); }
+.ftui-key { color: var(--t-accent); font-weight: 700; }
+.ftui-sum { color: var(--t-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ftui-badge { font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid transparent; white-space: nowrap; }
+.ftui-badge--prog { color: var(--t-yellow); border-color: color-mix(in srgb, var(--t-yellow) 50%, transparent); }
+.ftui-badge--todo { color: var(--t-dim); border-color: color-mix(in srgb, var(--t-dim) 50%, transparent); }
+.ftui-badge--done { color: var(--t-green); border-color: color-mix(in srgb, var(--t-green) 50%, transparent); }
+.ftui-badge--rev { color: var(--t-accent); border-color: color-mix(in srgb, var(--t-accent) 50%, transparent); }
+.ftui__foot { display: flex; gap: 16px; padding: 10px 14px; border-top: 1px solid var(--t-border); color: var(--t-dim); font-size: 11.5px; flex-wrap: wrap; }
+.ftui__foot b { color: var(--t-text); }
+
+/* ---------------- MCP ---------------- */
+.code-card { border: 1px solid var(--line); border-radius: 14px; overflow: hidden; background: var(--code-bg); box-shadow: var(--shadow); }
+.code-card__bar { display: flex; align-items: center; justify-content: space-between; padding: 11px 14px; border-bottom: 1px solid rgba(255,255,255,.07); }
+.code-card__name { font: 600 12px/1 "JetBrains Mono", monospace; color: #8b97b0; }
+.code-card pre { margin: 0; padding: 16px 18px; overflow-x: auto; }
+.code-card code { font-family: "JetBrains Mono", monospace; font-size: 13px; line-height: 1.7; color: var(--code-ink); }
+.mcp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+@media (max-width: 880px) { .mcp-grid { grid-template-columns: 1fr; } }
+.mcp-clients { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-top: 14px; }
+@media (max-width: 520px) { .mcp-clients { grid-template-columns: 1fr; } }
+.mcp-client { display: flex; align-items: center; gap: 8px; padding: 9px 12px; border-radius: 9px; border: 1px solid var(--line); background: var(--bg-elev); font: 600 12.5px/1 "JetBrains Mono", monospace; color: var(--ink-soft); }
+.mcp-client::before { content: ""; width: 7px; height: 7px; border-radius: 999px; background: var(--brand); }
+
+/* ---------------- FAQ ---------------- */
+.faq { display: grid; gap: 10px; max-width: 760px; }
+.faq details { border: 1px solid var(--line); border-radius: 13px; background: var(--bg-elev); overflow: hidden; transition: border-color .15s; }
+.faq details[open] { border-color: color-mix(in srgb, var(--brand) 40%, var(--line)); }
+.faq summary { list-style: none; cursor: pointer; padding: 17px 20px; font-weight: 600; font-size: 15.5px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after { content: "+"; font: 400 22px/1 "JetBrains Mono", monospace; color: var(--brand-ink); transition: transform .2s; }
+.faq details[open] summary::after { transform: rotate(45deg); }
+.faq p { margin: 0; padding: 0 20px 18px; color: var(--ink-soft); font-size: 14.5px; line-height: 1.65; }
+
+/* ---------------- CTA band ---------------- */
+.cta-band { border-radius: 22px; padding: 56px 40px; text-align: center; position: relative; overflow: hidden; border: 1px solid var(--line); background: var(--bg-elev); box-shadow: var(--shadow); }
+.cta-band__glow { position: absolute; inset: 0; z-index: 0; background: radial-gradient(520px 280px at 50% -30%, var(--glow), transparent 70%); pointer-events: none; }
+.cta-band > * { position: relative; z-index: 1; }
+.cta-band h2 { font-size: clamp(26px, 4vw, 38px); font-weight: 800; letter-spacing: -0.025em; margin: 0; }
+.cta-band p { margin: 14px auto 0; max-width: 480px; color: var(--ink-soft); font-size: 16px; }
+.cta-band .hero__cta { justify-content: center; margin-top: 28px; }
+
+/* ---------------- Footer ---------------- */
+.site-footer { border-top: 1px solid var(--line); padding-block: 44px; background: var(--bg-sunken); }
+.site-footer__row { display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
+.site-footer p { margin: 4px 0 0; font-size: 13.5px; color: var(--ink-dim); }
+.site-footer .brand { margin-bottom: 6px; }
+.site-footer__links { display: flex; gap: 22px; flex-wrap: wrap; align-items: flex-start; }
+.site-footer__links a { font-size: 13.5px; color: var(--ink-soft); text-decoration: none; }
+.site-footer__links a:hover { color: var(--brand-ink); }
+
+/* ---------------- Reveal ---------------- */
+[data-reveal] { opacity: 0; transform: translateY(16px); transition: opacity .6s cubic-bezier(.2,.7,.2,1), transform .6s cubic-bezier(.2,.7,.2,1); }
+[data-reveal].is-in { opacity: 1; transform: none; }
+[data-reveal][data-reveal-delay="1"] { transition-delay: .08s; }
+[data-reveal][data-reveal-delay="2"] { transition-delay: .16s; }
+[data-reveal][data-reveal-delay="3"] { transition-delay: .24s; }
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] { opacity: 1; transform: none; transition: none; }
+  html { scroll-behavior: auto; }
+}


### PR DESCRIPTION
## Summary
- replace the old docs landing page with the new GitHub Pages design
- add the extracted static assets for the new interactive landing page
- keep the docs site self-contained under `docs/`

## Verification
- served `docs/` locally and confirmed `index.html`, `styles.css`, `app.js`, and `data.js` return HTTP 200