### PR TITLE
feat(jira-core,cli,tui): JQL builder, attachment download, Agile board ops

### DIFF
--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -1005,6 +1005,116 @@ impl JiraClient {
             .await
     }
 
+    /// List Agile boards, optionally filtered by project key and board type.
+    pub async fn list_boards(
+        &self,
+        project_key: Option<&str>,
+        board_type: Option<&str>,
+    ) -> Result<Vec<crate::model::Board>> {
+        const MAX_PAGES: u32 = 500;
+        let mut boards: Vec<crate::model::Board> = Vec::new();
+        let mut start_at = 0u64;
+        let mut iterations = 0u32;
+
+        loop {
+            iterations += 1;
+            if iterations > MAX_PAGES {
+                return Err(JiraError::Api {
+                    status: 500,
+                    message: "board pagination exceeded MAX_PAGES safeguard".into(),
+                });
+            }
+            let mut query = format!("maxResults=50&startAt={start_at}");
+            if let Some(p) = project_key {
+                query.push_str(&format!("&projectKeyOrId={p}"));
+            }
+            if let Some(t) = board_type {
+                query.push_str(&format!("&type={t}"));
+            }
+            let path = format!("/rest/agile/1.0/board?{query}");
+            let resp = self
+                .raw_request("GET", &path, None)
+                .await?
+                .unwrap_or_default();
+            let values = Self::paged_values(&resp);
+            for v in values {
+                if let Some(b) = crate::model::Board::from_value(v) {
+                    boards.push(b);
+                }
+            }
+            if Self::page_is_last(&resp, values.len()) {
+                break;
+            }
+            start_at += values.len() as u64;
+        }
+
+        Ok(boards)
+    }
+
+    /// Fetch a single Agile board by ID.
+    pub async fn get_board(&self, board_id: u64) -> Result<crate::model::Board> {
+        let path = format!("/rest/agile/1.0/board/{board_id}");
+        let resp = self
+            .raw_request("GET", &path, None)
+            .await?
+            .ok_or_else(|| JiraError::NotFound(format!("board {board_id}")))?;
+        crate::model::Board::from_value(&resp).ok_or_else(|| JiraError::Api {
+            status: 500,
+            message: "could not parse board response".into(),
+        })
+    }
+
+    async fn board_issue_list(
+        &self,
+        board_id: u64,
+        endpoint: &str,
+        jql: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<Vec<Issue>> {
+        let max = max_results.unwrap_or(50).min(1000);
+        let mut path =
+            format!("/rest/agile/1.0/board/{board_id}/{endpoint}?maxResults={max}&startAt=0");
+        if let Some(j) = jql {
+            path.push_str(&format!("&jql={}", url_encode_component(j)));
+        }
+        let resp = self
+            .raw_request("GET", &path, None)
+            .await?
+            .unwrap_or_default();
+        let issues = resp
+            .get("issues")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        Ok(issues
+            .into_iter()
+            .filter_map(|v| serde_json::from_value::<RawIssue>(v).ok())
+            .map(|r| r.into_issue())
+            .collect())
+    }
+
+    /// List issues on a board (optionally filtered by JQL).
+    pub async fn board_issues(
+        &self,
+        board_id: u64,
+        jql: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<Vec<Issue>> {
+        self.board_issue_list(board_id, "issue", jql, max_results)
+            .await
+    }
+
+    /// List backlog issues on a board (issues not in an active or future sprint).
+    pub async fn board_backlog(
+        &self,
+        board_id: u64,
+        jql: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<Vec<Issue>> {
+        self.board_issue_list(board_id, "backlog", jql, max_results)
+            .await
+    }
+
     /// Create a sprint on a Jira board.
     pub async fn create_sprint(
         &self,
@@ -1853,6 +1963,20 @@ fn percent_decode(s: &str) -> String {
         i += 1;
     }
     String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+/// Percent-encode a query-string component (unreserved chars per RFC 3986 are left as-is).
+fn url_encode_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        match *b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*b as char);
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
 }
 
 /// Returns current UTC time in Jira worklog format: "2006-01-02T15:04:05.000+0000"
@@ -3440,6 +3564,92 @@ mod tests {
         let client = cloud_client(&server);
         let err = client.download_attachment("99").await.expect_err("err");
         assert!(matches!(err, JiraError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn list_boards_paginates() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/agile/1.0/board"))
+            .and(query_param("startAt", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "maxResults": 50, "startAt": 0, "isLast": false,
+                "values": [
+                    { "id": 1, "name": "B1", "type": "scrum" },
+                    { "id": 2, "name": "B2", "type": "kanban",
+                      "location": { "projectKey": "ABC", "projectId": 10 } }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/agile/1.0/board"))
+            .and(query_param("startAt", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "maxResults": 50, "startAt": 2, "isLast": true,
+                "values": []
+            })))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let boards = client.list_boards(None, None).await.expect("ok");
+        assert_eq!(boards.len(), 2);
+        assert_eq!(boards[1].project_key.as_deref(), Some("ABC"));
+    }
+
+    #[tokio::test]
+    async fn get_board_parses_single() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/agile/1.0/board/9"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": 9, "name": "X", "type": "scrum"
+            })))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let b = client.get_board(9).await.expect("ok");
+        assert_eq!(b.id, 9);
+        assert_eq!(b.name, "X");
+    }
+
+    #[tokio::test]
+    async fn board_issues_returns_issues() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/agile/1.0/board/5/issue"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "issues": [
+                    { "id": "1", "key": "ABC-1", "fields": { "summary": "s",
+                      "status": { "name": "To Do" }, "issuetype": { "name": "Task" },
+                      "project": { "key": "ABC" }, "created": "", "updated": "" } }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let issues = client.board_issues(5, None, Some(50)).await.expect("ok");
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].key, "ABC-1");
+    }
+
+    #[tokio::test]
+    async fn board_backlog_passes_jql() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/agile/1.0/board/5/backlog"))
+            .and(query_param("jql", "labels = \"x\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "issues": []
+            })))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let issues = client
+            .board_backlog(5, Some("labels = \"x\""), None)
+            .await
+            .expect("ok");
+        assert!(issues.is_empty());
     }
 
     #[tokio::test]

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -1342,6 +1342,86 @@ impl JiraClient {
             .await
     }
 
+    /// List attachments on an issue.
+    pub async fn list_attachments(&self, issue_key: &str) -> Result<Vec<Attachment>> {
+        let headers = self.auth_headers()?;
+        let url = self.platform_url(&format!("/issue/{issue_key}?fields=attachment"));
+
+        let http = &self.http;
+        let raw: Value = self
+            .request(|| http.get(&url).headers(headers.clone()))
+            .await?;
+
+        let arr = raw
+            .get("fields")
+            .and_then(|f| f.get("attachment"))
+            .and_then(|a| a.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        Ok(arr
+            .iter()
+            .filter_map(crate::model::attachment::Attachment::from_value)
+            .collect())
+    }
+
+    /// Download an attachment by ID.
+    ///
+    /// Returns `(filename, bytes, mime_type)`. The filename comes from the
+    /// `Content-Disposition` header when present, otherwise the trailing
+    /// path segment of the redirect URL, otherwise `"attachment-<id>"`.
+    pub async fn download_attachment(
+        &self,
+        attachment_id: &str,
+    ) -> Result<(String, Vec<u8>, String)> {
+        let headers = self.auth_headers_no_content_type()?;
+        let url = self.platform_url(&format!("/attachment/content/{attachment_id}"));
+
+        let http = &self.http;
+        let response = self
+            .execute_with_retry(|| http.get(&url).headers(headers.clone()))
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
+            if status == StatusCode::NOT_FOUND {
+                return Err(JiraError::NotFound(body));
+            }
+            return Err(JiraError::Api {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+
+        let mime_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream")
+            .to_string();
+
+        let filename = response
+            .headers()
+            .get(reqwest::header::CONTENT_DISPOSITION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_content_disposition_filename)
+            .or_else(|| {
+                response
+                    .url()
+                    .path_segments()
+                    .and_then(|mut s| s.next_back().map(|s| s.to_string()))
+                    .filter(|s| !s.is_empty())
+            })
+            .unwrap_or_else(|| format!("attachment-{attachment_id}"));
+
+        let bytes = response.bytes().await?.to_vec();
+        Ok((filename, bytes, mime_type))
+    }
+
     /// Delete an attachment by ID.
     pub async fn delete_attachment(&self, attachment_id: &str) -> Result<()> {
         let headers = self.auth_headers()?;
@@ -1733,6 +1813,46 @@ where
             message: body,
         }),
     }
+}
+
+/// Parse `filename` (or RFC 5987 `filename*`) from a Content-Disposition header.
+fn parse_content_disposition_filename(value: &str) -> Option<String> {
+    for part in value.split(';') {
+        let part = part.trim();
+        if let Some(rest) = part.strip_prefix("filename*=") {
+            // RFC 5987: charset'lang'percent-encoded-value
+            let payload = rest.splitn(3, '\'').nth(2)?;
+            return Some(percent_decode(payload));
+        }
+        if let Some(rest) = part.strip_prefix("filename=") {
+            let trimmed = rest.trim_matches('"').to_string();
+            if !trimmed.is_empty() {
+                return Some(trimmed);
+            }
+        }
+    }
+    None
+}
+
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (
+                (bytes[i + 1] as char).to_digit(16),
+                (bytes[i + 2] as char).to_digit(16),
+            ) {
+                out.push(((h << 4) | l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// Returns current UTC time in Jira worklog format: "2006-01-02T15:04:05.000+0000"
@@ -3236,6 +3356,90 @@ mod tests {
 
         assert_eq!(transitions[1].id, "31");
         assert!(transitions[1].to.is_some());
+    }
+
+    #[test]
+    fn parses_content_disposition_plain() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"report.pdf\""),
+            Some("report.pdf".to_string())
+        );
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=plain.txt"),
+            Some("plain.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_content_disposition_rfc5987() {
+        assert_eq!(
+            parse_content_disposition_filename(
+                "attachment; filename*=UTF-8''na%C3%AFve%20file.txt"
+            ),
+            Some("naïve file.txt".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_attachments_extracts_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/TEST-1"))
+            .and(query_param("fields", "attachment"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "fields": {
+                    "attachment": [
+                        {
+                            "id": "10001",
+                            "filename": "a.txt",
+                            "size": 12,
+                            "mimeType": "text/plain",
+                            "content": "https://example/c/10001",
+                            "created": "2026-06-14T00:00:00.000+0000"
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let items = client.list_attachments("TEST-1").await.expect("ok");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "10001");
+        assert_eq!(items[0].filename, "a.txt");
+    }
+
+    #[tokio::test]
+    async fn download_attachment_returns_bytes_and_filename() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/attachment/content/42"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Type", "application/pdf")
+                    .insert_header("Content-Disposition", "attachment; filename=\"file.pdf\"")
+                    .set_body_bytes(vec![0x25u8, 0x50, 0x44, 0x46]),
+            )
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let (name, bytes, mime) = client.download_attachment("42").await.expect("ok");
+        assert_eq!(name, "file.pdf");
+        assert_eq!(mime, "application/pdf");
+        assert_eq!(bytes, vec![0x25, 0x50, 0x44, 0x46]);
+    }
+
+    #[tokio::test]
+    async fn download_attachment_404_returns_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/attachment/content/99"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+            .mount(&server)
+            .await;
+        let client = cloud_client(&server);
+        let err = client.download_attachment("99").await.expect_err("err");
+        assert!(matches!(err, JiraError::NotFound(_)));
     }
 
     #[tokio::test]

--- a/crates/jira-core/src/jql.rs
+++ b/crates/jira-core/src/jql.rs
@@ -1,0 +1,421 @@
+//! Structured JQL builder.
+//!
+//! Compose safe JQL queries from typed parameters. Values are escaped
+//! to avoid injection through user-supplied identifiers, labels, or text.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderDir {
+    Asc,
+    Desc,
+}
+
+impl OrderDir {
+    fn as_str(self) -> &'static str {
+        match self {
+            OrderDir::Asc => "ASC",
+            OrderDir::Desc => "DESC",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AssigneeFilter {
+    CurrentUser,
+    Empty,
+    AccountId { account_id: String },
+    Email { email: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DateExpr {
+    /// Absolute date `YYYY-MM-DD`.
+    Date { date: String },
+    /// Relative window like `-7d`, `-2w`, `-1M`.
+    Relative { window: String },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct JqlParams {
+    pub project: Option<String>,
+    pub status: Vec<String>,
+    pub assignee: Vec<AssigneeFilter>,
+    pub priority: Vec<String>,
+    pub labels: Vec<String>,
+    pub components: Vec<String>,
+    pub fix_versions: Vec<String>,
+    pub text: Option<String>,
+    pub created_after: Option<DateExpr>,
+    pub updated_after: Option<DateExpr>,
+    pub extra_clauses: Vec<String>,
+    pub order_by: Vec<(String, OrderDir)>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JqlBuildError {
+    #[error("value contains control characters: {0:?}")]
+    ControlChar(String),
+    #[error("relative window must match `-?[0-9]+[dwmy]`, got {0:?}")]
+    BadRelativeWindow(String),
+    #[error("date must be YYYY-MM-DD, got {0:?}")]
+    BadDate(String),
+    #[error("field name must match `[A-Za-z0-9_.]+`, got {0:?}")]
+    BadFieldName(String),
+}
+
+/// Escape a value for use inside a double-quoted JQL literal.
+///
+/// Replaces `\` → `\\` and `"` → `\"`. Rejects control characters
+/// (any char with `is_control()` other than tab) to avoid breaking
+/// downstream parsers or smuggling newlines.
+pub fn escape_jql_literal(value: &str) -> Result<String, JqlBuildError> {
+    if value.chars().any(|c| c.is_control() && c != '\t') {
+        return Err(JqlBuildError::ControlChar(value.to_string()));
+    }
+    Ok(value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// Validate a JQL field name (used for ORDER BY and custom fields).
+fn validate_field_name(name: &str) -> Result<&str, JqlBuildError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty()
+        || !trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+    {
+        return Err(JqlBuildError::BadFieldName(name.to_string()));
+    }
+    Ok(trimmed)
+}
+
+fn validate_relative_window(s: &str) -> Result<&str, JqlBuildError> {
+    let trimmed = s.trim();
+    let mut chars = trimmed.chars().peekable();
+    if let Some('-') = chars.peek() {
+        chars.next();
+    }
+    let mut digits = String::new();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let unit: String = chars.collect();
+    if digits.is_empty() || !matches!(unit.as_str(), "d" | "w" | "m" | "M" | "y") {
+        return Err(JqlBuildError::BadRelativeWindow(s.to_string()));
+    }
+    Ok(trimmed)
+}
+
+fn validate_date(s: &str) -> Result<&str, JqlBuildError> {
+    let trimmed = s.trim();
+    let parts: Vec<&str> = trimmed.split('-').collect();
+    let lens_ok =
+        parts.len() == 3 && parts[0].len() == 4 && parts[1].len() == 2 && parts[2].len() == 2;
+    let digits_ok = parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    if !lens_ok || !digits_ok {
+        return Err(JqlBuildError::BadDate(s.to_string()));
+    }
+    Ok(trimmed)
+}
+
+fn or_clause(field: &str, values: &[String]) -> Result<Option<String>, JqlBuildError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    let mut quoted = Vec::with_capacity(values.len());
+    for v in values {
+        quoted.push(format!("\"{}\"", escape_jql_literal(v)?));
+    }
+    Ok(Some(format!("{} in ({})", field, quoted.join(", "))))
+}
+
+fn assignee_clause(filters: &[AssigneeFilter]) -> Result<Option<String>, JqlBuildError> {
+    if filters.is_empty() {
+        return Ok(None);
+    }
+    let mut parts = Vec::with_capacity(filters.len());
+    for f in filters {
+        match f {
+            AssigneeFilter::CurrentUser => parts.push("assignee = currentUser()".to_string()),
+            AssigneeFilter::Empty => parts.push("assignee is EMPTY".to_string()),
+            AssigneeFilter::AccountId { account_id } => parts.push(format!(
+                "assignee = \"{}\"",
+                escape_jql_literal(account_id)?
+            )),
+            AssigneeFilter::Email { email } => {
+                parts.push(format!("assignee = \"{}\"", escape_jql_literal(email)?))
+            }
+        }
+    }
+    Ok(Some(if parts.len() == 1 {
+        parts.remove(0)
+    } else {
+        format!("({})", parts.join(" OR "))
+    }))
+}
+
+fn date_clause(field: &str, expr: &DateExpr) -> Result<String, JqlBuildError> {
+    let rhs = match expr {
+        DateExpr::Date { date } => format!("\"{}\"", validate_date(date)?),
+        DateExpr::Relative { window } => format!("\"{}\"", validate_relative_window(window)?),
+    };
+    Ok(format!("{} >= {}", field, rhs))
+}
+
+/// Compose a JQL query from structured parameters.
+///
+/// Returns `Ok("")` if every input is empty (caller may treat as "no filter").
+pub fn compose_jql(params: &JqlParams) -> Result<String, JqlBuildError> {
+    let mut clauses: Vec<String> = Vec::new();
+
+    if let Some(project) = &params.project {
+        clauses.push(format!(
+            "project = \"{}\"",
+            escape_jql_literal(project.trim())?
+        ));
+    }
+    if let Some(c) = or_clause("status", &params.status)? {
+        clauses.push(c);
+    }
+    if let Some(c) = assignee_clause(&params.assignee)? {
+        clauses.push(c);
+    }
+    if let Some(c) = or_clause("priority", &params.priority)? {
+        clauses.push(c);
+    }
+    if let Some(c) = or_clause("labels", &params.labels)? {
+        clauses.push(c);
+    }
+    if let Some(c) = or_clause("component", &params.components)? {
+        clauses.push(c);
+    }
+    if let Some(c) = or_clause("fixVersion", &params.fix_versions)? {
+        clauses.push(c);
+    }
+    if let Some(text) = &params.text {
+        clauses.push(format!("text ~ \"{}\"", escape_jql_literal(text)?));
+    }
+    if let Some(expr) = &params.created_after {
+        clauses.push(date_clause("created", expr)?);
+    }
+    if let Some(expr) = &params.updated_after {
+        clauses.push(date_clause("updated", expr)?);
+    }
+    for extra in &params.extra_clauses {
+        let trimmed = extra.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.chars().any(|c| c.is_control() && c != '\t') {
+            return Err(JqlBuildError::ControlChar(extra.clone()));
+        }
+        clauses.push(format!("({})", trimmed));
+    }
+
+    let mut jql = clauses.join(" AND ");
+
+    if !params.order_by.is_empty() {
+        let mut order_parts = Vec::with_capacity(params.order_by.len());
+        for (field, dir) in &params.order_by {
+            let name = validate_field_name(field)?;
+            order_parts.push(format!("{} {}", name, dir.as_str()));
+        }
+        if !jql.is_empty() {
+            jql.push(' ');
+        }
+        jql.push_str("ORDER BY ");
+        jql.push_str(&order_parts.join(", "));
+    }
+
+    Ok(jql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_basic() {
+        assert_eq!(escape_jql_literal("plain").unwrap(), "plain");
+        assert_eq!(escape_jql_literal("a\"b").unwrap(), "a\\\"b");
+        assert_eq!(escape_jql_literal("a\\b").unwrap(), "a\\\\b");
+        assert_eq!(escape_jql_literal("O'Reilly").unwrap(), "O'Reilly");
+    }
+
+    #[test]
+    fn escape_rejects_control_chars() {
+        assert!(escape_jql_literal("line1\nline2").is_err());
+        assert!(escape_jql_literal("bell\x07").is_err());
+        assert!(escape_jql_literal("tab\there").is_ok());
+    }
+
+    #[test]
+    fn empty_params_returns_empty() {
+        let jql = compose_jql(&JqlParams::default()).unwrap();
+        assert_eq!(jql, "");
+    }
+
+    #[test]
+    fn project_and_status() {
+        let p = JqlParams {
+            project: Some("ABC".into()),
+            status: vec!["In Progress".into(), "Done".into()],
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(
+            jql,
+            r#"project = "ABC" AND status in ("In Progress", "Done")"#
+        );
+    }
+
+    #[test]
+    fn assignee_mixed() {
+        let p = JqlParams {
+            assignee: vec![
+                AssigneeFilter::CurrentUser,
+                AssigneeFilter::Email {
+                    email: "u@x.com".into(),
+                },
+            ],
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(jql, r#"(assignee = currentUser() OR assignee = "u@x.com")"#);
+    }
+
+    #[test]
+    fn assignee_empty_clause() {
+        let p = JqlParams {
+            assignee: vec![AssigneeFilter::Empty],
+            ..Default::default()
+        };
+        assert_eq!(compose_jql(&p).unwrap(), "assignee is EMPTY");
+    }
+
+    #[test]
+    fn text_search_escapes_quotes() {
+        let p = JqlParams {
+            text: Some(r#"He said "hi""#.into()),
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(jql, r#"text ~ "He said \"hi\"""#);
+    }
+
+    #[test]
+    fn dates_absolute_and_relative() {
+        let p = JqlParams {
+            created_after: Some(DateExpr::Date {
+                date: "2026-01-01".into(),
+            }),
+            updated_after: Some(DateExpr::Relative {
+                window: "-7d".into(),
+            }),
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(jql, r#"created >= "2026-01-01" AND updated >= "-7d""#);
+    }
+
+    #[test]
+    fn bad_date_rejected() {
+        let p = JqlParams {
+            created_after: Some(DateExpr::Date {
+                date: "2026/01/01".into(),
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(compose_jql(&p), Err(JqlBuildError::BadDate(_))));
+    }
+
+    #[test]
+    fn bad_relative_window_rejected() {
+        for bad in ["7", "-7x", "abc", ""] {
+            let p = JqlParams {
+                updated_after: Some(DateExpr::Relative { window: bad.into() }),
+                ..Default::default()
+            };
+            assert!(
+                matches!(compose_jql(&p), Err(JqlBuildError::BadRelativeWindow(_))),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn order_by_validated() {
+        let p = JqlParams {
+            project: Some("ABC".into()),
+            order_by: vec![
+                ("priority".into(), OrderDir::Desc),
+                ("created".into(), OrderDir::Asc),
+            ],
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(
+            jql,
+            r#"project = "ABC" ORDER BY priority DESC, created ASC"#
+        );
+    }
+
+    #[test]
+    fn order_by_rejects_bad_field() {
+        let p = JqlParams {
+            order_by: vec![("priority; DROP".into(), OrderDir::Asc)],
+            ..Default::default()
+        };
+        assert!(matches!(
+            compose_jql(&p),
+            Err(JqlBuildError::BadFieldName(_))
+        ));
+    }
+
+    #[test]
+    fn extra_clauses_wrapped() {
+        let p = JqlParams {
+            project: Some("ABC".into()),
+            extra_clauses: vec!["sprint in openSprints()".into()],
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(jql, r#"project = "ABC" AND (sprint in openSprints())"#);
+    }
+
+    #[test]
+    fn extra_clauses_reject_control() {
+        let p = JqlParams {
+            extra_clauses: vec!["foo\nbar".into()],
+            ..Default::default()
+        };
+        assert!(matches!(
+            compose_jql(&p),
+            Err(JqlBuildError::ControlChar(_))
+        ));
+    }
+
+    #[test]
+    fn labels_components_versions() {
+        let p = JqlParams {
+            labels: vec!["needs-review".into()],
+            components: vec!["api".into(), "ui".into()],
+            fix_versions: vec!["1.2.0".into()],
+            ..Default::default()
+        };
+        let jql = compose_jql(&p).unwrap();
+        assert_eq!(
+            jql,
+            r#"labels in ("needs-review") AND component in ("api", "ui") AND fixVersion in ("1.2.0")"#
+        );
+    }
+}

--- a/crates/jira-core/src/lib.rs
+++ b/crates/jira-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod client;
 pub mod config;
 pub mod error;
 pub mod field_cache;
+pub mod jql;
 pub mod model;
 
 pub use client::JiraClient;

--- a/crates/jira-core/src/model/board.rs
+++ b/crates/jira-core/src/model/board.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Board {
+    pub id: u64,
+    pub name: String,
+    /// e.g. `"scrum"`, `"kanban"`, `"simple"`.
+    #[serde(rename = "type")]
+    pub board_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<u64>,
+    #[serde(rename = "self", default, skip_serializing_if = "String::is_empty")]
+    pub self_url: String,
+}
+
+impl Board {
+    /// Parse from the raw Agile API board JSON object.
+    pub fn from_value(v: &Value) -> Option<Self> {
+        let location = v.get("location");
+        Some(Board {
+            id: v.get("id").and_then(|x| x.as_u64())?,
+            name: v.get("name").and_then(|x| x.as_str())?.to_string(),
+            board_type: v
+                .get("type")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string(),
+            project_key: location
+                .and_then(|l| l.get("projectKey"))
+                .and_then(|x| x.as_str())
+                .map(|s| s.to_string()),
+            project_id: location
+                .and_then(|l| l.get("projectId"))
+                .and_then(|x| x.as_u64()),
+            self_url: v
+                .get("self")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_minimal_board() {
+        let v = json!({
+            "id": 7,
+            "name": "ABC scrum",
+            "type": "scrum",
+            "self": "https://x/rest/agile/1.0/board/7"
+        });
+        let b = Board::from_value(&v).unwrap();
+        assert_eq!(b.id, 7);
+        assert_eq!(b.name, "ABC scrum");
+        assert_eq!(b.board_type, "scrum");
+        assert_eq!(b.project_key, None);
+        assert_eq!(b.self_url, "https://x/rest/agile/1.0/board/7");
+    }
+
+    #[test]
+    fn parses_board_with_location() {
+        let v = json!({
+            "id": 12,
+            "name": "Team board",
+            "type": "kanban",
+            "location": { "projectKey": "ABC", "projectId": 10000 }
+        });
+        let b = Board::from_value(&v).unwrap();
+        assert_eq!(b.project_key.as_deref(), Some("ABC"));
+        assert_eq!(b.project_id, Some(10000));
+    }
+
+    #[test]
+    fn missing_required_fields_returns_none() {
+        assert!(Board::from_value(&json!({})).is_none());
+        assert!(Board::from_value(&json!({ "id": 1 })).is_none());
+    }
+}

--- a/crates/jira-core/src/model/mod.rs
+++ b/crates/jira-core/src/model/mod.rs
@@ -1,4 +1,5 @@
 pub mod attachment;
+pub mod board;
 pub mod comment;
 pub mod component;
 pub mod field;
@@ -14,6 +15,7 @@ pub mod watcher;
 pub mod worklog;
 
 pub use attachment::Attachment;
+pub use board::Board;
 pub use comment::Comment;
 pub use component::Component;
 pub use field::{Field, FieldKind, FieldValue};

--- a/crates/jira/src/cli/board.rs
+++ b/crates/jira/src/cli/board.rs
@@ -1,0 +1,184 @@
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use indicatif::{ProgressBar, ProgressStyle};
+use jira_core::{model::Issue, JiraClient};
+
+#[derive(Debug, Subcommand)]
+pub enum BoardCommand {
+    /// List Agile boards (optionally filtered by project key and type)
+    List {
+        /// Project key filter (e.g. PROJ)
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Board type filter: scrum, kanban, simple
+        #[arg(short = 't', long, value_name = "TYPE")]
+        board_type: Option<String>,
+        /// Output as JSON array
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show a single board by ID
+    Get {
+        /// Board ID
+        id: u64,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List issues currently on a board
+    Issues {
+        /// Board ID
+        id: u64,
+        /// Optional JQL filter
+        #[arg(long)]
+        jql: Option<String>,
+        /// Maximum number of issues to return (default: 50)
+        #[arg(long, value_name = "N")]
+        max: Option<u32>,
+        /// Output as JSON array
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List backlog issues on a board (issues not in an active or future sprint)
+    Backlog {
+        /// Board ID
+        id: u64,
+        /// Optional JQL filter
+        #[arg(long)]
+        jql: Option<String>,
+        /// Maximum number of issues to return (default: 50)
+        #[arg(long, value_name = "N")]
+        max: Option<u32>,
+        /// Output as JSON array
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub async fn handle(cmd: BoardCommand, client: JiraClient) -> Result<()> {
+    match cmd {
+        BoardCommand::List {
+            project,
+            board_type,
+            json,
+        } => list_boards(client, project, board_type, json).await,
+        BoardCommand::Get { id, json } => get_board(client, id, json).await,
+        BoardCommand::Issues { id, jql, max, json } => {
+            board_issues(client, id, jql, max, json, /*backlog=*/ false).await
+        }
+        BoardCommand::Backlog { id, jql, max, json } => {
+            board_issues(client, id, jql, max, json, /*backlog=*/ true).await
+        }
+    }
+}
+
+async fn list_boards(
+    client: JiraClient,
+    project: Option<String>,
+    board_type: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let spinner = spinner_new("Fetching boards...");
+    let boards = client
+        .list_boards(project.as_deref(), board_type.as_deref())
+        .await
+        .context("Failed to list boards")?;
+    spinner.finish_and_clear();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&boards)?);
+        return Ok(());
+    }
+
+    if boards.is_empty() {
+        println!("No boards found.");
+        return Ok(());
+    }
+
+    for b in &boards {
+        println!(
+            "{:<8} {:<10} {:<10} {}",
+            b.id,
+            b.board_type,
+            b.project_key.as_deref().unwrap_or("-"),
+            b.name
+        );
+    }
+    Ok(())
+}
+
+async fn get_board(client: JiraClient, id: u64, json: bool) -> Result<()> {
+    let spinner = spinner_new(format!("Fetching board {id}..."));
+    let board = client
+        .get_board(id)
+        .await
+        .with_context(|| format!("Failed to fetch board {id}"))?;
+    spinner.finish_and_clear();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&board)?);
+        return Ok(());
+    }
+    println!("ID:           {}", board.id);
+    println!("Name:         {}", board.name);
+    println!("Type:         {}", board.board_type);
+    if let Some(p) = &board.project_key {
+        println!("Project key:  {p}");
+    }
+    if let Some(pid) = board.project_id {
+        println!("Project ID:   {pid}");
+    }
+    if !board.self_url.is_empty() {
+        println!("URL:          {}", board.self_url);
+    }
+    Ok(())
+}
+
+async fn board_issues(
+    client: JiraClient,
+    id: u64,
+    jql: Option<String>,
+    max: Option<u32>,
+    json: bool,
+    backlog: bool,
+) -> Result<()> {
+    let label = if backlog { "backlog" } else { "issues" };
+    let spinner = spinner_new(format!("Fetching {label} for board {id}..."));
+    let issues: Vec<Issue> = if backlog {
+        client.board_backlog(id, jql.as_deref(), max).await
+    } else {
+        client.board_issues(id, jql.as_deref(), max).await
+    }
+    .with_context(|| format!("Failed to fetch {label} for board {id}"))?;
+    spinner.finish_and_clear();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&issues)?);
+        return Ok(());
+    }
+
+    if issues.is_empty() {
+        println!("No issues.");
+        return Ok(());
+    }
+
+    for i in &issues {
+        println!("{:<14} {:<14} {}", i.key, i.status, i.summary);
+    }
+    Ok(())
+}
+
+fn spinner_new(msg: impl Into<String>) -> ProgressBar {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    spinner.set_message(msg.into());
+    spinner.enable_steady_tick(std::time::Duration::from_millis(80));
+    spinner
+}

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -906,6 +906,15 @@ pub enum IssueCommand {
         /// Execute the generated JQL immediately (shows up to 25 results)
         #[arg(long)]
         run: bool,
+        /// JQL builder params as JSON. Accepts a literal JSON object or @path/to/file.json.
+        /// Skips the interactive prompts.
+        ///
+        /// Schema: see `jira_core::jql::JqlParams`. Example:
+        ///   {"project":"PROJ","status":["In Progress"],
+        ///    "assignee":[{"type":"current_user"}],
+        ///    "order_by":[["updated","desc"]]}
+        #[arg(long, value_name = "JSON")]
+        params: Option<String>,
     },
 
     /// Run mixed operations from a JSON manifest file
@@ -1469,7 +1478,7 @@ pub async fn handle(
             json,
         } => bulk_update(client, jql, assignee, priority, force, json).await,
         IssueCommand::Archive { jql, force } => archive(client, jql, force).await,
-        IssueCommand::Jql { run } => jql_builder(client, run).await,
+        IssueCommand::Jql { run, params } => jql_builder(client, run, params).await,
         IssueCommand::BulkCreate { manifest, json } => bulk_create(client, manifest, json).await,
         IssueCommand::Clone {
             key,
@@ -3114,9 +3123,13 @@ async fn attachment_download(
             dest.display()
         );
     }
-    std::fs::write(&dest, &bytes)
-        .with_context(|| format!("Failed to write {}", dest.display()))?;
-    println!("✓ Saved {} ({} bytes, {})", dest.display(), bytes.len(), mime);
+    std::fs::write(&dest, &bytes).with_context(|| format!("Failed to write {}", dest.display()))?;
+    println!(
+        "✓ Saved {} ({} bytes, {})",
+        dest.display(),
+        bytes.len(),
+        mime
+    );
     Ok(())
 }
 
@@ -4165,7 +4178,32 @@ async fn archive(client: JiraClient, jql: String, force: bool) -> Result<()> {
 
 // ─── jql builder ─────────────────────────────────────────────────────────────
 
-async fn jql_builder(client: JiraClient, run: bool) -> Result<()> {
+fn jql_params_filters_empty(p: &jira_core::jql::JqlParams) -> bool {
+    p.project.is_none()
+        && p.status.is_empty()
+        && p.assignee.is_empty()
+        && p.priority.is_empty()
+        && p.labels.is_empty()
+        && p.components.is_empty()
+        && p.fix_versions.is_empty()
+        && p.text.is_none()
+        && p.created_after.is_none()
+        && p.updated_after.is_none()
+        && p.extra_clauses.is_empty()
+}
+
+fn load_jql_params(spec: &str) -> Result<jira_core::jql::JqlParams> {
+    let raw = if let Some(path) = spec.strip_prefix('@') {
+        std::fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?
+    } else {
+        spec.to_string()
+    };
+    serde_json::from_str(&raw).context("Failed to parse JqlParams JSON")
+}
+
+fn prompt_jql_params() -> Result<jira_core::jql::JqlParams> {
+    use jira_core::jql::{AssigneeFilter, JqlParams, OrderDir};
+
     println!("JQL Builder — press Enter to skip any field\n");
 
     let project = Text::new("Project key (e.g. PROJ):")
@@ -4186,9 +4224,9 @@ async fn jql_builder(client: JiraClient, run: bool) -> Result<()> {
         .prompt()
         .context("Failed to read status")?;
     let status = if status_sel == "(any)" {
-        None
+        Vec::new()
     } else {
-        Some(status_sel.to_string())
+        vec![status_sel.to_string()]
     };
 
     let assignee_opts = vec!["Me (currentUser)", "Unassigned", "Custom email", "(any)"];
@@ -4196,15 +4234,15 @@ async fn jql_builder(client: JiraClient, run: bool) -> Result<()> {
         .prompt()
         .context("Failed to read assignee")?;
     let assignee = match assignee_sel {
-        "Me (currentUser)" => Some("currentUser()".to_string()),
-        "Unassigned" => Some("EMPTY".to_string()),
+        "Me (currentUser)" => vec![AssigneeFilter::CurrentUser],
+        "Unassigned" => vec![AssigneeFilter::Empty],
         "Custom email" => {
             let email = Text::new("Email:")
                 .prompt()
                 .context("Failed to read email")?;
-            Some(format!("\"{email}\""))
+            vec![AssigneeFilter::Email { email }]
         }
-        _ => None,
+        _ => Vec::new(),
     };
 
     let priority_opts = vec!["Highest", "High", "Medium", "Low", "Lowest", "(any)"];
@@ -4212,37 +4250,51 @@ async fn jql_builder(client: JiraClient, run: bool) -> Result<()> {
         .prompt()
         .context("Failed to read priority")?;
     let priority = if priority_sel == "(any)" {
-        None
+        Vec::new()
     } else {
-        Some(priority_sel.to_string())
+        vec![priority_sel.to_string()]
     };
 
     let order_opts = vec!["updated DESC", "created DESC", "priority DESC", "key ASC"];
-    let order = Select::new("Order by:", order_opts)
+    let order_sel = Select::new("Order by:", order_opts)
         .prompt()
         .context("Failed to read order")?;
+    let order_by = vec![match order_sel {
+        "updated DESC" => ("updated".to_string(), OrderDir::Desc),
+        "created DESC" => ("created".to_string(), OrderDir::Desc),
+        "priority DESC" => ("priority".to_string(), OrderDir::Desc),
+        _ => ("key".to_string(), OrderDir::Asc),
+    }];
 
-    // Build JQL
-    let mut parts: Vec<String> = Vec::new();
-    if let Some(p) = project {
-        parts.push(format!("project = {p}"));
+    Ok(JqlParams {
+        project,
+        status,
+        assignee,
+        priority,
+        order_by,
+        ..Default::default()
+    })
+}
+
+async fn jql_builder(client: JiraClient, run: bool, params: Option<String>) -> Result<()> {
+    let mut jql_params = if let Some(spec) = params {
+        load_jql_params(&spec)?
+    } else {
+        prompt_jql_params()?
+    };
+
+    if jql_params_filters_empty(&jql_params) {
+        jql_params
+            .assignee
+            .push(jira_core::jql::AssigneeFilter::CurrentUser);
     }
-    if let Some(s) = status {
-        parts.push(format!("status = \"{s}\""));
-    }
-    if let Some(a) = assignee {
-        parts.push(format!("assignee = {a}"));
-    }
-    if let Some(p) = priority {
-        parts.push(format!("priority = \"{p}\""));
+    if jql_params.order_by.is_empty() {
+        jql_params
+            .order_by
+            .push(("updated".into(), jira_core::jql::OrderDir::Desc));
     }
 
-    if parts.is_empty() {
-        parts.push("assignee = currentUser()".to_string());
-    }
-
-    let jql = format!("{} ORDER BY {}", parts.join(" AND "), order);
-
+    let jql = jira_core::jql::compose_jql(&jql_params).context("Failed to compose JQL")?;
     println!("\nGenerated JQL:\n  {jql}\n");
 
     if run {

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -565,6 +565,17 @@ pub enum IssueCommand {
         files: Vec<std::path::PathBuf>,
     },
 
+    /// Manage attachments on an issue (list, download, delete)
+    ///
+    /// Examples:
+    ///   jirac issue attachment list PROJ-123
+    ///   jirac issue attachment download 10100 --out ./tmp
+    ///   jirac issue attachment delete 10100 --force
+    Attachment {
+        #[command(subcommand)]
+        command: AttachmentCommand,
+    },
+
     /// List available fields for a project and issue type
     ///
     /// Shows field name, ID, type (text, select, number, user, etc.),
@@ -1017,6 +1028,42 @@ pub enum WatchCommand {
 }
 
 #[derive(Debug, Subcommand)]
+pub enum AttachmentCommand {
+    /// List all attachments on an issue
+    List {
+        /// Issue key (e.g. PROJ-123)
+        key: String,
+        /// Output as JSON array
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Download an attachment by ID
+    Download {
+        /// Attachment ID (visible via `jirac issue attachment list`)
+        id: String,
+        /// Output directory (defaults to current directory)
+        #[arg(long, value_name = "DIR")]
+        out: Option<std::path::PathBuf>,
+        /// Override the filename (defaults to the server-provided name)
+        #[arg(long, value_name = "NAME")]
+        filename: Option<String>,
+        /// Overwrite if the destination file already exists
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Delete an attachment by ID
+    Delete {
+        /// Attachment ID to delete
+        id: String,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 pub enum CommentCommand {
     /// List all comments on the issue
     List,
@@ -1376,6 +1423,7 @@ pub async fn handle(
         } => transition_issue(client, key, transition, json).await,
         IssueCommand::Link { command } => handle_link_command(client, command).await,
         IssueCommand::Attach { key, files } => attach_files(client, key, files).await,
+        IssueCommand::Attachment { command } => attachment(client, command).await,
         IssueCommand::Fields {
             project,
             issue_type,
@@ -2994,6 +3042,102 @@ async fn attach_files(
         }
     }
 
+    Ok(())
+}
+
+// ─── attachment ──────────────────────────────────────────────────────────────
+
+async fn attachment(client: JiraClient, cmd: AttachmentCommand) -> Result<()> {
+    match cmd {
+        AttachmentCommand::List { key, json } => attachment_list(client, key, json).await,
+        AttachmentCommand::Download {
+            id,
+            out,
+            filename,
+            force,
+        } => attachment_download(client, id, out, filename, force).await,
+        AttachmentCommand::Delete { id, force } => attachment_delete(client, id, force).await,
+    }
+}
+
+async fn attachment_list(client: JiraClient, key: String, json: bool) -> Result<()> {
+    let spinner = spinner_new(format!("Fetching attachments for {key}..."));
+    let attachments = client
+        .list_attachments(&key)
+        .await
+        .with_context(|| format!("Failed to list attachments for {key}"))?;
+    spinner.finish_and_clear();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&attachments)?);
+        return Ok(());
+    }
+
+    if attachments.is_empty() {
+        println!("No attachments on {key}.");
+        return Ok(());
+    }
+
+    for a in &attachments {
+        println!(
+            "{:<10} {:<10} {:>10}  {}",
+            a.id, a.mime_type, a.size, a.filename
+        );
+    }
+    Ok(())
+}
+
+async fn attachment_download(
+    client: JiraClient,
+    id: String,
+    out: Option<std::path::PathBuf>,
+    filename: Option<String>,
+    force: bool,
+) -> Result<()> {
+    let spinner = spinner_new(format!("Downloading attachment {id}..."));
+    let (server_name, bytes, mime) = client
+        .download_attachment(&id)
+        .await
+        .with_context(|| format!("Failed to download attachment {id}"))?;
+    spinner.finish_and_clear();
+
+    let out_dir = out.unwrap_or_else(|| std::path::PathBuf::from("."));
+    if !out_dir.exists() {
+        std::fs::create_dir_all(&out_dir)
+            .with_context(|| format!("Failed to create {}", out_dir.display()))?;
+    }
+    let name = filename.unwrap_or(server_name);
+    let dest = out_dir.join(&name);
+    if dest.exists() && !force {
+        anyhow::bail!(
+            "{} already exists. Use --force to overwrite.",
+            dest.display()
+        );
+    }
+    std::fs::write(&dest, &bytes)
+        .with_context(|| format!("Failed to write {}", dest.display()))?;
+    println!("✓ Saved {} ({} bytes, {})", dest.display(), bytes.len(), mime);
+    Ok(())
+}
+
+async fn attachment_delete(client: JiraClient, id: String, force: bool) -> Result<()> {
+    if !force {
+        let ok = Confirm::new(&format!("Delete attachment {id}?"))
+            .with_default(false)
+            .prompt()
+            .context("Failed to read confirmation")?;
+        if !ok {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+    let spinner = spinner_new(format!("Deleting attachment {id}..."));
+    client
+        .delete_attachment(&id)
+        .await
+        .with_context(|| format!("Failed to delete attachment {id}"))?;
+    spinner.finish_and_clear();
+    println!("✓ Deleted attachment {id}");
     Ok(())
 }
 

--- a/crates/jira/src/cli/mod.rs
+++ b/crates/jira/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod auth;
+pub mod board;
 pub mod issue;
 pub mod mcp;
 pub mod plan;

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -61,6 +61,11 @@ enum Commands {
         #[command(subcommand)]
         command: cli::mcp::McpCommand,
     },
+    /// Browse Agile boards: list boards, show details, fetch issues or backlog
+    Board {
+        #[command(subcommand)]
+        command: cli::board::BoardCommand,
+    },
 }
 
 #[tokio::main]
@@ -143,6 +148,13 @@ async fn main() -> Result<()> {
         }
         Commands::Mcp { command } => {
             cli::mcp::handle(command)?;
+            if let Some(notice) = &update_notice {
+                eprintln!("{}", version_check::cli_message(notice));
+            }
+        }
+        Commands::Board { command } => {
+            let client = build_client().context("Failed to initialize Jira client")?;
+            cli::board::handle(command, client).await?;
             if let Some(notice) = &update_notice {
                 eprintln!("{}", version_check::cli_message(notice));
             }

--- a/crates/jira/src/tui/app.rs
+++ b/crates/jira/src/tui/app.rs
@@ -21,7 +21,7 @@ use jira_core::config::{config_file_path, JiraConfig, JiraProfilesFile};
 use jira_core::{
     adf::{inject_mentions, markdown_to_adf},
     model::{
-        field::Field, CreateProjectVersionRequest, Issue, Sprint, UpdateIssueRequest,
+        field::Field, Board, CreateProjectVersionRequest, Issue, Sprint, UpdateIssueRequest,
         UpdateProjectVersionRequest,
     },
     IssueType, JiraClient,
@@ -156,6 +156,14 @@ pub(super) struct App {
     pub(super) sprint_project_key: String,
     pub(super) sprint_catalog: Vec<Sprint>,
     pub(super) sprint_cache: HashMap<String, Vec<Sprint>>,
+    pub(super) board_query: String,
+    pub(super) board_cursor: usize,
+    pub(super) board_options: Vec<PickerOption>,
+    pub(super) board_state: ListState,
+    pub(super) board_project_key: String,
+    pub(super) board_catalog: Vec<Board>,
+    /// Keyed by project key; empty string `""` caches the "all boards" listing.
+    pub(super) board_cache: HashMap<String, Vec<Board>>,
     pub(super) prefs: TuiPreferences,
     pub(super) saved_jql_state: ListState,
     pub(super) jql_picker_filter: String,
@@ -212,6 +220,11 @@ pub(super) enum AppAction {
     OpenSprintPicker(String),
     RefreshSprintOptions,
     ApplySprintSelection(String),
+    /// Open the board picker. The argument is the project key to scope the
+    /// board listing; `None` means "list all boards".
+    OpenBoardPicker(Option<String>),
+    RefreshBoardOptions,
+    ApplyBoardSelection,
     OpenChangeTypeModal(String),
     OpenMoveIssueModal(String),
     RefreshMentionOptions,
@@ -344,6 +357,13 @@ impl App {
             sprint_project_key: String::new(),
             sprint_catalog: Vec::new(),
             sprint_cache: HashMap::new(),
+            board_query: String::new(),
+            board_cursor: 0,
+            board_options: Vec::new(),
+            board_state: ListState::default(),
+            board_project_key: String::new(),
+            board_catalog: Vec::new(),
+            board_cache: HashMap::new(),
             prefs,
             saved_jql_state,
             jql_picker_filter: String::new(),
@@ -1552,6 +1572,94 @@ pub async fn run_tui(
                                 }
                             }
                         }
+                    }
+                }
+            }
+
+            AppAction::OpenBoardPicker(project_key_opt) => {
+                app.board_query.clear();
+                app.board_cursor = 0;
+                app.board_options.clear();
+                app.board_catalog.clear();
+                app.board_state = ListState::default();
+                let project_key = project_key_opt.unwrap_or_default();
+                app.board_project_key = project_key.clone();
+                app.mode = Mode::BoardPicker;
+                app.focus = Focus::List;
+
+                if let Some(cached) = app.board_cache.get(&project_key).cloned() {
+                    app.board_options = cached
+                        .iter()
+                        .map(|b| PickerOption {
+                            value: b.id.to_string(),
+                            label: format!("{}  [{}]", b.name, b.board_type),
+                        })
+                        .collect();
+                    app.board_catalog = cached;
+                    if !app.board_options.is_empty() {
+                        app.board_state.select(Some(0));
+                    }
+                    app.clear_status();
+                    continue;
+                }
+
+                let load_label = if project_key.is_empty() {
+                    "all projects".to_string()
+                } else {
+                    project_key.clone()
+                };
+                app.set_status(format!("Loading boards for {load_label}..."), false);
+                let project_arg = if project_key.is_empty() {
+                    None
+                } else {
+                    Some(project_key.as_str())
+                };
+                match client.list_boards(project_arg, None).await {
+                    Ok(boards) => {
+                        app.board_options = boards
+                            .iter()
+                            .map(|b| PickerOption {
+                                value: b.id.to_string(),
+                                label: format!("{}  [{}]", b.name, b.board_type),
+                            })
+                            .collect();
+                        app.board_catalog = boards.clone();
+                        app.board_cache.insert(project_key, boards);
+                        if !app.board_options.is_empty() {
+                            app.board_state.select(Some(0));
+                        }
+                        app.clear_status();
+                    }
+                    Err(e) => app.set_status(format!("Board lookup failed: {e}"), true),
+                }
+            }
+
+            AppAction::RefreshBoardOptions => {
+                let query = app.board_query.to_lowercase();
+                app.board_options = app
+                    .board_catalog
+                    .iter()
+                    .filter(|b| {
+                        query.is_empty()
+                            || b.name.to_lowercase().contains(&query)
+                            || b.board_type.to_lowercase().contains(&query)
+                    })
+                    .map(|b| PickerOption {
+                        value: b.id.to_string(),
+                        label: format!("{}  [{}]", b.name, b.board_type),
+                    })
+                    .collect();
+                app.board_state.select(Some(0));
+            }
+
+            AppAction::ApplyBoardSelection => {
+                if let Some(idx) = app.board_state.selected() {
+                    if let Some(option) = app.board_options.get(idx).cloned() {
+                        app.mode = Mode::Browse;
+                        app.set_status(
+                            format!("Selected board: {} (id={})", option.label, option.value),
+                            false,
+                        );
                     }
                 }
             }

--- a/crates/jira/src/tui/keys.rs
+++ b/crates/jira/src/tui/keys.rs
@@ -39,6 +39,7 @@ pub(super) fn handle_key(app: &mut App, event: KeyEvent) -> AppAction {
         Mode::ComponentPicker => handle_component_picker_key(app, code),
         Mode::FixVersionPicker => handle_fix_version_picker_key(app, code),
         Mode::SprintPicker => handle_sprint_picker_key(app, code),
+        Mode::BoardPicker => handle_board_picker_key(app, code),
         Mode::Help => handle_help_key(app, code),
         Mode::SavedJqlPicker => handle_saved_jql_key(app, code),
         Mode::ThemePicker => handle_theme_picker_key(app, code),
@@ -152,6 +153,7 @@ fn handle_browse_key(app: &mut App, code: KeyCode) -> AppAction {
             .selected_issue_key()
             .map(AppAction::OpenSprintPicker)
             .unwrap_or(AppAction::None),
+        KeyCode::Char('B') => AppAction::OpenBoardPicker(app.active_project_key()),
         KeyCode::Char('u') => app
             .selected_issue_key()
             .map(AppAction::UploadAttachment)
@@ -978,6 +980,44 @@ fn handle_sprint_picker_key(app: &mut App, code: KeyCode) -> AppAction {
             AppAction::RefreshSprintOptions
         }
         KeyCode::Enter => AppAction::ApplySprintSelection(app.sprint_issue_key.clone()),
+        _ => AppAction::None,
+    }
+}
+
+fn handle_board_picker_key(app: &mut App, code: KeyCode) -> AppAction {
+    match code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.mode = Mode::Browse;
+            AppAction::None
+        }
+        KeyCode::Down => {
+            picker_nav_down(&mut app.board_state, app.board_options.len());
+            AppAction::None
+        }
+        KeyCode::Up => {
+            picker_nav_up(&mut app.board_state);
+            AppAction::None
+        }
+        KeyCode::Left => {
+            picker_cursor_left(&mut app.board_cursor);
+            AppAction::None
+        }
+        KeyCode::Right => {
+            picker_cursor_right(&mut app.board_cursor, &app.board_query);
+            AppAction::None
+        }
+        KeyCode::Backspace => {
+            if picker_backspace(&mut app.board_query, &mut app.board_cursor) {
+                AppAction::RefreshBoardOptions
+            } else {
+                AppAction::None
+            }
+        }
+        KeyCode::Char(c) => {
+            picker_type_char(&mut app.board_query, &mut app.board_cursor, c);
+            AppAction::RefreshBoardOptions
+        }
+        KeyCode::Enter => AppAction::ApplyBoardSelection,
         _ => AppAction::None,
     }
 }

--- a/crates/jira/src/tui/mode.rs
+++ b/crates/jira/src/tui/mode.rs
@@ -10,6 +10,7 @@ pub(super) enum Mode {
     ComponentPicker,
     FixVersionPicker,
     SprintPicker,
+    BoardPicker,
     SavedJqlPicker,
     ServerInfo,
     ConfigView,

--- a/crates/jira/src/tui/mouse.rs
+++ b/crates/jira/src/tui/mouse.rs
@@ -147,6 +147,14 @@ pub(super) fn handle_mouse(app: &mut App, event: MouseEvent) -> AppAction {
                                     KeyCode::Enter,
                                 );
                             }
+                            Mode::BoardPicker => {
+                                return select_and_press(
+                                    app,
+                                    |a| &mut a.board_state,
+                                    idx,
+                                    KeyCode::Enter,
+                                );
+                            }
                             Mode::SavedJqlPicker => {
                                 return select_and_press(
                                     app,
@@ -333,6 +341,7 @@ fn is_popup_mode(mode: &Mode) -> bool {
             | Mode::ComponentPicker
             | Mode::FixVersionPicker
             | Mode::SprintPicker
+            | Mode::BoardPicker
             | Mode::SavedJqlPicker
             | Mode::ThemePicker
             | Mode::ServerInfo

--- a/crates/jira/src/tui/render.rs
+++ b/crates/jira/src/tui/render.rs
@@ -71,6 +71,7 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
         Mode::ComponentPicker => " Jira CLI — Component Picker ".to_string(),
         Mode::FixVersionPicker => " Jira CLI — Fix Version Picker ".to_string(),
         Mode::SprintPicker => " Jira CLI — Sprint Picker ".to_string(),
+        Mode::BoardPicker => " Jira CLI — Board Picker ".to_string(),
         Mode::SavedJqlPicker => " Jira CLI — Saved Queries ".to_string(),
         Mode::ServerInfo => " Jira CLI — Server ".to_string(),
         Mode::ConfigView => " Jira CLI — Config ".to_string(),
@@ -128,6 +129,10 @@ pub(super) fn ui(f: &mut Frame, app: &mut App) {
             render_browse(f, app, chunks[1], palette);
             render_sprint_picker_popup(f, app, size, palette);
         }
+        Mode::BoardPicker => {
+            render_browse(f, app, chunks[1], palette);
+            render_board_picker_popup(f, app, size, palette);
+        }
         Mode::SavedJqlPicker => {
             render_browse(f, app, chunks[1], palette);
             render_saved_jql_popup(f, app, size, palette);
@@ -163,7 +168,7 @@ fn render_footer(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
                 .to_string()
         }
         Mode::Browse => {
-            " j/k:move  Enter:detail  p:queries  n:mentions  R:mark-read  T:theme  S:server  g:config  t:transition  C:columns  c:create  e:edit  y:type  M:move  a:assign  ;:comment  ::bulk-comment  w:worklog  b:bulk-log  l:labels  m:comps  v:versions  u:upload  o:browser  r:refresh  /:search  ?:help  q:quit"
+            " j/k:move  Enter:detail  p:queries  n:mentions  R:mark-read  T:theme  S:server  g:config  t:transition  C:columns  c:create  e:edit  y:type  M:move  a:assign  ;:comment  ::bulk-comment  w:worklog  b:bulk-log  l:labels  m:comps  v:versions  s:sprint  B:boards  u:upload  o:browser  r:refresh  /:search  ?:help  q:quit"
                 .to_string()
         }
         Mode::Search => " Type JQL  Enter:search  Esc:cancel".to_string(),
@@ -177,6 +182,7 @@ fn render_footer(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
         Mode::ComponentPicker => " type:search  j/k:move  Space:toggle  Enter:save  Esc:cancel".to_string(),
         Mode::FixVersionPicker => " type:search  j/k:move  Space:toggle  Enter:save  Esc:cancel".to_string(),
         Mode::SprintPicker => " type:filter  j/k:move  Enter:assign to sprint  Esc:cancel".to_string(),
+        Mode::BoardPicker => " type:filter  j/k:move  Enter:select board  Esc:cancel".to_string(),
         Mode::SavedJqlPicker => " ↑/↓:move  Enter:run  type:filter  Tab:clear  c:new  e:edit  d:delete  Esc:cancel".to_string(),
         Mode::ThemePicker => " j/k:move  Enter:apply theme  Esc:cancel".to_string(),
         Mode::Modal => {
@@ -1152,6 +1158,36 @@ fn render_sprint_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette:
     ));
 }
 
+fn render_board_picker_popup(f: &mut Frame, app: &mut App, area: Rect, palette: Palette) {
+    let scope = if app.board_project_key.is_empty() {
+        "all projects".to_string()
+    } else {
+        app.board_project_key.clone()
+    };
+    let title = format!(" Boards: {scope} ");
+    let option_count = app.board_options.len();
+    let (popup_area, list_area) = render_single_select_picker_popup(
+        f,
+        area,
+        palette,
+        &app.board_query,
+        app.board_cursor,
+        &app.board_options.clone(),
+        &mut app.board_state,
+        &title,
+        &[
+            "Type to filter boards",
+            "↑/↓ move   Enter select   Esc cancel",
+        ],
+    );
+    app.hit_zones.popup = Some(popup_area);
+    app.hit_zones.picker = Some(picker_hit_for_bordered(
+        list_area,
+        app.board_state.offset(),
+        option_count,
+    ));
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_multi_select_picker_popup(
     f: &mut Frame,
@@ -1536,6 +1572,7 @@ fn render_help_popup(f: &mut Frame, area: Rect, palette: Palette, scroll_offset:
         Line::from("  r         Refresh list"),
         Line::from("  R         Mark selected notification issue as read"),
         Line::from("  s         Add to sprint"),
+        Line::from("  B         Browse boards (filtered by active project)"),
         Line::from("  S         Show server info"),
         Line::from("  t         Transition issue"),
         Line::from("  T         Open theme picker"),


### PR DESCRIPTION
## Summary

- Round out `jira-core` so the upcoming `jira-mcp` work has the primitives it needs: a structured JQL builder, attachment list/download, and Agile board operations.
- Surface the new capabilities through `jirac` (CLI + TUI) so they are usable today, not only via MCP.

## Changes

### jira-core
- `jql` module with `JqlParams`, `compose_jql`, escape + validation helpers (`escape_jql_literal`, control-character rejection, relative-window / date / field-name validators) covering project, status, assignee (current user / empty / email / accountId), priority, labels, components, fix versions, text search, created/updated date filters, extra clauses, and ordered `ORDER BY`.
- Attachment lifecycle on `JiraClient`: `list_attachments(issue_key)` and `download_attachment(attachment_id)` returning filename + bytes + MIME (parsing both RFC 5987 `filename*` and quoted `filename` forms of `Content-Disposition`).
- Agile board surface: `Board` model with `from_value` plus `list_boards`, `get_board`, `board_issues`, and `board_backlog` on `JiraClient`, all paginated against `/rest/agile/1.0/board`.
- Wiremock tests for each new client method.

### jira (CLI)
- `jirac issue attachment list/download/delete` wrapping the new core methods. Download refuses to overwrite without `--force`; delete prompts unless `--force`.
- New top-level `jirac board list/get/issues/backlog` subcommand group with project/type filters, optional JQL, max-results cap, and JSON output for scripting.
- `jirac issue jql` now builds the query through `JqlParams` + `compose_jql` instead of ad-hoc string concat, picking up the same escaping. Adds `--params <json|@file>` for non-interactive callers.

### jira (TUI)
- New `Mode::BoardPicker` mirroring the existing sprint picker: capital `B` in Browse mode opens a project-scoped board picker (active issue's project key, falling back to all boards). Per-project cache, incremental search, status-line feedback on selection. No mutation of the issue list.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` — 138 passed (jira-core wiremock coverage for attachment + board endpoints, JQL builder unit tests, existing suites)
- [x] `cargo build --all`
- [x] Manual: `jirac board list --project ABC`, `jirac board backlog <id>`, `jirac issue attachment list ABC-1`, `jirac issue attachment download <id> --out /tmp`, `jirac issue jql --params '{"project":"ABC"}'`
- [x] Manual: launch `jirac tui -p ABC`, press `B`, verify board picker opens and selection shows status line