### PR TITLE
chore(packaging): refresh jira-mcp Winget manifests for v2.2.0

### DIFF
--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.1.1
+PackageVersion: 2.2.0
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-06-10
+ReleaseDate: 2026-06-15
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-x86_64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.1.1/jirac-mcp-windows-x86_64.zip
-    InstallerSha256: 3d5d79a1145ac7293536641a202051ad8cf2ceca4cc71c86c3055f6e36f85626
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.2.0/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: 738cf07da7b60d5d498124b3d47648b0a0968a4ef468d7a49202da230c1770c4
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-aarch64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.1.1/jirac-mcp-windows-aarch64.zip
-    InstallerSha256: 34d400a5f3335b3479461145793c4250bcec815d0b3d0f28ffe235cfee69a34d
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.2.0/jirac-mcp-windows-aarch64.zip
+    InstallerSha256: 45324a719e51ba51407eb40ca31fd4bb5f48c3523091b4c42c2706ebe0a688da
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
+++ b/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.1.1
+PackageVersion: 2.2.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget-mcp/jirac-mcp.yaml
+++ b/packaging/winget-mcp/jirac-mcp.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.1.1
+PackageVersion: 2.2.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for jira-mcp v2.2.0

## Notes

- generated by the jira-mcp release workflow after publishing GitHub release assets
- Winget community submission remains handled by the separate `Winget Submit jira-mcp` workflow