### PR TITLE
chore(deps): bump undici to 7.28.0 to close scorecard alert #12

### DIFF
--- a/.github/clawhub-cli/package-lock.json
+++ b/.github/clawhub-cli/package-lock.json
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/.github/clawhub-cli/package.json
+++ b/.github/clawhub-cli/package.json
@@ -5,5 +5,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "clawhub": "0.12.2"
+  },
+  "overrides": {
+    "undici": "7.28.0"
   }
 }


### PR DESCRIPTION
## Summary

- Scorecard code-scanning alert **#12** (Vulnerabilities, high) flagged 7 `undici` advisories in the pinned ClawHub CLI tooling.
- `undici` resolved to `7.25.0` via `clawhub@0.12.2`, inside the affected range `>=7.23.0,<7.28.0`. Force the patched 7.x release via npm `overrides` (stays on 7.x, avoids the 8.x major bump).
- The alert's two Rust findings (`RUSTSEC-2026-0190`/anyhow, `RUSTSEC-2026-0185`/quinn-proto) are already remediated on `main`; `cargo audit` is clean.

## Changes

- `.github/clawhub-cli/package.json` — add `overrides` forcing `undici` to `7.28.0`.
- `.github/clawhub-cli/package-lock.json` — regenerate; `undici` now resolves to `7.28.0`.

Closes: GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m, GHSA-hm92-r4w5-c3mj, GHSA-p88m-4jfj-68fv, GHSA-pr7r-676h-xcf6, GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q.

## Test plan

- [x] `npm install` in `.github/clawhub-cli/` regenerates lock cleanly.
- [x] `npm ls undici` → `undici@7.28.0 overridden`.
- [x] `undici@7.28.0` is outside all 7 affected ranges (patched = 7.28.0).
- [x] `cargo audit` clean (Rust side unchanged).
- [ ] Scorecard hosted rescan clears alert [#12](https://github.com/mulhamna/jira-commands/security/code-scanning/12) findings.