### PR TITLE
fix: address audit findings (HIGH + MED + LOW)

### DIFF
--- a/crates/jira-core/src/adf.rs
+++ b/crates/jira-core/src/adf.rs
@@ -1,5 +1,9 @@
 use serde_json::{json, Value};
 
+/// Maximum recursion depth for ADF node rendering. Guards against
+/// stack overflow from maliciously deep or cyclic documents.
+const MAX_RENDER_DEPTH: usize = 128;
+
 /// Convert an ADF (Atlassian Document Format) JSON value to plain text.
 pub fn adf_to_text(value: &Value) -> String {
     let mut output = String::new();
@@ -8,6 +12,9 @@ pub fn adf_to_text(value: &Value) -> String {
 }
 
 fn render_node(node: &Value, out: &mut String, depth: usize) {
+    if depth > MAX_RENDER_DEPTH {
+        return;
+    }
     let node_type = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
     match node_type {
@@ -197,10 +204,13 @@ pub fn inject_mentions(node: &mut Value, mention_map: &[(String, String)]) {
     if mention_map.is_empty() {
         return;
     }
-    inject_mentions_node(node, mention_map);
+    inject_mentions_node(node, mention_map, 0);
 }
 
-fn inject_mentions_node(node: &mut Value, mention_map: &[(String, String)]) {
+fn inject_mentions_node(node: &mut Value, mention_map: &[(String, String)], depth: usize) {
+    if depth > MAX_RENDER_DEPTH {
+        return;
+    }
     if let Some(Value::Array(content)) = node.get_mut("content") {
         let old = std::mem::take(content);
         let mut new_content: Vec<Value> = Vec::new();
@@ -225,7 +235,7 @@ fn inject_mentions_node(node: &mut Value, mention_map: &[(String, String)]) {
     }
     if let Some(Value::Array(content)) = node.get_mut("content") {
         for child in content.iter_mut() {
-            inject_mentions_node(child, mention_map);
+            inject_mentions_node(child, mention_map, depth + 1);
         }
     }
 }
@@ -267,11 +277,14 @@ fn expand_text_mentions(text: &str, mention_map: &[(String, String)]) -> Vec<Val
 /// Collect all mentioned Jira account IDs found in an ADF document.
 pub fn mentioned_account_ids(value: &Value) -> Vec<String> {
     let mut out = Vec::new();
-    collect_mentioned_account_ids(value, &mut out);
+    collect_mentioned_account_ids(value, &mut out, 0);
     out
 }
 
-fn collect_mentioned_account_ids(node: &Value, out: &mut Vec<String>) {
+fn collect_mentioned_account_ids(node: &Value, out: &mut Vec<String>, depth: usize) {
+    if depth > MAX_RENDER_DEPTH {
+        return;
+    }
     if node.get("type").and_then(|v| v.as_str()) == Some("mention") {
         if let Some(id) = node
             .get("attrs")
@@ -286,7 +299,7 @@ fn collect_mentioned_account_ids(node: &Value, out: &mut Vec<String>) {
 
     if let Some(children) = node.get("content").and_then(|v| v.as_array()) {
         for child in children {
-            collect_mentioned_account_ids(child, out);
+            collect_mentioned_account_ids(child, out, depth + 1);
         }
     }
 }

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -832,6 +832,11 @@ impl JiraClient {
     }
 
     fn page_is_last(response: &Value, fetched_count: usize) -> bool {
+        // Empty page = definitely last. Prevents infinite loops when API returns
+        // a quirky page with no records but also no metadata.
+        if fetched_count == 0 {
+            return true;
+        }
         if let Some(is_last) = response.get("isLast").and_then(|v| v.as_bool()) {
             return is_last;
         }
@@ -845,6 +850,8 @@ impl JiraClient {
         if let Some(max_results) = response.get("maxResults").and_then(|v| v.as_u64()) {
             return fetched_count < max_results as usize;
         }
+        // Last resort: no metadata at all. Treat as last page to avoid an
+        // unbounded loop; callers should also enforce MAX_PAGINATION_ITERATIONS.
         true
     }
 
@@ -854,10 +861,20 @@ impl JiraClient {
         project_key: &str,
         states: &[&str],
     ) -> Result<Vec<Sprint>> {
+        const MAX_PAGES: u32 = 500;
+
         let mut board_ids = Vec::new();
         let mut board_start_at = 0u64;
+        let mut iterations = 0u32;
 
         loop {
+            iterations += 1;
+            if iterations > MAX_PAGES {
+                return Err(JiraError::Api {
+                    status: 500,
+                    message: "board pagination exceeded MAX_PAGES safeguard".to_string(),
+                });
+            }
             let boards_path = format!(
                 "/rest/agile/1.0/board?projectKeyOrId={project_key}&maxResults=100&startAt={board_start_at}"
             );
@@ -885,7 +902,17 @@ impl JiraClient {
 
         for board_id in board_ids {
             let mut sprint_start_at = 0u64;
+            let mut sprint_iterations = 0u32;
             loop {
+                sprint_iterations += 1;
+                if sprint_iterations > MAX_PAGES {
+                    return Err(JiraError::Api {
+                        status: 500,
+                        message: format!(
+                            "sprint pagination exceeded MAX_PAGES safeguard for board {board_id}"
+                        ),
+                    });
+                }
                 let sprint_path = format!(
                     "/rest/agile/1.0/board/{board_id}/sprint?state={state_filter}&maxResults=200&startAt={sprint_start_at}"
                 );

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -212,7 +212,10 @@ impl JiraClient {
         if status.is_success() {
             return Ok(());
         }
-        let body = response.text().await.unwrap_or_default();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
         if status == StatusCode::NOT_FOUND {
             return Err(JiraError::NotFound(body));
         }

--- a/crates/jira-core/src/config.rs
+++ b/crates/jira-core/src/config.rs
@@ -5,6 +5,28 @@ use std::{collections::BTreeMap, env, path::PathBuf};
 
 use crate::error::{JiraError, Result};
 
+/// Emit an `eprintln!` warning if the config file is readable by group/other.
+/// Tokens are stored in this file, so loose permissions are a security risk.
+#[cfg(unix)]
+fn warn_if_world_readable(path: &std::path::Path) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return;
+    };
+    let mode = meta.permissions().mode() & 0o077;
+    if mode != 0 {
+        eprintln!(
+            "warning: {} is group/world accessible (mode {:o}); contains an API token. \
+             Run: chmod 600 {}",
+            path.display(),
+            meta.permissions().mode() & 0o777,
+            path.display(),
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_world_readable(_path: &std::path::Path) {}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum JiraDeployment {
@@ -209,6 +231,15 @@ impl JiraConfig {
         }
     }
 
+    /// Apply `JIRA_*` environment variables on top of the loaded profile.
+    ///
+    /// Precedence (highest first):
+    ///   1. Environment variables (`JIRA_URL`, `JIRA_EMAIL`, `JIRA_TOKEN`, ...)
+    ///   2. Profile values from the config file
+    ///   3. Built-in defaults
+    ///
+    /// Env vars always win because this runs *after* the file has been parsed
+    /// into `self`. Empty `JIRA_PROJECT` is treated as "unset" (clears project).
     fn apply_env_overrides(&mut self) {
         if let Ok(url) = env::var("JIRA_URL") {
             self.base_url = url;
@@ -262,6 +293,8 @@ impl JiraProfilesFile {
         if !config_path.exists() {
             return Ok(Self::default());
         }
+
+        warn_if_world_readable(&config_path);
 
         let content = std::fs::read_to_string(&config_path)
             .map_err(|e| JiraError::Config(format!("Failed to read config: {e}")))?;

--- a/crates/jira-core/src/field_cache.rs
+++ b/crates/jira-core/src/field_cache.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crate::{client::JiraClient, error::Result, model::field::Field};
@@ -17,29 +18,35 @@ impl CacheEntry {
 }
 
 /// In-memory cache for Jira field metadata, keyed by "project:issue_type_id".
+///
+/// Safe to share across tokio tasks: interior mutability via `Mutex`. The lock
+/// is never held across an `.await`.
 pub struct FieldCache {
-    entries: HashMap<String, CacheEntry>,
+    entries: Mutex<HashMap<String, CacheEntry>>,
 }
 
 impl FieldCache {
     pub fn new() -> Self {
         Self {
-            entries: HashMap::new(),
+            entries: Mutex::new(HashMap::new()),
         }
     }
 
     /// Return cached fields or fetch from the API if stale / missing.
     pub async fn get_or_fetch(
-        &mut self,
+        &self,
         client: &JiraClient,
         project_key: &str,
         issue_type_id: &str,
     ) -> Result<Vec<Field>> {
         let key = format!("{project_key}:{issue_type_id}");
 
-        if let Some(entry) = self.entries.get(&key) {
-            if entry.is_fresh() {
-                return Ok(entry.fields.clone());
+        {
+            let entries = self.entries.lock().expect("FieldCache mutex poisoned");
+            if let Some(entry) = entries.get(&key) {
+                if entry.is_fresh() {
+                    return Ok(entry.fields.clone());
+                }
             }
         }
 
@@ -47,13 +54,16 @@ impl FieldCache {
             .get_fields_for_issue_type(project_key, issue_type_id)
             .await?;
 
-        self.entries.insert(
-            key,
-            CacheEntry {
-                fields: fields.clone(),
-                fetched_at: Instant::now(),
-            },
-        );
+        {
+            let mut entries = self.entries.lock().expect("FieldCache mutex poisoned");
+            entries.insert(
+                key,
+                CacheEntry {
+                    fields: fields.clone(),
+                    fetched_at: Instant::now(),
+                },
+            );
+        }
 
         Ok(fields)
     }

--- a/crates/jira-core/src/model/link.rs
+++ b/crates/jira-core/src/model/link.rs
@@ -36,7 +36,14 @@ impl LinkedIssue {
         let key = value.get("key")?.as_str()?.to_string();
         let fields = value.get("fields")?;
 
-        let summary = fields.get("summary")?.as_str()?.to_string();
+        // Use the same defaulting pattern as `RawIssue::into_issue`: missing
+        // textual fields fall back to a placeholder instead of dropping the
+        // whole linked issue. Caller relies on `id`/`key` being present.
+        let summary = fields
+            .get("summary")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         let status = fields
             .get("status")
             .and_then(|s| s.get("name"))

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -2622,7 +2622,7 @@ async fn collect_custom_fields(
         return Ok(HashMap::new());
     }
 
-    let mut cache = FieldCache::new();
+    let cache = FieldCache::new();
     let fields = cache.get_or_fetch(client, project_key, issue_type_id).await;
 
     let fields = match fields {

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -2547,7 +2547,15 @@ async fn create_issue(
     if json {
         // Re-fetch to include any attachment metadata
         let full = if had_attachments {
-            client.get_issue(&issue.key).await.unwrap_or(issue)
+            match client.get_issue(&issue.key).await {
+                Ok(refreshed) => refreshed,
+                Err(e) => {
+                    eprintln!(
+                        "warning: re-fetch after attach failed ({e}); attachment metadata may be missing"
+                    );
+                    issue
+                }
+            }
         } else {
             issue
         };
@@ -3110,7 +3118,7 @@ fn spinner_new(msg: impl Into<String>) -> ProgressBar {
     pb.set_style(
         ProgressStyle::default_spinner()
             .template("{spinner:.cyan} {msg}")
-            .unwrap(),
+            .expect("spinner template is a compile-time constant"),
     );
     pb.set_message(msg.into());
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
@@ -3126,7 +3134,7 @@ fn progress_bar(len: u64) -> ProgressBar {
     pb.set_style(
         ProgressStyle::default_bar()
             .template("{spinner:.cyan} [{bar:40}] {pos}/{len} {msg}")
-            .unwrap()
+            .expect("progress bar template is a compile-time constant")
             .progress_chars("=> "),
     );
     pb

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -799,6 +799,44 @@ async fn search_visible(
         .await
 }
 
+/// RAII guard that restores the terminal on drop, even if the TUI panics.
+struct TerminalGuard {
+    pushed_keyboard_flags: bool,
+}
+
+impl TerminalGuard {
+    fn install() -> io::Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        // Best-effort: ask for Kitty keyboard protocol so SUPER (Cmd) modifier and
+        // distinct shifted keys reach the app. Terminals that don't implement it
+        // ignore the sequence — failure is silent on purpose.
+        let pushed_keyboard_flags = execute!(
+            stdout,
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+            )
+        )
+        .is_ok();
+        Ok(Self {
+            pushed_keyboard_flags,
+        })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let mut stdout = io::stdout();
+        if self.pushed_keyboard_flags {
+            let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+        }
+        let _ = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture);
+        let _ = disable_raw_mode();
+    }
+}
+
 pub async fn run_tui(
     client: JiraClient,
     project: Option<String>,
@@ -812,19 +850,8 @@ pub async fn run_tui(
 
     let base_url = client.base_url().to_string();
 
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    // Best-effort: ask for Kitty keyboard protocol so SUPER (Cmd) modifier and
-    // distinct shifted keys reach the app. Terminals that don't implement it
-    // ignore the sequence — failure is silent on purpose.
-    let _ = execute!(
-        stdout,
-        PushKeyboardEnhancementFlags(
-            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-        )
-    );
+    let _terminal_guard = TerminalGuard::install()?;
+    let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -2786,16 +2813,9 @@ pub async fn run_tui(
         }
     }
 
-    disable_raw_mode()?;
-    // Pop only if we successfully pushed (silent failure either way — pairs
-    // with the best-effort push above).
-    let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
     terminal.show_cursor()?;
+    // TerminalGuard's Drop restores raw mode, alt-screen, mouse capture, and
+    // keyboard enhancement flags.
 
     Ok(())
 }

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -1644,10 +1644,12 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette, scroll_offset:
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(inner);
-        let left = Paragraph::new(col1).wrap(Wrap { trim: false });
-        let right = Paragraph::new(col2).wrap(Wrap { trim: false });
-        f.render_widget(left, cols[0]);
-        f.render_widget(right, cols[1]);
+        if let (Some(&left_rect), Some(&right_rect)) = (cols.first(), cols.get(1)) {
+            let left = Paragraph::new(col1).wrap(Wrap { trim: false });
+            let right = Paragraph::new(col2).wrap(Wrap { trim: false });
+            f.render_widget(left, left_rect);
+            f.render_widget(right, right_rect);
+        }
     } else {
         let max_scroll = total_lines.saturating_sub(inner.height);
         let scroll = scroll_offset.min(max_scroll);
@@ -1676,14 +1678,20 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         ])
         .split(r);
 
-    Layout::default()
+    let Some(&middle) = popup_layout.get(1) else {
+        return r;
+    };
+
+    let horizontal = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Percentage((100 - percent_x) / 2),
             Constraint::Percentage(percent_x),
             Constraint::Percentage((100 - percent_x) / 2),
         ])
-        .split(popup_layout[1])[1]
+        .split(middle);
+
+    horizontal.get(1).copied().unwrap_or(r)
 }
 
 fn bottom_bar_rect(r: Rect) -> Rect {


### PR DESCRIPTION
## Description

Addresses 9 of 15 findings from a manual audit of `crates/jira-core` and `crates/jira` (see commit messages for per-finding rationale). One commit per finding (or per file where two related fixes share a file).

**HIGH severity (5)**
- `1df79da` `fix(jira-core)`: cap ADF recursion depth to prevent stack overflow
- `b060cfd` `fix(jira-core)`: make `FieldCache` thread-safe via interior mutability
- `d46ec9c` `fix(jira-core)`: cap sprint/board pagination and harden `page_is_last`
- `6b539d1` `fix(tui)`: guard layout rect indexing in `render` and `centered_rect`
- `4f89449` `fix(tui)`: restore terminal state on panic via RAII guard

**MEDIUM severity (5)**
- `8017b6f` `fix(jira-core)`: preserve body-read error in API error response
- `71f9a73` `fix(jira-core)`: default missing `summary` on `LinkedIssue` to empty string
- `1e81fe8` `fix(jira-core)`: document env precedence and warn on insecure config perms
- `cee8d7b` `fix(cli)`: surface re-fetch failure (also covers L13 progress template)

**LOW severity (1)**
- `cee8d7b` `fix(cli)`: `.expect(...)` on compile-time progress templates

### Findings intentionally deferred (4)

| # | Why deferred |
|---|--------------|
| `model/issue.rs` `unwrap_or` defaults | Schema-drift detection needs a design decision (log-once? `Result<Issue>`? breaking API). Out of scope for a fix PR. |
| `adf.rs` mention expansion O(n×m) | Performance, not correctness. Needs benchmark + single-pass redesign. |
| `tui/app.rs` ignores `Event::Resize/Focus/Paste` | Ratatui re-draws every poll tick (100ms); resize is picked up on the next frame. Intentional. |
| `error.rs` `#[from]` "loses source chain" | `thiserror`'s `#[from]` already implements `Error::source()` returning the inner error. The agent finding was incorrect. Not a bug. |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [x] `cargo fmt --all` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (108 tests)
- [x] `cargo audit` passes (no new CVEs introduced)
- [ ] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [x] No new dependency added without justification in PR description
- [x] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [x] No new `unsafe` blocks without explanation
- [x] No outbound network calls added outside of `jira-core/src/client.rs`
- [x] No changes to `.github/workflows/` without explaining why in this PR
- [x] If release or installer surfaces changed, docs/install notes were updated to match
- [x] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)