### PR TITLE
fix(cli): guard board spinner off-TTY and dedup helpers

### DIFF
--- a/crates/jira/src/cli/board.rs
+++ b/crates/jira/src/cli/board.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use clap::Subcommand;
-use indicatif::{ProgressBar, ProgressStyle};
 use jira_core::{model::Issue, JiraClient};
+
+use crate::cli::progress::spinner_new;
 
 #[derive(Debug, Subcommand)]
 pub enum BoardCommand {
@@ -169,16 +170,4 @@ async fn board_issues(
         println!("{:<14} {:<14} {}", i.key, i.status, i.summary);
     }
     Ok(())
-}
-
-fn spinner_new(msg: impl Into<String>) -> ProgressBar {
-    let spinner = ProgressBar::new_spinner();
-    spinner.set_style(
-        ProgressStyle::with_template("{spinner:.cyan} {msg}")
-            .unwrap()
-            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
-    );
-    spinner.set_message(msg.into());
-    spinner.enable_steady_tick(std::time::Duration::from_millis(80));
-    spinner
 }

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::cli::progress::{progress_bar, spinner_new};
 use crate::{
     datetime::{build_worklog_range_dates, build_worklog_started, build_worklog_started_for_date},
     notifications::scan_mention_notifications,
@@ -8,7 +9,6 @@ use crate::{
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use clap::Subcommand;
-use indicatif::{ProgressBar, ProgressStyle};
 use inquire::{Confirm, MultiSelect, Select, Text};
 use jira_core::{
     model::{
@@ -3301,37 +3301,6 @@ fn normalize_render_output(value: &str) -> Result<&str> {
         "text" | "txt" => Ok("text"),
         other => anyhow::bail!("Unsupported output format '{other}'. Use one of: adf, text"),
     }
-}
-
-fn spinner_new(msg: impl Into<String>) -> ProgressBar {
-    use std::io::IsTerminal;
-    if !std::io::stdout().is_terminal() {
-        return ProgressBar::hidden();
-    }
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.cyan} {msg}")
-            .expect("spinner template is a compile-time constant"),
-    );
-    pb.set_message(msg.into());
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
-    pb
-}
-
-fn progress_bar(len: u64) -> ProgressBar {
-    use std::io::IsTerminal;
-    if !std::io::stdout().is_terminal() {
-        return ProgressBar::hidden();
-    }
-    let pb = ProgressBar::new(len);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.cyan} [{bar:40}] {pos}/{len} {msg}")
-            .expect("progress bar template is a compile-time constant")
-            .progress_chars("=> "),
-    );
-    pb
 }
 
 fn truncate(s: &str, max_len: usize) -> String {

--- a/crates/jira/src/cli/mod.rs
+++ b/crates/jira/src/cli/mod.rs
@@ -4,3 +4,4 @@ pub mod board;
 pub mod issue;
 pub mod mcp;
 pub mod plan;
+pub mod progress;

--- a/crates/jira/src/cli/progress.rs
+++ b/crates/jira/src/cli/progress.rs
@@ -1,0 +1,34 @@
+use std::io::IsTerminal;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Spinner that hides itself when stdout is not a TTY (piped/redirected output).
+pub fn spinner_new(msg: impl Into<String>) -> ProgressBar {
+    if !std::io::stdout().is_terminal() {
+        return ProgressBar::hidden();
+    }
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.cyan} {msg}")
+            .expect("spinner template is a compile-time constant"),
+    );
+    pb.set_message(msg.into());
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}
+
+/// Determinate progress bar that hides itself when stdout is not a TTY.
+pub fn progress_bar(len: u64) -> ProgressBar {
+    if !std::io::stdout().is_terminal() {
+        return ProgressBar::hidden();
+    }
+    let pb = ProgressBar::new(len);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{spinner:.cyan} [{bar:40}] {pos}/{len} {msg}")
+            .expect("progress bar template is a compile-time constant")
+            .progress_chars("=> "),
+    );
+    pb
+}

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -112,53 +112,41 @@ async fn main() -> Result<()> {
     match command {
         Commands::Auth { command } => {
             cli::auth::handle(command).await?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
         Commands::Issue { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             let config = JiraConfig::load().unwrap_or_default();
             cli::issue::handle(*command, client, config.project).await?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
         Commands::Tui { project } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             let config = JiraConfig::load().unwrap_or_default();
             let effective_project = project.or(config.project);
-            tui::run_tui(client, effective_project, update_notice)
+            // run_tui consumes update_notice and surfaces it itself; return so the
+            // post-match print below does not touch the moved value.
+            return tui::run_tui(client, effective_project, update_notice)
                 .await
-                .context("TUI error")?;
+                .context("TUI error");
         }
         Commands::Api { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             cli::api::handle(command, client).await?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
         Commands::Plan { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             cli::plan::handle(command, client).await?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
         Commands::Mcp { command } => {
             cli::mcp::handle(command)?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
         Commands::Board { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             cli::board::handle(command, client).await?;
-            if let Some(notice) = &update_notice {
-                eprintln!("{}", version_check::cli_message(notice));
-            }
         }
+    }
+
+    if let Some(notice) = &update_notice {
+        eprintln!("{}", version_check::cli_message(notice));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Board's spinner emitted ticks when stdout was piped/redirected — the `issue` command already guarded this; board did not. Now consistent.
- Removes duplicated spinner/progress helpers and repeated update-notice prints.

## Changes

- **`cli/progress.rs` (new)**: single tty-aware `spinner_new` + `progress_bar` (both return `ProgressBar::hidden()` off-TTY).
- **board.rs**: drop local `spinner_new`, use shared helper → inherits the TTY guard (bug fix).
- **issue.rs**: drop local `spinner_new` + `progress_bar`, import shared.
- **main.rs**: hoist the repeated update-notice `eprintln!` out of 6 match arms into one post-match print; `Tui` arm returns early since it consumes the notice.

Net ~-30 lines, -1 latent bug.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo build --all`
- [ ] Manual: `jirac board list -p PROJ | cat` → no spinner ticks in piped output; same in terminal → spinner shows