### PR TITLE
fix(jira-mcp): document markdown/ADF affordance on issue tools

### DIFF
--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -221,7 +221,12 @@ pub struct IssueCreateArgs {
     pub project_key: String,
     pub summary: String,
     pub issue_type: String,
+    /// Issue description as plain Markdown (headings, lists, tables, code,
+    /// links). Auto-converted to Atlassian Document Format. Use this for
+    /// normal text — do NOT hand-build ADF.
     pub description: Option<String>,
+    /// Advanced/optional: pre-built ADF JSON. Leave unset and use `description`
+    /// for Markdown. If both are set, this one wins.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
@@ -231,6 +236,8 @@ pub struct IssueCreateArgs {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    /// Map of field id (e.g. customfield_10011) or name -> value. Fetch ids
+    /// via jira_issue_fields.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub custom_fields: Option<BTreeMap<String, Value>>,
@@ -240,7 +247,12 @@ pub struct IssueCreateArgs {
 pub struct IssueUpdateArgs {
     pub key: String,
     pub summary: Option<String>,
+    /// Issue description as plain Markdown (headings, lists, tables, code,
+    /// links). Auto-converted to Atlassian Document Format. Use this for
+    /// normal text — do NOT hand-build ADF.
     pub description: Option<String>,
+    /// Advanced/optional: pre-built ADF JSON. Leave unset and use `description`
+    /// for Markdown. If both are set, this one wins.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
@@ -250,6 +262,8 @@ pub struct IssueUpdateArgs {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    /// Map of field id (e.g. customfield_10011) or name -> value. Fetch ids
+    /// via jira_issue_fields.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub custom_fields: Option<BTreeMap<String, Value>>,
@@ -390,7 +404,11 @@ pub struct BatchCreateOp {
     pub project_key: String,
     pub summary: String,
     pub issue_type: Option<String>,
+    /// Issue description as plain Markdown. Auto-converted to ADF — do NOT
+    /// hand-build ADF.
     pub description: Option<String>,
+    /// Advanced/optional: pre-built ADF JSON. Leave unset and use `description`
+    /// for Markdown. If both are set, this one wins.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
@@ -400,6 +418,8 @@ pub struct BatchCreateOp {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    /// Map of field id (e.g. customfield_10011) or name -> value. Fetch ids
+    /// via jira_issue_fields.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub custom_fields: Option<BTreeMap<String, Value>>,
@@ -409,7 +429,11 @@ pub struct BatchCreateOp {
 pub struct BatchUpdateOp {
     pub key: String,
     pub summary: Option<String>,
+    /// Issue description as plain Markdown. Auto-converted to ADF — do NOT
+    /// hand-build ADF.
     pub description: Option<String>,
+    /// Advanced/optional: pre-built ADF JSON. Leave unset and use `description`
+    /// for Markdown. If both are set, this one wins.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub description_adf: Option<Value>,
@@ -419,6 +443,8 @@ pub struct BatchUpdateOp {
     pub components: Option<Vec<String>>,
     pub parent: Option<String>,
     pub fix_versions: Option<Vec<String>>,
+    /// Map of field id (e.g. customfield_10011) or name -> value. Fetch ids
+    /// via jira_issue_fields.
     #[serde(default)]
     #[schemars(schema_with = "any_json_object")]
     pub custom_fields: Option<BTreeMap<String, Value>>,

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -485,7 +485,10 @@ save_path must be an absolute path inside $HOME unless force_path=true."
         self.respond(self.app.issue_transitions_list(args).await)
     }
 
-    #[tool(name = "jira_issue_create", description = "Create a Jira issue")]
+    #[tool(
+        name = "jira_issue_create",
+        description = "Create a Jira issue. Put normal text in 'description' as Markdown (auto-converted to ADF); only use 'description_adf' for pre-built ADF."
+    )]
     pub async fn jira_issue_create(
         &self,
         Parameters(args): Parameters<IssueCreateArgs>,
@@ -495,7 +498,7 @@ save_path must be an absolute path inside $HOME unless force_path=true."
 
     #[tool(
         name = "jira_issue_update",
-        description = "Update fields on a Jira issue"
+        description = "Update fields on a Jira issue. Put normal text in 'description' as Markdown (auto-converted to ADF); only use 'description_adf' for pre-built ADF."
     )]
     pub async fn jira_issue_update(
         &self,
@@ -712,7 +715,7 @@ save_path must be an absolute path inside $HOME unless force_path=true."
 
     #[tool(
         name = "jira_issue_batch",
-        description = "Run typed create, update, transition, and archive issue operations in sequence; requires confirm=true"
+        description = "Run typed issue operations in sequence; requires confirm=true. 'operations' is an array of {op: \"create\"|\"update\"|\"transition\"|\"archive\", ...}; create/update take Markdown 'description' (auto-converted to ADF)."
     )]
     pub async fn jira_issue_batch(
         &self,


### PR DESCRIPTION
## Summary
- External agent feedback flagged "high friction" on Jira MCP tools and fell back to raw `jira_api_request` for all creates. Root cause was **not** parsing bugs — the typed tool schema never told the calling model that `description` accepts Markdown.
- The `description` field carried no doc comment and `description_adf` looked required, so weaker tool-callers hand-built ADF or gave up. Markdown→ADF auto-conversion already exists in jira-core (predates v0.2.0).

## Changes
- `crates/jira-mcp/src/models.rs` — `///` schema docs on `description`, `description_adf`, `custom_fields` for `IssueCreateArgs`, `IssueUpdateArgs`, `BatchCreateOp`, `BatchUpdateOp`.
- `crates/jira-mcp/src/server.rs` — enriched `jira_issue_create`/`jira_issue_update`/`jira_issue_batch` tool descriptions with the Markdown affordance and batch op shape.
- Doc-only; no behavior change.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` (143 passed)
- [x] `cargo build --all`