### PR TITLE
feat(cli): non-interactive guard for no-TTY environments

### DIFF
--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -188,11 +188,14 @@ async fn login(args: LoginArgs) -> Result<()> {
 
     let base_url = match args.url {
         Some(url) => url.trim().to_string(),
-        None => Text::new("Jira base URL (e.g. https://yourorg.atlassian.net):")
-            .prompt()
-            .context("Failed to read URL")?
-            .trim()
-            .to_string(),
+        None => {
+            crate::cli::interactive::require_interactive("Jira base URL", "--url")?;
+            Text::new("Jira base URL (e.g. https://yourorg.atlassian.net):")
+                .prompt()
+                .context("Failed to read URL")?
+                .trim()
+                .to_string()
+        }
     };
 
     let deployment = args
@@ -203,6 +206,7 @@ async fn login(args: LoginArgs) -> Result<()> {
     let deployment = if args.deployment.is_some() {
         deployment
     } else {
+        crate::cli::interactive::require_interactive("deployment type", "--deployment")?;
         prompt_deployment(deployment.clone())?
     };
 
@@ -214,6 +218,7 @@ async fn login(args: LoginArgs) -> Result<()> {
     let auth_type = if args.auth_type.is_some() {
         auth_type
     } else {
+        crate::cli::interactive::require_interactive("auth type", "--auth-type")?;
         prompt_auth_type(&deployment, auth_type.clone())?
     };
 
@@ -232,21 +237,27 @@ async fn login(args: LoginArgs) -> Result<()> {
     if config.requires_user_identity() {
         config.email = match args.email {
             Some(email) => email.trim().to_string(),
-            None => Text::new(config.user_label())
-                .prompt()
-                .context("Failed to read user identity")?
-                .trim()
-                .to_string(),
+            None => {
+                crate::cli::interactive::require_interactive("user identity", "--email")?;
+                Text::new(config.user_label())
+                    .prompt()
+                    .context("Failed to read user identity")?
+                    .trim()
+                    .to_string()
+            }
         };
     }
 
     let secret_prompt = format!("{}:", config.credential_label());
     let secret = match args.token {
         Some(token) => token,
-        None => Password::new(&secret_prompt)
-            .with_display_mode(PasswordDisplayMode::Masked)
-            .prompt()
-            .context("Failed to read secret")?,
+        None => {
+            crate::cli::interactive::require_interactive("API token/secret", "--token")?;
+            Password::new(&secret_prompt)
+                .with_display_mode(PasswordDisplayMode::Masked)
+                .prompt()
+                .context("Failed to read secret")?
+        }
     };
     config.token = Some(secret);
 

--- a/crates/jira/src/cli/interactive.rs
+++ b/crates/jira/src/cli/interactive.rs
@@ -1,0 +1,35 @@
+//! Non-interactive guard shared across CLI flows.
+//!
+//! Set once from `main` and read by a small guard helper, so interactive flows
+//! can refuse to prompt (and give an actionable message) when there is no TTY —
+//! the agent/CI/MCP case — instead of blocking or emitting inquire's generic
+//! error. Mirrors the `stdout().is_terminal()` pattern in `progress.rs`.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+use anyhow::{bail, Result};
+
+static NON_INTERACTIVE: OnceLock<bool> = OnceLock::new();
+
+/// Called once from `main`. Non-interactive if the flag is set, the
+/// `JIRAC_NON_INTERACTIVE` env var is set, or stdin is not a TTY.
+pub fn init(flag: bool) {
+    let val = flag
+        || std::env::var_os("JIRAC_NON_INTERACTIVE").is_some()
+        || !std::io::stdin().is_terminal();
+    let _ = NON_INTERACTIVE.set(val);
+}
+
+pub fn is_non_interactive() -> bool {
+    *NON_INTERACTIVE.get().unwrap_or(&false)
+}
+
+/// Guard placed at the entry of an interactive flow. `what` names the thing being
+/// asked for, `flag` names the CLI flag that supplies it non-interactively.
+pub fn require_interactive(what: &str, flag: &str) -> Result<()> {
+    if is_non_interactive() {
+        bail!("cannot prompt for {what}: no interactive terminal. Pass {flag} instead (or run without --non-interactive on a terminal).");
+    }
+    Ok(())
+}

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::cli::interactive::require_interactive;
 use crate::cli::progress::{progress_bar, spinner_new};
 use crate::{
     datetime::{build_worklog_range_dates, build_worklog_started, build_worklog_started_for_date},
@@ -2297,6 +2298,7 @@ async fn sprint_delete(
         .context("Project key is required. Pass --project or configure a default project.")?;
     let sprint_meta = resolve_sprint_for_project(&client, &project_key, &sprint).await?;
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirmed = Confirm::new(&format!(
             "Delete sprint '{}' (id:{}) in project {}? This cannot be undone.",
             sprint_meta.name, sprint_meta.id, project_key
@@ -2574,9 +2576,12 @@ async fn create_issue(
     // 1. Project key
     let project_key = match project {
         Some(p) => p,
-        None => Text::new("Project key:")
-            .prompt()
-            .context("Failed to read project key")?,
+        None => {
+            require_interactive("project key", "--project")?;
+            Text::new("Project key:")
+                .prompt()
+                .context("Failed to read project key")?
+        }
     };
 
     // 2. Issue type — interactive picker if not supplied
@@ -2586,9 +2591,12 @@ async fn create_issue(
     // 3. Summary
     let summary = match summary {
         Some(s) => s,
-        None => Text::new("Summary:")
-            .prompt()
-            .context("Failed to read summary")?,
+        None => {
+            require_interactive("summary", "--summary")?;
+            Text::new("Summary:")
+                .prompt()
+                .context("Failed to read summary")?
+        }
     };
 
     // 4. Description from file
@@ -2687,6 +2695,7 @@ async fn resolve_issue_type(
             }
 
             // Interactive picker
+            require_interactive("issue type", "--type")?;
             let options: Vec<String> = types.iter().map(|t| t.name.clone()).collect();
             let selected = Select::new("Issue type:", options)
                 .prompt()
@@ -2704,10 +2713,13 @@ async fn resolve_issue_type(
             // API call failed or returned empty — fall back gracefully
             let name = match issue_type {
                 Some(n) => n,
-                None => Text::new("Issue type (e.g. Task, Bug, Story):")
-                    .with_default("Task")
-                    .prompt()
-                    .context("Failed to read issue type")?,
+                None => {
+                    require_interactive("issue type", "--type")?;
+                    Text::new("Issue type (e.g. Task, Bug, Story):")
+                        .with_default("Task")
+                        .prompt()
+                        .context("Failed to read issue type")?
+                }
             };
             Ok((name, String::new()))
         }
@@ -2760,6 +2772,8 @@ async fn collect_custom_fields(
     if custom.is_empty() {
         return Ok(HashMap::new());
     }
+
+    require_interactive("required custom fields", "--field / --no-custom-fields")?;
 
     println!("\nRequired custom fields:");
     println!("{}", "─".repeat(40));
@@ -2940,6 +2954,7 @@ async fn update_issue(
 
 async fn delete_issue(client: JiraClient, key: String, force: bool) -> Result<()> {
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!("Delete {key}? This cannot be undone."))
             .with_default(false)
             .prompt()
@@ -2988,6 +3003,7 @@ async fn transition_issue(
             .map(|t| t.id.clone())
             .ok_or_else(|| anyhow::anyhow!("Transition '{}' not found", name_or_id))?
     } else {
+        require_interactive("target transition", "the transition name/id argument")?;
         let options: Vec<String> = transitions
             .iter()
             .map(|t| format!("{} [{}]", t.name, t.id))
@@ -3135,6 +3151,7 @@ async fn attachment_download(
 
 async fn attachment_delete(client: JiraClient, id: String, force: bool) -> Result<()> {
     if !force {
+        require_interactive("confirmation", "--force")?;
         let ok = Confirm::new(&format!("Delete attachment {id}?"))
             .with_default(false)
             .prompt()
@@ -3165,9 +3182,12 @@ async fn list_fields(
 ) -> Result<()> {
     let project_key = match project {
         Some(p) => p,
-        None => Text::new("Project key:")
-            .prompt()
-            .context("Failed to read project key")?,
+        None => {
+            require_interactive("project key", "--project")?;
+            Text::new("Project key:")
+                .prompt()
+                .context("Failed to read project key")?
+        }
     };
 
     // Get issue types to resolve the ID
@@ -3186,6 +3206,7 @@ async fn list_fields(
                 anyhow::anyhow!("Issue type '{}' not found in {}", filter, project_key)
             })?
     } else {
+        require_interactive("issue type", "--type")?;
         let options: Vec<String> = types.iter().map(|t| t.name.clone()).collect();
         let selected = Select::new("Issue type:", options)
             .prompt()
@@ -3273,7 +3294,15 @@ fn read_render_input(path: Option<&std::path::Path>) -> Result<String> {
         Some(path) => std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read input file: {}", path.display())),
         None => {
-            use std::io::Read;
+            use std::io::{IsTerminal, Read};
+
+            // A TTY with nothing piped would block on stdin forever — refuse instead.
+            // Piped input is NOT a terminal, so it still reads normally below.
+            if std::io::stdin().is_terminal() {
+                anyhow::bail!(
+                    "no input file and nothing piped on stdin. Pass a file path or pipe content."
+                );
+            }
 
             let mut input = String::new();
             std::io::stdin()
@@ -3498,6 +3527,7 @@ async fn watch_list(client: JiraClient, key: String) -> Result<()> {
 
 async fn watch_rm(client: JiraClient, key: String, account_id: String, force: bool) -> Result<()> {
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!("Remove watcher {account_id} from {key}?"))
             .with_default(false)
             .prompt()
@@ -3645,6 +3675,7 @@ async fn bulk_comment(
     println!("Found {} issue(s).", target_keys.len());
 
     if !force {
+        require_interactive("confirmation", "--force")?;
         let target_label = if jql.is_some() {
             "matched issues"
         } else {
@@ -3909,6 +3940,7 @@ async fn worklog_add_range(
 
 async fn worklog_delete(client: JiraClient, key: String, id: String, force: bool) -> Result<()> {
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!("Delete worklog {id} on {key}?"))
             .with_default(false)
             .prompt()
@@ -3953,6 +3985,7 @@ async fn bulk_transition(
     println!("Found {} issues.", issues.len());
 
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!(
             "Transition all {} issues to '{to}'?",
             issues.len()
@@ -4046,6 +4079,7 @@ async fn bulk_update(
     println!("Found {} issues.", issues.len());
 
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!("Update {} issues?", issues.len()))
             .with_default(false)
             .prompt()
@@ -4119,6 +4153,7 @@ async fn archive(client: JiraClient, jql: String, force: bool) -> Result<()> {
     println!("Found {} issues.", issues.len());
 
     if !force {
+        require_interactive("confirmation", "--force")?;
         let confirm = inquire::Confirm::new(&format!(
             "Archive {} issues? This cannot be undone.",
             issues.len()
@@ -4172,6 +4207,8 @@ fn load_jql_params(spec: &str) -> Result<jira_core::jql::JqlParams> {
 
 fn prompt_jql_params() -> Result<jira_core::jql::JqlParams> {
     use jira_core::jql::{AssigneeFilter, JqlParams, OrderDir};
+
+    require_interactive("JQL parameters", "--params <json|@file>")?;
 
     println!("JQL Builder — press Enter to skip any field\n");
 
@@ -4732,6 +4769,10 @@ async fn clone_issue(
 
     if move_issue {
         // Confirm before deleting original
+        require_interactive(
+            "deletion of the original after clone",
+            "`jirac issue move` (native move) or run interactively",
+        )?;
         let confirm = inquire::Confirm::new(&format!(
             "Delete original {key} after cloning to {}?",
             clone.key
@@ -4942,6 +4983,7 @@ async fn handle_link_command(client: JiraClient, cmd: LinkCommand) -> Result<()>
         }
         LinkCommand::Delete { id, force } => {
             if !force {
+                require_interactive("confirmation", "--force")?;
                 let confirmed = inquire::Confirm::new(&format!("Delete issue link {id}?"))
                     .with_default(false)
                     .prompt()?;

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -90,7 +90,13 @@ pub fn handle(command: McpCommand) -> Result<()> {
         } => {
             let resolved_client = match client {
                 Some(c) => c,
-                None => run_interactive_prereqs_and_pick(&command)?,
+                None => {
+                    crate::cli::interactive::require_interactive(
+                        "MCP client",
+                        "--client <target>",
+                    )?;
+                    run_interactive_prereqs_and_pick(&command)?
+                }
             };
             install_client(
                 resolved_client,

--- a/crates/jira/src/cli/mod.rs
+++ b/crates/jira/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod board;
+pub mod interactive;
 pub mod issue;
 pub mod mcp;
 pub mod plan;

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -27,6 +27,10 @@ struct Cli {
     /// Enable verbose logging (sets RUST_LOG=debug)
     #[arg(short, long, global = true)]
     verbose: bool,
+
+    /// Never prompt; error if required input is missing (for scripts/agents/CI)
+    #[arg(long, global = true)]
+    non_interactive: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -85,6 +89,7 @@ async fn main() -> Result<()> {
     }
 
     let cli = Cli::parse();
+    cli::interactive::init(cli.non_interactive);
     let update_notice = version_check::check_for_update().await;
 
     let filter = if cli.verbose {
@@ -119,6 +124,9 @@ async fn main() -> Result<()> {
             cli::issue::handle(*command, client, config.project).await?;
         }
         Commands::Tui { project } => {
+            if cli::interactive::is_non_interactive() {
+                anyhow::bail!("`jirac tui` requires an interactive terminal");
+            }
             let client = build_client().context("Failed to initialize Jira client")?;
             let config = JiraConfig::load().unwrap_or_default();
             let effective_project = project.or(config.project);


### PR DESCRIPTION
## Summary
- Agents, CI, and MCP callers run `jirac` without a TTY. Interactive flows either blocked on stdin or surfaced inquire's generic error with no hint which flag to pass — operators worked around it by calling the Jira REST API directly.
- Adds a global `--non-interactive` guard that makes the CLI itself no-TTY-safe: prompts become actionable errors naming the exact flag, and the one true stdin hang is fixed.

## Changes
- **New `crates/jira/src/cli/interactive.rs`** — process-global guard set once in `main`. Non-interactive when `--non-interactive` is passed, `JIRAC_NON_INTERACTIVE` is set, or stdin is not a TTY (auto-detected — the real agent/CI/MCP case).
- **`main.rs`** — global `--non-interactive` flag, `init` call, and a clean error for `jirac tui` under no-TTY instead of a crossterm raw-mode failure.
- **Guards at prompt fallbacks** across `auth login` (url/email/token/deployment/auth-type), `issue create`/`fields`/`transition`/`jql`, all `--force` confirms (delete/archive/bulk/worklog/watcher/link/sprint), clone `--move`, and `mcp install` — each errors with the flag that supplies the value.
- **`read_render_input`** — a TTY with nothing piped now bails fast instead of blocking forever; piped input still reads normally.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` (147 pass)
- [x] `cargo build --all`
- [x] Manual: `jirac mcp install` and `jirac tui` under no-TTY emit clear errors naming the flag
- [x] Manual: piped `jirac issue render` still renders; happy path with all flags supplied unaffected

## Notes
- Global flags placed *before* the subcommand (`jirac --non-interactive tui`) don't register — pre-existing clap behavior (`--verbose` behaves the same). Use flag-after-subcommand or rely on auto-detection.