### PR TITLE
fix(jira-mcp): bound tool responses under stdio line limits

### DIFF
--- a/crates/jira-mcp/src/app/issue.rs
+++ b/crates/jira-mcp/src/app/issue.rs
@@ -25,7 +25,7 @@ use super::{
         create_issue_request_from_batch_create, create_issue_request_from_issue, issue_is_blocked,
         issue_status_category, issue_updated_at,
     },
-    shared::{normalize_issue_keys, require_confirm, to_value},
+    shared::{normalize_issue_keys, require_confirm, slim_issue, to_value},
     JiraApp,
 };
 
@@ -46,9 +46,10 @@ impl JiraApp {
         };
 
         let result = client.search_issues(&jql, None, Some(limit)).await?;
+        let issues: Vec<Value> = result.issues.iter().map(slim_issue).collect();
         Ok(json!({
             "jql": jql,
-            "issues": result.issues,
+            "issues": issues,
             "next_page_token": result.next_page_token,
             "total": result.total
         }))
@@ -102,14 +103,15 @@ impl JiraApp {
             }
         }
 
+        let slim = |issues: &[Issue]| issues.iter().map(slim_issue).collect::<Vec<_>>();
         Ok(json!({
             "query": query,
             "since": since,
-            "recently_done": done,
-            "in_progress": in_progress,
-            "next_up": next_up,
-            "blocked": blocked,
-            "other": other,
+            "recently_done": slim(&done),
+            "in_progress": slim(&in_progress),
+            "next_up": slim(&next_up),
+            "blocked": slim(&blocked),
+            "other": slim(&other),
         }))
     }
 
@@ -170,6 +172,10 @@ impl JiraApp {
         }
 
         let total: usize = by_status.values().map(Vec::len).sum();
+        let by_status: HashMap<String, Vec<Value>> = by_status
+            .into_iter()
+            .map(|(status, issues)| (status, issues.iter().map(slim_issue).collect()))
+            .collect();
 
         Ok(json!({
             "project": args.project_key,
@@ -259,7 +265,7 @@ impl JiraApp {
             .create_issue_v2(create_issue_request_from_issue(args))
             .await?;
 
-        to_value(issue)
+        Ok(slim_issue(&issue))
     }
 
     pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {
@@ -269,7 +275,7 @@ impl JiraApp {
 
         client.update_issue(&key, request).await?;
         let issue = client.get_issue(&key).await?;
-        to_value(issue)
+        Ok(slim_issue(&issue))
     }
 
     pub async fn issue_bulk_comment(&self, args: BulkCommentArgs) -> AppResult<Value> {
@@ -350,7 +356,7 @@ impl JiraApp {
                                 "op": "create",
                                 "key": issue.key,
                                 "status": "created",
-                                "issue": issue
+                                "issue": slim_issue(&issue)
                             })
                         }
                         Err(err) => json!({

--- a/crates/jira-mcp/src/app/shared.rs
+++ b/crates/jira-mcp/src/app/shared.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use url::form_urlencoded;
 
-use jira_core::{config::JiraConfig, JiraClient};
+use jira_core::{adf::adf_to_text, config::JiraConfig, model::Issue, JiraClient};
 
 use crate::error::{AppError, AppResult};
 
@@ -103,6 +103,47 @@ where
     T: Serialize,
 {
     serde_json::to_value(value).map_err(Into::into)
+}
+
+/// Max characters of a flattened ADF description kept in a slimmed issue.
+const DESCRIPTION_EXCERPT_LEN: usize = 500;
+
+/// Project a full [`Issue`] down to the LLM-useful fields, replacing the heavy
+/// ADF `description` (and the raw `fields` map) with a short plain-text excerpt.
+///
+/// MCP stdio responses are newline-delimited JSON on a single line; many clients
+/// cap line length (e.g. Python `asyncio.StreamReader` defaults to 64 KB), so a
+/// list of full issues with ADF bodies can overflow and surface as a truncated
+/// `Unexpected EOF` parse error. Slimming keeps responses well under that cap.
+pub(super) fn slim_issue(issue: &Issue) -> Value {
+    let excerpt = issue.description.as_ref().map(|adf| {
+        let text = adf_to_text(adf);
+        truncate_chars(text.trim(), DESCRIPTION_EXCERPT_LEN)
+    });
+
+    json!({
+        "id": issue.id,
+        "key": issue.key,
+        "summary": issue.summary,
+        "status": issue.status,
+        "issue_type": issue.issue_type,
+        "project_key": issue.project_key,
+        "assignee": issue.assignee,
+        "priority": issue.priority,
+        "created": issue.created,
+        "updated": issue.updated,
+        "description_excerpt": excerpt,
+    })
+}
+
+/// Truncate a string to at most `max` characters (not bytes), appending an
+/// ellipsis marker when content was dropped.
+pub(super) fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(max).collect();
+    format!("{kept}…[truncated]")
 }
 
 pub(super) fn value_or_null(value: String) -> Value {

--- a/crates/jira-mcp/src/app/tests.rs
+++ b/crates/jira-mcp/src/app/tests.rs
@@ -465,3 +465,60 @@ async fn remote_link_list_returns_links() {
 
     clear_test_env();
 }
+
+fn issue_with_description(desc_len: usize) -> jira_core::model::Issue {
+    let body = "x".repeat(desc_len);
+    jira_core::model::Issue {
+        id: "10001".into(),
+        key: "PROJ-1".into(),
+        summary: "Compact me".into(),
+        description: Some(jira_core::adf::plain_text_to_adf(&body)),
+        status: "To Do".into(),
+        assignee: Some("Dev".into()),
+        reporter: Some("Reporter".into()),
+        priority: Some("High".into()),
+        issue_type: "Task".into(),
+        project_key: "PROJ".into(),
+        created: "2024-01-01T00:00:00.000+0000".into(),
+        updated: "2024-01-02T00:00:00.000+0000".into(),
+        attachments: vec![],
+        links: vec![],
+        fields: json!({ "customfield_10010": "noise" }),
+    }
+}
+
+#[test]
+fn slim_issue_drops_adf_and_caps_excerpt() {
+    let slim = super::shared::slim_issue(&issue_with_description(5_000));
+
+    assert_eq!(slim["key"], json!("PROJ-1"));
+    assert_eq!(slim["status"], json!("To Do"));
+    // Heavy ADF description and the raw fields map must be gone.
+    assert!(slim.get("description").is_none());
+    assert!(slim.get("fields").is_none());
+
+    let excerpt = slim["description_excerpt"].as_str().expect("excerpt");
+    assert!(excerpt.ends_with("…[truncated]"));
+    // 500 kept chars + the truncation marker.
+    assert!(excerpt.chars().count() <= 500 + "…[truncated]".chars().count());
+}
+
+#[test]
+fn slimmed_issue_list_stays_under_stdio_cap() {
+    let issues: Vec<Value> = (0..25)
+        .map(|_| super::shared::slim_issue(&issue_with_description(20_000)))
+        .collect();
+    let payload = json!({ "issues": issues });
+    let len = serde_json::to_string(&payload).expect("serialize").len();
+
+    // Full issues with 20 KB ADF bodies x25 would be ~500 KB; slimmed must be
+    // comfortably under a 64 KB stdio line cap.
+    assert!(len < 48 * 1024, "slimmed list was {len} bytes");
+}
+
+#[test]
+fn truncate_chars_appends_marker_when_over_limit() {
+    assert_eq!(super::shared::truncate_chars("short", 10), "short");
+    let out = super::shared::truncate_chars(&"a".repeat(50), 10);
+    assert_eq!(out, format!("{}…[truncated]", "a".repeat(10)));
+}

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -46,8 +46,54 @@ impl JiraMcpServer {
 
     fn respond(&self, result: AppResult<Value>) -> Result<Json<ToolResponse>, ErrorData> {
         result
-            .map(|value| Json(ToolResponse { result: value }))
+            .map(|value| {
+                Json(ToolResponse {
+                    result: bound_response(value),
+                })
+            })
             .map_err(|err| err.to_mcp())
+    }
+}
+
+/// Keep a tool response comfortably under typical MCP stdio line-length caps.
+///
+/// MCP stdio frames are newline-delimited JSON on a single line; several clients
+/// limit how long a line may be (e.g. Python `asyncio.StreamReader` defaults to
+/// 64 KB) and report overflow as a truncated `Unexpected EOF` parse error. This
+/// is a defensive net for any tool — even ones that return full payloads such as
+/// `jira_issue_view` or raw `jira_api_request` passthrough.
+const MAX_RESPONSE_BYTES: usize = 48 * 1024;
+/// Cap individual string fields when a response is over budget.
+const MAX_STRING_CHARS: usize = 2000;
+
+fn bound_response(mut value: Value) -> Value {
+    if serialized_len(&value) <= MAX_RESPONSE_BYTES {
+        return value;
+    }
+    truncate_long_strings(&mut value, MAX_STRING_CHARS);
+    if let Value::Object(map) = &mut value {
+        map.insert("_truncated".to_string(), Value::Bool(true));
+    }
+    value
+}
+
+fn serialized_len(value: &Value) -> usize {
+    serde_json::to_string(value).map(|s| s.len()).unwrap_or(0)
+}
+
+fn truncate_long_strings(value: &mut Value, max_chars: usize) {
+    match value {
+        Value::String(text) if text.chars().count() > max_chars => {
+            let kept: String = text.chars().take(max_chars).collect();
+            *text = format!("{kept}…[truncated]");
+        }
+        Value::Array(items) => items
+            .iter_mut()
+            .for_each(|item| truncate_long_strings(item, max_chars)),
+        Value::Object(map) => map
+            .values_mut()
+            .for_each(|item| truncate_long_strings(item, max_chars)),
+        _ => {}
     }
 }
 
@@ -721,6 +767,29 @@ mod tests {
     struct TestClient;
 
     impl ClientHandler for TestClient {}
+
+    #[test]
+    fn bound_response_passes_small_values_through() {
+        let value = serde_json::json!({ "key": "PROJ-1", "status": "To Do" });
+        assert_eq!(bound_response(value.clone()), value);
+    }
+
+    #[test]
+    fn bound_response_truncates_oversized_payloads() {
+        let value = serde_json::json!({ "blob": "x".repeat(60 * 1024) });
+        let bounded = bound_response(value);
+
+        assert_eq!(bounded["_truncated"], serde_json::json!(true));
+        assert!(bounded["blob"]
+            .as_str()
+            .expect("blob")
+            .ends_with("…[truncated]"));
+        let len = serde_json::to_string(&bounded).expect("serialize").len();
+        assert!(
+            len <= MAX_RESPONSE_BYTES,
+            "bounded response was {len} bytes"
+        );
+    }
 
     fn set_config_home_vars(temp_dir: &TempDir) {
         std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());


### PR DESCRIPTION
## Summary

- MCP tool calls returning large payloads failed for some clients with `JSON Parse error: Unexpected EOF` — the JSON-RPC response was truncated mid-stream. Reported against **jirac-mcp 2.2.0**; users fell back to the `jirac` CLI (unaffected).
- Root cause is **response size**, not parameters: MCP stdio frames are newline-delimited JSON on a single line, and several clients cap line length (e.g. Python `asyncio.StreamReader` defaults to 64 KB). `issue_list`/`standup`/`sprint_summary` returned full issue objects with ADF descriptions, and `issue_create`/`update`/`batch` re-fetched and returned the full issue — a 25-issue list with ADF bodies easily blows past 64 KB on one line.
- The server stdout stream is clean (zero `println!`/stdout writes; `eprintln!` + tracing both go to stderr), so this is purely payload size.

## Changes

- **`crates/jira-mcp/src/server.rs`** — add a `bound_response` backstop in `respond()`: any response serializing over 48 KB has its long string fields recursively truncated and is marked `_truncated`. Covers every tool, including full-detail ones (`issue_view`, raw `api_request`).
- **`crates/jira-mcp/src/app/shared.rs`** — add `slim_issue()` projecting an issue down to LLM-useful fields with a flattened, length-capped (~500 char) description excerpt; drops the heavy raw `fields` map.
- **`crates/jira-mcp/src/app/issue.rs`** — use `slim_issue()` across `issue_list`/`standup`/`sprint_summary`/`create`/`update`/`batch` return paths.
- **`crates/jira-mcp/src/app/tests.rs`** — cover `slim_issue` (drops ADF, caps excerpt), the slimmed list size bound (<48 KB for 25 issues), and `truncate_chars`.
- `jira-core` and the `jirac` CLI keep full-fidelity behavior — all trimming lives in the MCP layer.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` (143 pass, 5 new)
- [x] `cargo build --all`