### PR TITLE
fix(jira-mcp): structured validation errors + jira_search_users

### DIFF
--- a/crates/jira-mcp/src/app/issue.rs
+++ b/crates/jira-mcp/src/app/issue.rs
@@ -13,7 +13,7 @@ use crate::{
         BulkTransitionArgs, BulkUpdateArgs, IssueAttachArgs, IssueCloneArgs, IssueCreateArgs,
         IssueDeleteArgs, IssueFieldsArgs, IssueKeyArgs, IssueListArgs, IssueMoveArgs,
         IssueNotificationsArgs, IssueStandupArgs, IssueTransitionArgs, IssueTypesListArgs,
-        IssueUpdateArgs, SprintSummaryArgs,
+        IssueUpdateArgs, SearchUsersArgs, SprintSummaryArgs,
     },
 };
 
@@ -321,6 +321,12 @@ impl JiraApp {
             .collect();
 
         (!required.is_empty()).then(|| json!(required))
+    }
+
+    pub async fn search_users(&self, args: SearchUsersArgs) -> AppResult<Value> {
+        let client = self.build_client()?;
+        let users = client.search_users(&args.query).await?;
+        Ok(json!({ "users": users }))
     }
 
     pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {

--- a/crates/jira-mcp/src/app/issue.rs
+++ b/crates/jira-mcp/src/app/issue.rs
@@ -261,11 +261,66 @@ impl JiraApp {
 
     pub async fn issue_create(&self, args: IssueCreateArgs) -> AppResult<Value> {
         let client = self.build_client()?;
-        let issue = client
-            .create_issue_v2(create_issue_request_from_issue(args))
-            .await?;
+        let project_key = args.project_key.clone();
+        let issue_type = args.issue_type.clone();
 
-        Ok(slim_issue(&issue))
+        match client
+            .create_issue_v2(create_issue_request_from_issue(args))
+            .await
+        {
+            Ok(issue) => Ok(slim_issue(&issue)),
+            Err(err) => {
+                let err = AppError::from(err);
+                // On a required-field rejection, attach the schema's required
+                // fields so the agent can retry in one shot instead of looping.
+                if err.is_field_validation() {
+                    if let Some(required) = self
+                        .required_fields_hint(&client, &project_key, &issue_type)
+                        .await
+                    {
+                        return Err(err.with_data_field("required_fields", required));
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+
+    /// Best-effort lookup of required fields for a project + issue type (matched
+    /// by id or name) to enrich a validation error. Returns `None` on any
+    /// failure — this runs only on the error path and must never mask the
+    /// original error.
+    async fn required_fields_hint(
+        &self,
+        client: &jira_core::JiraClient,
+        project_key: &str,
+        issue_type: &str,
+    ) -> Option<Value> {
+        let type_id = client
+            .get_issue_types(project_key)
+            .await
+            .ok()?
+            .into_iter()
+            .find(|t| t.id == issue_type || t.name.eq_ignore_ascii_case(issue_type))
+            .map(|t| t.id)?;
+
+        let required: Vec<Value> = client
+            .get_fields_for_issue_type(project_key, &type_id)
+            .await
+            .ok()?
+            .into_iter()
+            .filter(|f| f.required)
+            .map(|f| {
+                json!({
+                    "id": f.id,
+                    "name": f.name,
+                    "field_type": f.field_type,
+                    "allowed_values": f.allowed_values,
+                })
+            })
+            .collect();
+
+        (!required.is_empty()).then(|| json!(required))
     }
 
     pub async fn issue_update(&self, args: IssueUpdateArgs) -> AppResult<Value> {

--- a/crates/jira-mcp/src/error.rs
+++ b/crates/jira-mcp/src/error.rs
@@ -32,6 +32,73 @@ impl AppError {
         Self::new(ErrorCode::INTERNAL_ERROR, "jira_api_error", detail, data)
     }
 
+    /// Build a `jira_api_error`, lifting Jira's structured `errors` map and
+    /// `errorMessages` array out of the raw response body into the error `data`
+    /// when present. Falls back to the raw body as `detail` for non-JSON or
+    /// non-standard responses (best-effort — never panics on a weird body).
+    fn from_jira_api(status: u16, body: String) -> Self {
+        if let Ok(Value::Object(parsed)) = serde_json::from_str::<Value>(&body) {
+            let errors = parsed.get("errors").cloned();
+            let error_messages = parsed.get("errorMessages").cloned();
+            let has_errors = errors
+                .as_ref()
+                .and_then(Value::as_object)
+                .is_some_and(|m| !m.is_empty());
+            let has_messages = error_messages
+                .as_ref()
+                .and_then(Value::as_array)
+                .is_some_and(|a| !a.is_empty());
+            if has_errors || has_messages {
+                let mut data = Map::new();
+                data.insert("status".into(), json!(status));
+                if let Some(e) = errors {
+                    data.insert("errors".into(), e);
+                }
+                if let Some(m) = error_messages {
+                    data.insert("errorMessages".into(), m);
+                }
+                let field_count = data
+                    .get("errors")
+                    .and_then(Value::as_object)
+                    .map_or(0, Map::len);
+                let detail = if field_count > 0 {
+                    format!("Jira rejected the request: {field_count} field error(s)")
+                } else {
+                    "Jira rejected the request".to_string()
+                };
+                return Self::jira_api_error(detail, Some(Value::Object(data)));
+            }
+        }
+        Self::jira_api_error(body, Some(json!({ "status": status })))
+    }
+
+    /// True when this error carries a non-empty Jira field-validation `errors` map.
+    pub fn is_field_validation(&self) -> bool {
+        self.stable_code == "jira_api_error"
+            && self
+                .data
+                .as_ref()
+                .and_then(|d| d.get("errors"))
+                .and_then(Value::as_object)
+                .is_some_and(|m| !m.is_empty())
+    }
+
+    /// Attach a key/value into this error's structured `data` payload.
+    pub fn with_data_field(mut self, key: &str, value: Value) -> Self {
+        let mut map = match self.data.take() {
+            Some(Value::Object(m)) => m,
+            Some(other) => {
+                let mut m = Map::new();
+                m.insert("context".into(), other);
+                m
+            }
+            None => Map::new(),
+        };
+        map.insert(key.into(), value);
+        self.data = Some(Value::Object(map));
+        self
+    }
+
     pub fn not_found(detail: impl Into<String>, data: Option<Value>) -> Self {
         Self::new(ErrorCode::RESOURCE_NOT_FOUND, "not_found", detail, data)
     }
@@ -98,9 +165,7 @@ impl From<jira_core::JiraError> for AppError {
     fn from(value: jira_core::JiraError) -> Self {
         match value {
             jira_core::JiraError::Auth(message) => Self::auth_missing(message),
-            jira_core::JiraError::Api { status, message } => {
-                Self::jira_api_error(message, Some(json!({ "status": status })))
-            }
+            jira_core::JiraError::Api { status, message } => Self::from_jira_api(status, message),
             jira_core::JiraError::Config(message) => Self::config_error(message),
             jira_core::JiraError::NotFound(message) => Self::not_found(message, None),
             jira_core::JiraError::RateLimit { retry_after } => Self::rate_limited(retry_after),
@@ -126,5 +191,39 @@ impl From<std::io::Error> for AppError {
 impl From<base64::DecodeError> for AppError {
     fn from(value: base64::DecodeError) -> Self {
         Self::validation(format!("Invalid base64 attachment payload: {value}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_jira_field_validation_body() {
+        let body = r#"{"errorMessages":[],"errors":{"customfield_10011":"Epic Link is required"}}"#;
+        let err = AppError::from(jira_core::JiraError::Api {
+            status: 400,
+            message: body.to_string(),
+        });
+
+        assert!(err.is_field_validation());
+        let data = err.data.as_ref().expect("data present");
+        assert_eq!(
+            data["errors"]["customfield_10011"],
+            json!("Epic Link is required")
+        );
+        assert_eq!(data["status"], json!(400));
+        assert!(data.get("errorMessages").is_some());
+    }
+
+    #[test]
+    fn non_json_body_passes_through() {
+        let err = AppError::from(jira_core::JiraError::Api {
+            status: 500,
+            message: "<html>boom</html>".to_string(),
+        });
+
+        assert!(!err.is_field_validation());
+        assert_eq!(err.detail, "<html>boom</html>");
     }
 }

--- a/crates/jira-mcp/src/models.rs
+++ b/crates/jira-mcp/src/models.rs
@@ -88,6 +88,12 @@ pub struct IssueFieldsArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SearchUsersArgs {
+    /// Name, email, or partial string to match Jira users against.
+    pub query: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SprintListArgs {
     pub project_key: String,
     pub states: Option<Vec<String>>,

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -25,9 +25,9 @@ use crate::{
         IssueNotificationsArgs, IssueStandupArgs, IssueTransitionArgs, IssueTypesListArgs,
         IssueUpdateArgs, JqlBuildArgs, NotificationsMarkReadArgs, ProjectKeyArgs,
         ProjectVersionCreateArgs, ProjectVersionUpdateArgs, RemoteLinkAddArgs,
-        RemoteLinkDeleteArgs, SprintAddIssueArgs, SprintCreateArgs, SprintDeleteArgs,
-        SprintListArgs, SprintSummaryArgs, SprintUpdateArgs, ToolResponse, WatcherAddArgs,
-        WatcherRemoveArgs, WorklogAddArgs, WorklogDeleteArgs,
+        RemoteLinkDeleteArgs, SearchUsersArgs, SprintAddIssueArgs, SprintCreateArgs,
+        SprintDeleteArgs, SprintListArgs, SprintSummaryArgs, SprintUpdateArgs, ToolResponse,
+        WatcherAddArgs, WatcherRemoveArgs, WorklogAddArgs, WorklogDeleteArgs,
     },
 };
 
@@ -250,6 +250,17 @@ impl JiraMcpServer {
         Parameters(args): Parameters<IssueFieldsArgs>,
     ) -> Result<Json<ToolResponse>, ErrorData> {
         self.respond(self.app.issue_fields(args).await)
+    }
+
+    #[tool(
+        name = "jira_search_users",
+        description = "Search Jira users by name or email to resolve an accountId for assignee/reporter fields"
+    )]
+    pub async fn jira_search_users(
+        &self,
+        Parameters(args): Parameters<SearchUsersArgs>,
+    ) -> Result<Json<ToolResponse>, ErrorData> {
+        self.respond(self.app.search_users(args).await)
     }
 
     #[tool(


### PR DESCRIPTION
## Summary
- MCP agents looped on issue create when a required field was missing — the real Jira validation response was passed through as an opaque string, so the client could not tell which field to fix. Now surfaced as structured data plus a required-field hint.
- Add `jira_search_users` so clients can resolve an accountId for assignee/reporter instead of guessing.

## Changes
**Bug fix (required-field loop)**
- `error.rs` — `From<JiraError>::Api` parses Jira's `errors` map + `errorMessages` array into structured MCP error `data` for every API error; non-JSON bodies pass through unchanged. New `is_field_validation()` + `with_data_field()` accessors. +2 unit tests.
- `app/issue.rs issue_create` — on field-validation failure, best-effort resolves issue type and fetches the schema to attach `required_fields: [{id,name,field_type,allowed_values}]`. Error path only; never masks the original error.

**Feature**
- `jira_search_users` MCP tool wrapping existing `client.search_users`. `SearchUsersArgs{query}` in models, handler in app, registration in server.

All edits under `crates/jira-mcp/**` → jira-mcp release lane only.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` (147 pass, 2 new)
- [x] `cargo build --all`
- [ ] Manual against live Jira: create with missing required field → confirm structured `errors` + `required_fields`; `jira_search_users` partial name → `users[]` with accountId