### PR TITLE
chore(packaging): refresh jira-mcp Winget manifests for v2.3.1

### DIFF
--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.0
+PackageVersion: 2.3.1
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-06-21
+ReleaseDate: 2026-06-22
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-x86_64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.0/jirac-mcp-windows-x86_64.zip
-    InstallerSha256: e2fbeb345d0d4ff7f1fc52866cd20bad9714f8240ba57d3acc9764d80a1c50ec
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.1/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: 5371fa5f4e46c8a94b6552a1f3b727904322d3bcb53a3918eb9ac788f29446ef
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-aarch64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.0/jirac-mcp-windows-aarch64.zip
-    InstallerSha256: 6267107f445f5ce6956041cafd7321a860a89fe837f0dc3283f47fdf0784cf71
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.1/jirac-mcp-windows-aarch64.zip
+    InstallerSha256: fbf1e821471d703dfe6c8de09f452c3d190207b5fe517b1983dacaae32ccf3b2
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
+++ b/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.0
+PackageVersion: 2.3.1
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget-mcp/jirac-mcp.yaml
+++ b/packaging/winget-mcp/jirac-mcp.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.0
+PackageVersion: 2.3.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for jira-mcp v2.3.1

## Notes

- generated by the jira-mcp release workflow after publishing GitHub release assets
- Winget community submission remains handled by the separate `Winget Submit jira-mcp` workflow