### PR TITLE
fix(release): route mcp work to the mcp lane and stop jirac leakage

### DIFF
--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -30,7 +30,7 @@ scoop install mulhamna/jirac-mcp
 cargo install --path crates/jira-mcp --locked
 ```
 
-You can also use the workspace shell installer on macOS/Linux, the PowerShell installer flow on Windows, or download packaged release archives from GitHub Releases.
+You can also use the workspace shell installer on macOS/Linux, the PowerShell installer flow on Windows (x64 + ARM64), or download packaged release archives from GitHub Releases. Native Windows ARM64 binaries ship as `jirac-mcp-windows-aarch64.zip`.
 
 ## Run
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,14 @@
         "crates/jira-core",
         "packaging/npm"
       ],
+      "exclude-paths": [
+        "crates/jira-mcp",
+        "packaging/npm-mcp",
+        "packaging/winget-mcp",
+        ".github/workflows/release-tag-mcp.yml",
+        "release-please-config-mcp.json",
+        ".release-please-manifest-mcp.json"
+      ],
       "extra-files": [
         { "type": "generic", "path": "/Cargo.toml" },
         { "type": "generic", "path": "/crates/jira/Cargo.toml" },


### PR DESCRIPTION
## Summary

- The jirac-mcp Windows ARM64 + GitHub Packages work in #359 was correctly authored but landed in the wrong release lane: release-please opened #360 against the jirac lane (2.0.0 → 2.1.0) even though the squash diff contained zero jirac changes. I closed #360.
- Root cause is two-fold:
  1. `release-please-config.json` uses literal prefix matching on `include-paths`. The `packaging/npm` entry transparently swallowed `packaging/npm-mcp/*`, pulling MCP-only commits into the jirac lane.
  2. `release-please-config-mcp.json` scopes a package at `crates/jira-mcp` and adding `include-paths` outside that dir does **not** extend the scan to those paths — the workflow log for the previous run shows `commits: 0` for `crates/jira-mcp` and `No commits for path: crates/jira-mcp, skipping`.

## Changes

- `release-please-config.json` — add an `exclude-paths` block listing every MCP/wrapper surface (`crates/jira-mcp`, `packaging/npm-mcp`, `packaging/winget-mcp`, `.github/workflows/release-tag-mcp.yml`, `release-please-config-mcp.json`, `.release-please-manifest-mcp.json`) so MCP work cannot leak in via prefix overlap again.
- `crates/jira-mcp/README.md` — note Windows ARM64 + dual-publish in the install matrix. This commit is intentionally placed under `crates/jira-mcp/` so release-please routes the bump to the MCP lane.

## Why both commits

- The `chore` commit fixes the future. The `feat(mcp)` commit triggers the present: it brings the previously-merged release-pipeline changes into a release the MCP lane can actually own (jira-mcp 2.1.0 → 2.2.0).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p jira-mcp --all-targets -- -D warnings`
- [ ] After merge, confirm release-please opens **only** the `jira-mcp` Release PR bumping `2.1.0 → 2.2.0`, and **not** a `jira-commands` Release PR
- [ ] After the jira-mcp tag lands, confirm `release-tag-mcp.yml` produces `jirac-mcp-windows-aarch64.zip`, the refresh-package-manifests PR rewrites both arch entries in the winget installer YAML, and `publish-github-packages` lands `@mulhamna/jirac-mcp` in the repo Packages sidebar