### PR TITLE
feat(mcp): windows arm64 support and dual-publish to GitHub Packages

### DIFF
--- a/.github/scripts/update_scoop_manifest.py
+++ b/.github/scripts/update_scoop_manifest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 VERSION = os.environ["VERSION"]
 SHA_WINDOWS_X86 = os.environ["SHA_WINDOWS_X86"]
+SHA_WINDOWS_ARM = os.environ.get("SHA_WINDOWS_ARM")
 REPOSITORY = os.environ.get("REPOSITORY", "mulhamna/jira-commands")
 MANIFEST_PATH = Path(os.environ.get("SCOOP_MANIFEST_PATH", "bucket/jirac.json"))
 SCOOP_BINARY = os.environ.get("SCOOP_BINARY", "jirac")
@@ -15,22 +16,57 @@ SCOOP_WINDOWS_ARCHIVE = os.environ.get(
     "SCOOP_WINDOWS_ARCHIVE",
     f"{SCOOP_BINARY}-windows-x86_64.zip",
 )
+SCOOP_WINDOWS_ARCHIVE_ARM = os.environ.get(
+    "SCOOP_WINDOWS_ARCHIVE_ARM",
+    f"{SCOOP_BINARY}-windows-aarch64.zip",
+)
+
+
+def release_url(archive: str) -> str:
+    return (
+        f"https://github.com/{REPOSITORY}/releases/download/"
+        f"{SCOOP_RELEASE_TAG_PREFIX}{VERSION}/{archive}"
+    )
+
+
+def autoupdate_url(archive: str) -> str:
+    return (
+        f"https://github.com/{REPOSITORY}/releases/download/"
+        f"{SCOOP_RELEASE_TAG_PREFIX}$version/{archive}"
+    )
+
 
 manifest = json.loads(MANIFEST_PATH.read_text())
 manifest["version"] = VERSION
-manifest["url"] = (
-    f"https://github.com/{REPOSITORY}/releases/download/"
-    f"{SCOOP_RELEASE_TAG_PREFIX}{VERSION}/{SCOOP_WINDOWS_ARCHIVE}"
-)
-manifest["hash"] = SHA_WINDOWS_X86
+
+if SHA_WINDOWS_ARM:
+    # Per-arch schema: emit architecture.{64bit,arm64} and drop legacy
+    # top-level url/hash so Scoop picks the right asset per host.
+    manifest.pop("url", None)
+    manifest.pop("hash", None)
+    manifest["architecture"] = {
+        "64bit": {
+            "url": release_url(SCOOP_WINDOWS_ARCHIVE),
+            "hash": SHA_WINDOWS_X86,
+        },
+        "arm64": {
+            "url": release_url(SCOOP_WINDOWS_ARCHIVE_ARM),
+            "hash": SHA_WINDOWS_ARM,
+        },
+    }
+    autoupdate = manifest.setdefault("autoupdate", {})
+    autoupdate.pop("url", None)
+    autoupdate["architecture"] = {
+        "64bit": {"url": autoupdate_url(SCOOP_WINDOWS_ARCHIVE)},
+        "arm64": {"url": autoupdate_url(SCOOP_WINDOWS_ARCHIVE_ARM)},
+    }
+else:
+    manifest["url"] = release_url(SCOOP_WINDOWS_ARCHIVE)
+    manifest["hash"] = SHA_WINDOWS_X86
+    autoupdate = manifest.setdefault("autoupdate", {})
+    autoupdate["url"] = autoupdate_url(SCOOP_WINDOWS_ARCHIVE)
+
 manifest.setdefault("checkver", {})
-manifest.setdefault("autoupdate", {})
-manifest["autoupdate"]["url"] = (
-    "https://github.com/{repo}/releases/download/{tag}$version/{archive}".format(
-        repo=REPOSITORY,
-        tag=SCOOP_RELEASE_TAG_PREFIX,
-        archive=SCOOP_WINDOWS_ARCHIVE,
-    )
-)
+
 MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")
 print(f"updated {MANIFEST_PATH} -> v{VERSION}")

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -345,6 +345,57 @@ jobs:
             npm publish ./packaging/npm-mcp --access public
           fi
 
+  publish-github-packages:
+    name: Publish npm package to GitHub Packages (jira-mcp)
+    runs-on: ubuntu-latest
+    needs: create-release
+    timeout-minutes: 10
+    # `packages: write` is what lets the package show up under the repo's
+    # right-side "Packages" panel — GitHub Packages only surfaces entries
+    # published through `npm.pkg.github.com`, not npmjs.com.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+
+      - name: Set up Node for GitHub Packages
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@mulhamna'
+
+      - name: Rewrite package name and version for GitHub Packages
+        run: |
+          VERSION=$(cat crates/jira-mcp/VERSION | tr -d '[:space:]')
+          # GitHub Packages requires the npm scope to match the repository
+          # owner exactly, so the @mulham28 scope used on npmjs.com is
+          # replaced with @mulhamna for the GH Packages publish only.
+          VERSION="$VERSION" node - <<'EOF'
+          const fs = require('fs');
+          const path = 'packaging/npm-mcp/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.name = '@mulhamna/jirac-mcp';
+          pkg.version = process.env.VERSION;
+          if (!pkg.version) throw new Error('VERSION env missing for GH Packages publish');
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + String.fromCharCode(10));
+          console.log(`prepared ${pkg.name} -> ${pkg.version} for GH Packages`);
+          EOF
+
+      - name: Publish @mulhamna/jirac-mcp to GitHub Packages (skip if already published)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
+          if npm view @mulhamna/jirac-mcp@"$VERSION" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "✓ @mulhamna/jirac-mcp on GH Packages v$VERSION already published, skipping"
+          else
+            npm publish ./packaging/npm-mcp --access public
+          fi
+
   collect-release-metadata:
     name: Collect release metadata
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -113,6 +113,10 @@ jobs:
             os: windows-latest
             artifact: jirac-mcp-windows-x86_64.exe
             archive_artifact: jirac-mcp-windows-x86_64.zip
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            artifact: jirac-mcp-windows-aarch64.exe
+            archive_artifact: jirac-mcp-windows-aarch64.zip
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -147,18 +151,18 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} -p jira-mcp
 
       - name: Copy binary (Unix)
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         run: |
           cp target/${{ matrix.target }}/release/jirac-mcp ${{ matrix.artifact }}
 
       - name: Copy binary (Windows)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           Copy-Item target/${{ matrix.target }}/release/jirac-mcp.exe ${{ matrix.artifact }}
 
       - name: Package archive (Unix)
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist/jirac-mcp
           cp ${{ matrix.artifact }} dist/jirac-mcp/
@@ -166,7 +170,7 @@ jobs:
           tar -czf ${{ matrix.archive_artifact }} -C dist/jirac-mcp .
 
       - name: Package archive (Windows)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist/jirac-mcp | Out-Null

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -355,6 +355,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       sha_windows_x86: ${{ steps.vars.outputs.sha_windows_x86 }}
+      sha_windows_arm: ${{ steps.vars.outputs.sha_windows_arm }}
       sha_mcp_macos_arm: ${{ steps.vars.outputs.sha_mcp_macos_arm }}
       sha_mcp_macos_x86: ${{ steps.vars.outputs.sha_mcp_macos_x86 }}
       sha_mcp_linux_arm: ${{ steps.vars.outputs.sha_mcp_linux_arm }}
@@ -381,16 +382,19 @@ jobs:
           SHA_MCP_LINUX_ARM=$(grep -E '(^|/)jirac-mcp-linux-aarch64\.tar\.gz$'  checksums.txt | awk '{print $1}')
           SHA_MCP_LINUX_X86=$(grep -E '(^|/)jirac-mcp-linux-x86_64\.tar\.gz$'   checksums.txt | awk '{print $1}')
           SHA_WINDOWS_X86=$(grep -E '(^|/)jirac-mcp-windows-x86_64\.zip$' checksums.txt | awk '{print $1}')
+          SHA_WINDOWS_ARM=$(grep -E '(^|/)jirac-mcp-windows-aarch64\.zip$' checksums.txt | awk '{print $1}')
 
           test -n "$SHA_MCP_MACOS_ARM"
           test -n "$SHA_MCP_MACOS_X86"
           test -n "$SHA_MCP_LINUX_ARM"
           test -n "$SHA_MCP_LINUX_X86"
           test -n "$SHA_WINDOWS_X86"
+          test -n "$SHA_WINDOWS_ARM"
 
           {
             echo "version=$VERSION"
             echo "sha_windows_x86=$SHA_WINDOWS_X86"
+            echo "sha_windows_arm=$SHA_WINDOWS_ARM"
             echo "sha_mcp_macos_arm=$SHA_MCP_MACOS_ARM"
             echo "sha_mcp_macos_x86=$SHA_MCP_MACOS_X86"
             echo "sha_mcp_linux_arm=$SHA_MCP_LINUX_ARM"
@@ -420,24 +424,48 @@ jobs:
 
           version = os.environ['VERSION']
           release_date = os.environ['RELEASE_DATE']
-          sha_windows = os.environ['SHA_WINDOWS_X86']
+          sha_windows_x86 = os.environ['SHA_WINDOWS_X86']
+          sha_windows_arm = os.environ['SHA_WINDOWS_ARM']
 
-          files = {
+          installer_path = Path('packaging/winget-mcp/jirac-mcp.installer.yaml')
+
+          def patch_installer(content, arch, asset, sha):
+              # Within the block starting at `- Architecture: <arch>` up to the
+              # next `- Architecture:` (or EOF), rewrite InstallerUrl + Sha256.
+              block_re = re.compile(
+                  rf'(- Architecture: {arch}\b.*?)(?=^  - Architecture:|\Z)',
+                  re.MULTILINE | re.DOTALL,
+              )
+              m = block_re.search(content)
+              if not m:
+                  raise SystemExit(f'No installer block for Architecture: {arch} in {installer_path}')
+              block = m.group(0)
+              new_block, n_url = re.subn(
+                  r'(?m)^(\s+InstallerUrl: ).*$',
+                  rf'\g<1>https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v{version}/{asset}',
+                  block,
+                  count=1,
+              )
+              new_block, n_sha = re.subn(
+                  r'(?m)^(\s+InstallerSha256: ).*$',
+                  rf'\g<1>{sha}',
+                  new_block,
+                  count=1,
+              )
+              if n_url != 1 or n_sha != 1:
+                  raise SystemExit(f'Expected one Url and one Sha replacement for {arch}, got {n_url}/{n_sha}')
+              return content.replace(block, new_block, 1)
+
+          simple_files = {
               Path('packaging/winget-mcp/jirac-mcp.yaml'): [
                   (r'(?m)^PackageVersion: .*$', f'PackageVersion: {version}'),
               ],
               Path('packaging/winget-mcp/jirac-mcp.locale.en-US.yaml'): [
                   (r'(?m)^PackageVersion: .*$', f'PackageVersion: {version}'),
               ],
-              Path('packaging/winget-mcp/jirac-mcp.installer.yaml'): [
-                  (r'(?m)^PackageVersion: .*$', f'PackageVersion: {version}'),
-                  (r'(?m)^ReleaseDate: .*$', f'ReleaseDate: {release_date}'),
-                  (r'(?m)^    InstallerUrl: .*$', f'    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v{version}/jirac-mcp-windows-x86_64.zip'),
-                  (r'(?m)^    InstallerSha256: .*$', f'    InstallerSha256: {sha_windows}'),
-              ],
           }
 
-          for path, replacements in files.items():
+          for path, replacements in simple_files.items():
               content = path.read_text()
               for pattern, repl in replacements:
                   content, count = re.subn(pattern, repl, content, count=1)
@@ -445,11 +473,24 @@ jobs:
                       raise SystemExit(f'Expected exactly one match for {pattern!r} in {path}')
               path.write_text(content)
               print(f'updated {path}')
+
+          content = installer_path.read_text()
+          content, count = re.subn(r'(?m)^PackageVersion: .*$', f'PackageVersion: {version}', content, count=1)
+          if count != 1:
+              raise SystemExit(f'Expected PackageVersion replacement in {installer_path}')
+          content, count = re.subn(r'(?m)^ReleaseDate: .*$', f'ReleaseDate: {release_date}', content, count=1)
+          if count != 1:
+              raise SystemExit(f'Expected ReleaseDate replacement in {installer_path}')
+          content = patch_installer(content, 'x64', f'jirac-mcp-windows-x86_64.zip', sha_windows_x86)
+          content = patch_installer(content, 'arm64', f'jirac-mcp-windows-aarch64.zip', sha_windows_arm)
+          installer_path.write_text(content)
+          print(f'updated {installer_path}')
           EOF
         env:
           VERSION: ${{ needs.collect-release-metadata.outputs.version }}
           RELEASE_DATE: ${{ needs.collect-release-metadata.outputs.release_date }}
           SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
+          SHA_WINDOWS_ARM: ${{ needs.collect-release-metadata.outputs.sha_windows_arm }}
 
       - name: Create manifest refresh pull request (jira-mcp)
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -590,10 +590,12 @@ jobs:
     env:
       VERSION: ${{ needs.collect-release-metadata.outputs.version }}
       SHA_WINDOWS_X86: ${{ needs.collect-release-metadata.outputs.sha_windows_x86 }}
+      SHA_WINDOWS_ARM: ${{ needs.collect-release-metadata.outputs.sha_windows_arm }}
       REPOSITORY: ${{ github.repository }}
       SCOOP_BINARY: jirac-mcp
       SCOOP_RELEASE_TAG_PREFIX: jira-mcp-v
       SCOOP_WINDOWS_ARCHIVE: jirac-mcp-windows-x86_64.zip
+      SCOOP_WINDOWS_ARCHIVE_ARM: jirac-mcp-windows-aarch64.zip
     steps:
       - name: Checkout source repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -618,15 +620,30 @@ jobs:
             "description": "Typed Jira MCP server built in Rust.",
             "homepage": "https://github.com/mulhamna/jira-commands",
             "license": ["MIT", "Apache-2.0"],
-            "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
-            "hash": "",
             "bin": "jirac-mcp.exe",
+            "architecture": {
+              "64bit": {
+                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-x86_64.zip",
+                "hash": ""
+              },
+              "arm64": {
+                "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v0.0.0/jirac-mcp-windows-aarch64.zip",
+                "hash": ""
+              }
+            },
             "checkver": {
               "url": "https://api.github.com/repos/mulhamna/jira-commands/releases?per_page=20",
               "regex": "\"tag_name\":\\s*\"jira-mcp-v([^\"]+)\""
             },
             "autoupdate": {
-              "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
+              "architecture": {
+                "64bit": {
+                  "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-x86_64.zip"
+                },
+                "arm64": {
+                  "url": "https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v$version/jirac-mcp-windows-aarch64.zip"
+                }
+              }
             }
           }
           JSON

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,7 @@ Preferred MCP (`jira-mcp-vX.Y.Z`) archives:
 | Linux x86_64        | `jirac-mcp-linux-x86_64.tar.gz`  |
 | Linux ARM64         | `jirac-mcp-linux-aarch64.tar.gz` |
 | Windows x86_64      | `jirac-mcp-windows-x86_64.zip`   |
+| Windows ARM64       | `jirac-mcp-windows-aarch64.zip`  |
 
 ## Winget (Windows)
 

--- a/packaging/npm-mcp/lib/install.js
+++ b/packaging/npm-mcp/lib/install.js
@@ -18,11 +18,12 @@ function getPlatformAsset() {
   const platform = process.platform;
   const arch = process.arch;
 
-  if (platform === 'darwin' && arch === 'arm64') return { archive: 'jirac-mcp-macos-aarch64.tar.gz', binary: 'jirac-mcp' };
-  if (platform === 'darwin' && arch === 'x64') return { archive: 'jirac-mcp-macos-x86_64.tar.gz', binary: 'jirac-mcp' };
-  if (platform === 'linux' && arch === 'x64') return { archive: 'jirac-mcp-linux-x86_64.tar.gz', binary: 'jirac-mcp' };
-  if (platform === 'linux' && arch === 'arm64') return { archive: 'jirac-mcp-linux-aarch64.tar.gz', binary: 'jirac-mcp' };
-  if (platform === 'win32' && arch === 'x64') return { archive: 'jirac-mcp-windows-x86_64.zip', binary: 'jirac-mcp.exe' };
+  if (platform === 'darwin' && arch === 'arm64') return { archive: 'jirac-mcp-macos-aarch64.tar.gz', binary: 'jirac-mcp', archivedBinary: 'jirac-mcp' };
+  if (platform === 'darwin' && arch === 'x64') return { archive: 'jirac-mcp-macos-x86_64.tar.gz', binary: 'jirac-mcp', archivedBinary: 'jirac-mcp' };
+  if (platform === 'linux' && arch === 'x64') return { archive: 'jirac-mcp-linux-x86_64.tar.gz', binary: 'jirac-mcp', archivedBinary: 'jirac-mcp' };
+  if (platform === 'linux' && arch === 'arm64') return { archive: 'jirac-mcp-linux-aarch64.tar.gz', binary: 'jirac-mcp', archivedBinary: 'jirac-mcp' };
+  if (platform === 'win32' && arch === 'x64') return { archive: 'jirac-mcp-windows-x86_64.zip', binary: 'jirac-mcp.exe', archivedBinary: 'jirac-mcp-windows-x86_64.exe' };
+  if (platform === 'win32' && arch === 'arm64') return { archive: 'jirac-mcp-windows-aarch64.zip', binary: 'jirac-mcp.exe', archivedBinary: 'jirac-mcp-windows-aarch64.exe' };
 
   throw new Error(`Unsupported platform for jirac-mcp npm install: ${platform}/${arch}`);
 }
@@ -75,7 +76,7 @@ async function extractArchive(archivePath, destDir) {
 }
 
 async function main() {
-  const { archive, binary } = getPlatformAsset();
+  const { archive, binary, archivedBinary } = getPlatformAsset();
   const archiveUrl = `${BASE_URL}/${archive}`;
   const checksumsUrl = `${BASE_URL}/checksums.txt`;
   const archivePath = path.join(TMP_DIR, archive);
@@ -100,12 +101,13 @@ async function main() {
   await extractArchive(archivePath, extractDir);
 
   const candidates = [
+    path.join(extractDir, archivedBinary),
     path.join(extractDir, binary),
     path.join(extractDir, archive.replace(/\.tar\.gz$/, '').replace(/\.zip$/, ''))
   ];
   const extractedBinary = candidates.find((candidate) => fs.existsSync(candidate));
   if (!extractedBinary) {
-    throw new Error(`Extracted binary not found in archive: ${binary}`);
+    throw new Error(`Extracted binary not found in archive: ${archivedBinary}`);
   }
 
   await fs.promises.mkdir(BIN_DIR, { recursive: true });

--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -3,13 +3,19 @@ PackageIdentifier: mulhamna.jirac-mcp
 PackageVersion: 2.1.0
 InstallerType: zip
 NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: jirac-mcp-windows-x86_64.exe
-    PortableCommandAlias: jirac-mcp
 ReleaseDate: 2026-06-02
 Installers:
   - Architecture: x64
+    NestedInstallerFiles:
+      - RelativeFilePath: jirac-mcp-windows-x86_64.exe
+        PortableCommandAlias: jirac-mcp
     InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.1.0/jirac-mcp-windows-x86_64.zip
     InstallerSha256: d85d7e58b8a42ad078f65e055dd5ec58cda626f056f3e61d007a559bcd2ad9e4
+  - Architecture: arm64
+    NestedInstallerFiles:
+      - RelativeFilePath: jirac-mcp-windows-aarch64.exe
+        PortableCommandAlias: jirac-mcp
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.1.0/jirac-mcp-windows-aarch64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/release-please-config-mcp.json
+++ b/release-please-config-mcp.json
@@ -8,6 +8,12 @@
       "package-name": "jira-mcp",
       "version-file": "VERSION",
       "changelog-path": "CHANGELOG.md",
+      "include-paths": [
+        "crates/jira-mcp",
+        "packaging/npm-mcp",
+        "packaging/winget-mcp",
+        ".github/workflows/release-tag-mcp.yml"
+      ],
       "extra-files": [
         { "type": "generic", "path": "Cargo.toml" },
         { "type": "generic", "path": "/packaging/npm-mcp/package.json" }


### PR DESCRIPTION
## Summary

- Mirror the jirac-lane v2.0.0 work onto the jirac-mcp lane: native Windows ARM64 build, archive-lookup fix for the npm installer, per-arch Winget + Scoop manifests, and a GitHub Packages dual-publish so `@mulhamna/jirac-mcp` surfaces in the repo's Packages sidebar.
- Bump target is MINOR (`feat(mcp):`). No `!` / `BREAKING CHANGE` — release-please should land `jira-mcp v2.1.0 → v2.2.0`.
- Make `release-please-config-mcp.json` `include-paths` explicit so commits touching `packaging/npm-mcp/`, `packaging/winget-mcp/`, and `.github/workflows/release-tag-mcp.yml` actually participate in the MCP release lane (previously only `crates/jira-mcp/**` did).

## Changes

- **release-please** — add `include-paths` to `release-please-config-mcp.json` covering MCP crate + packaging surfaces + workflow.
- **npm-mcp installer** — `packaging/npm-mcp/lib/install.js` now carries `archivedBinary` per platform; fixes the long-standing Windows lookup bug (was probing for `jirac-mcp.exe`, archive ships `jirac-mcp-windows-x86_64.exe`). Adds the `win32/arm64 → jirac-mcp-windows-aarch64.zip` mapping.
- **release workflow** — `.github/workflows/release-tag-mcp.yml`
  - matrix: add `aarch64-pc-windows-msvc` on the `windows-11-arm` runner.
  - swap `matrix.os == 'windows-latest'` → `runner.os == 'Windows'` on Copy/Package steps.
  - `collect-release-metadata`: surface `sha_windows_arm` from `checksums.txt`.
  - `refresh-package-manifests`: per-arch `patch_installer` over the Winget installer YAML (mirrors jirac lane).
  - `update-scoop-bucket`: switch to architecture-block schema; seed skeleton + env vars carry both archs.
  - new `publish-github-packages` job: re-publishes the npm package as `@mulhamna/jirac-mcp` on `npm.pkg.github.com` using `GITHUB_TOKEN` + `packages: write`.
- **Scoop script** — `.github/scripts/update_scoop_manifest.py` now emits `architecture.{64bit,arm64}` when `SHA_WINDOWS_ARM` is set, with backwards-compatible top-level url/hash when it is not.
- **Winget manifest** — `packaging/winget-mcp/jirac-mcp.installer.yaml` moves `NestedInstallerFiles` to per-installer scope and adds the arm64 entry (sha placeholder, overwritten by the refresh job at release time).
- **docs** — `INSTALL.md` lists the new `jirac-mcp-windows-aarch64.zip` row.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p jira-mcp -p jira-core --all-targets --all-features -- -D warnings`
- [x] `cargo test -p jira-mcp -p jira-core` (71 passed)
- [x] Local dry-run of the Scoop manifest update script against a seeded skeleton — emits architecture block as expected
- [x] Local dry-run of the Winget `patch_installer` against the modified installer YAML — x64 + arm64 blocks rewritten independently, version + release date refreshed
- [ ] Post-merge: `release-please` opens a `jira-mcp` release PR bumping `2.1.0 → 2.2.0`; jirac lane stays untouched
- [ ] Post-tag: `release-tag-mcp.yml` spawns `windows-11-arm` runner, ships `jirac-mcp-windows-aarch64.zip`, `collect-release-metadata` passes `test -n "$SHA_WINDOWS_ARM"`, refresh-package-manifests PR rewrites both arch entries, `publish-github-packages` lands `@mulhamna/jirac-mcp` in the repo sidebar
- [x] `npm i -g @mulham28/jirac-mcp` on a Windows x64 + Windows ARM64 host → `jirac-mcp --version`
- [ ] `winget install mulhamna.jirac-mcp` + `scoop install mulhamna/jirac-mcp` on an ARM64 host