### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- `cargo audit` started failing CI on all open PRs after RUSTSEC-2026-0185 was published against `quinn-proto` 0.11.14. This is a fresh transitive-dependency advisory, unrelated to feature work.

## Changes
- Cargo.lock: `quinn-proto` 0.11.14 -> 0.11.15 (the patched release per the advisory). Lockfile-only.

## Test plan
- [x] `cargo audit` clean locally (0 vulnerabilities)
- [x] `cargo build --all` succeeds
- [ ] CI cargo audit (CVE scan) green