### PR TITLE
fix(windows): harden MCP path and home handling

### DIFF
--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -657,7 +657,50 @@ fn config_path_from_env_or_default(env_key: &str, default: PathBuf) -> PathBuf {
 }
 
 fn home_dir() -> Option<PathBuf> {
-    env::var_os("HOME").map(PathBuf::from)
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("USERPROFILE").map(PathBuf::from))
+        .or_else(
+            || match (env::var_os("HOMEDRIVE"), env::var_os("HOMEPATH")) {
+                (Some(drive), Some(path)) => {
+                    let mut home = PathBuf::from(drive);
+                    home.push(path);
+                    Some(home)
+                }
+                _ => None,
+            },
+        )
+}
+
+#[cfg(target_os = "windows")]
+fn executable_path_candidates(path: &Path) -> Vec<PathBuf> {
+    let mut candidates = vec![path.to_path_buf()];
+    if path.extension().is_some() {
+        return candidates;
+    }
+
+    let pathext = env::var_os("PATHEXT")
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+
+    for ext in pathext
+        .split(';')
+        .map(str::trim)
+        .filter(|ext| !ext.is_empty())
+    {
+        let trimmed = ext.trim_start_matches('.');
+        if trimmed.is_empty() {
+            continue;
+        }
+        candidates.push(path.with_extension(trimmed));
+    }
+
+    candidates
+}
+
+#[cfg(not(target_os = "windows"))]
+fn executable_path_candidates(path: &Path) -> Vec<PathBuf> {
+    vec![path.to_path_buf()]
 }
 
 fn claude_desktop_settings_path(home: &Path) -> PathBuf {
@@ -726,13 +769,17 @@ fn resolve_command_for_client(client: &McpClient, command: &str, dry_run: bool) 
 fn resolve_command_path(command: &str) -> Option<PathBuf> {
     let path = PathBuf::from(command);
     if path.components().count() > 1 || path.is_absolute() {
-        return path.is_file().then_some(path);
+        return executable_path_candidates(&path)
+            .into_iter()
+            .find(|candidate| candidate.is_file());
     }
 
     env::var_os("PATH").and_then(|paths| {
         env::split_paths(&paths).find_map(|dir| {
             let candidate = dir.join(command);
-            candidate.is_file().then_some(candidate)
+            executable_path_candidates(&candidate)
+                .into_iter()
+                .find(|resolved| resolved.is_file())
         })
     })
 }
@@ -923,6 +970,12 @@ fn shell_escape(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn generic_json_snippet_contains_server_name() {
@@ -994,6 +1047,44 @@ mod tests {
     fn resolve_command_path_finds_absolute_path() {
         let path = resolve_command_path("/bin/sh").unwrap();
         assert_eq!(path, PathBuf::from("/bin/sh"));
+    }
+
+    #[test]
+    fn home_dir_falls_back_to_userprofile() {
+        let _guard = env_lock().lock().unwrap();
+        let temp_dir =
+            std::env::temp_dir().join(format!("jirac-home-dir-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let original_home = std::env::var_os("HOME");
+        let original_userprofile = std::env::var_os("USERPROFILE");
+        let original_homedrive = std::env::var_os("HOMEDRIVE");
+        let original_homepath = std::env::var_os("HOMEPATH");
+
+        std::env::remove_var("HOME");
+        std::env::set_var("USERPROFILE", &temp_dir);
+        std::env::remove_var("HOMEDRIVE");
+        std::env::remove_var("HOMEPATH");
+
+        assert_eq!(home_dir().as_deref(), Some(temp_dir.as_path()));
+
+        match original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match original_userprofile {
+            Some(value) => std::env::set_var("USERPROFILE", value),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        match original_homedrive {
+            Some(value) => std::env::set_var("HOMEDRIVE", value),
+            None => std::env::remove_var("HOMEDRIVE"),
+        }
+        match original_homepath {
+            Some(value) => std::env::set_var("HOMEPATH", value),
+            None => std::env::remove_var("HOMEPATH"),
+        }
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -2867,13 +2867,107 @@ fn build_project_version_options(
         .collect()
 }
 
+fn user_home_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(std::path::PathBuf::from))
+        .or_else(
+            || match (std::env::var_os("HOMEDRIVE"), std::env::var_os("HOMEPATH")) {
+                (Some(drive), Some(path)) => {
+                    let mut home = std::path::PathBuf::from(drive);
+                    home.push(path);
+                    Some(home)
+                }
+                _ => None,
+            },
+        )
+}
+
 fn shellexpand_tilde(path: &str) -> std::borrow::Cow<'_, str> {
-    if let Some(stripped) = path.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            let mut p = std::path::PathBuf::from(home);
+    let stripped = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\"));
+
+    if let Some(stripped) = stripped {
+        if let Some(home) = user_home_dir() {
+            let mut p = home;
             p.push(stripped);
             return std::borrow::Cow::Owned(p.to_string_lossy().into_owned());
         }
     }
     std::borrow::Cow::Borrowed(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn shellexpand_tilde_falls_back_to_userprofile() {
+        let _guard = env_lock().lock().unwrap();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "jirac-tilde-userprofile-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let original_home = std::env::var_os("HOME");
+        let original_userprofile = std::env::var_os("USERPROFILE");
+        let original_homedrive = std::env::var_os("HOMEDRIVE");
+        let original_homepath = std::env::var_os("HOMEPATH");
+
+        std::env::remove_var("HOME");
+        std::env::set_var("USERPROFILE", &temp_dir);
+        std::env::remove_var("HOMEDRIVE");
+        std::env::remove_var("HOMEPATH");
+
+        let expanded = shellexpand_tilde("~/Desktop/file.txt");
+        assert!(expanded.starts_with(&*temp_dir.to_string_lossy()));
+        assert!(expanded.contains("Desktop"));
+
+        restore_env("HOME", original_home);
+        restore_env("USERPROFILE", original_userprofile);
+        restore_env("HOMEDRIVE", original_homedrive);
+        restore_env("HOMEPATH", original_homepath);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn shellexpand_tilde_accepts_backslash_prefix() {
+        let _guard = env_lock().lock().unwrap();
+        let temp_dir =
+            std::env::temp_dir().join(format!("jirac-tilde-backslash-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let original_home = std::env::var_os("HOME");
+        let original_userprofile = std::env::var_os("USERPROFILE");
+        let original_homedrive = std::env::var_os("HOMEDRIVE");
+        let original_homepath = std::env::var_os("HOMEPATH");
+
+        std::env::remove_var("HOME");
+        std::env::set_var("USERPROFILE", &temp_dir);
+        std::env::remove_var("HOMEDRIVE");
+        std::env::remove_var("HOMEPATH");
+
+        let expanded = shellexpand_tilde("~\\Desktop\\file.txt");
+        assert!(expanded.starts_with(&*temp_dir.to_string_lossy()));
+        assert!(expanded.contains("Desktop"));
+
+        restore_env("HOME", original_home);
+        restore_env("USERPROFILE", original_userprofile);
+        restore_env("HOMEDRIVE", original_homedrive);
+        restore_env("HOMEPATH", original_homepath);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
 }


### PR DESCRIPTION
## Why
Windows support exists across install/distribution, but a few path-resolution assumptions were still Unix-leaning. That could make Windows users hit false "binary not found" or "home directory not found" failures, especially around `jirac mcp install`, `jirac mcp doctor`, and TUI attachment paths.

## What changed
- fallback home-dir resolution now checks `HOME`, then `USERPROFILE`, then `HOMEDRIVE` + `HOMEPATH`
- MCP command lookup now respects Windows executable suffixes via `PATHEXT`
- TUI tilde expansion now supports both `~/...` and `~\\...` with the same Windows home fallback
- added regression tests for the new fallback behavior

## User impact
This should fix three Windows-specific pain points:
1. `jirac mcp install` / related config-target logic no longer fail just because `HOME` is unset
2. PATH lookup now finds binaries like `jirac-mcp.exe`, `codex.cmd`, or similar Windows-resolved commands
3. TUI attachment/file inputs using `~` behave more naturally on Windows

## Scope / safety
- changes are limited to `crates/jira/src/cli/mcp.rs` and `crates/jira/src/tui/app.rs`
- non-Windows platforms keep their existing behavior
- Windows executable suffix expansion is gated to Windows builds only

## Testing
- `cargo test -p jira-commands --quiet`
- `cargo test -p jira-core --quiet`
