### PR TITLE
fix: honest jira_issue_create errors (-32602 on 4xx, keep issue)

### DIFF
--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -1241,6 +1241,12 @@ impl JiraClient {
         let headers = self.auth_headers()?;
         let url = self.platform_url("/issue");
 
+        // Kept for a best-effort fallback if the post-create re-fetch fails:
+        // the issue already exists, so we must never report the create as failed.
+        let fallback_project_key = req.project_key.clone();
+        let fallback_summary = req.summary.clone();
+        let fallback_issue_type = req.issue_type.clone();
+
         let description_adf = req
             .description_adf
             .or_else(|| req.description.as_deref().map(markdown_to_adf));
@@ -1289,6 +1295,8 @@ impl JiraClient {
 
         #[derive(serde::Deserialize)]
         struct CreateResponse {
+            #[serde(default)]
+            id: String,
             key: String,
         }
 
@@ -1297,7 +1305,31 @@ impl JiraClient {
             .request(|| http.post(&url).headers(headers.clone()).json(&body))
             .await?;
 
-        self.get_issue(&resp.key).await
+        // The issue is now created. Re-fetching the full record is a
+        // convenience, not part of creation — if it fails (rate limit,
+        // transient 5xx, or read-after-write lag), return a minimal issue
+        // built from the create response so the caller still gets the key
+        // instead of a false failure (which would tempt a duplicate retry).
+        match self.get_issue(&resp.key).await {
+            Ok(issue) => Ok(issue),
+            Err(_) => Ok(Issue {
+                id: resp.id,
+                key: resp.key,
+                summary: fallback_summary,
+                description: None,
+                status: String::new(),
+                assignee: None,
+                reporter: None,
+                priority: None,
+                issue_type: fallback_issue_type,
+                project_key: fallback_project_key,
+                created: String::new(),
+                updated: String::new(),
+                attachments: Vec::new(),
+                links: Vec::new(),
+                fields: serde_json::Value::Null,
+            }),
+        }
     }
 
     // ── Comments ─────────────────────────────────────────────────────────────
@@ -2062,6 +2094,44 @@ mod tests {
 
         let info = client.get_server_info().await.expect("server info");
         assert_eq!(info["deploymentType"], Value::String("Data Center".into()));
+    }
+
+    #[tokio::test]
+    async fn create_issue_returns_key_when_refetch_fails() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/issue"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": "10042",
+                "key": "PROJ-42"
+            })))
+            .mount(&server)
+            .await;
+
+        // The convenience re-fetch fails; creation itself succeeded.
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/issue/PROJ-42"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = cloud_client(&server);
+        let issue = client
+            .create_issue_v2(CreateIssueRequestV2 {
+                project_key: "PROJ".into(),
+                summary: "hello".into(),
+                issue_type: "Task".into(),
+                ..Default::default()
+            })
+            .await
+            .expect("create must not fail when only the re-fetch fails");
+
+        assert_eq!(issue.key, "PROJ-42");
+        assert_eq!(issue.id, "10042");
+        assert_eq!(issue.summary, "hello");
+        assert_eq!(issue.project_key, "PROJ");
+        assert_eq!(issue.issue_type, "Task");
     }
 
     #[tokio::test]

--- a/crates/jira-mcp/src/error.rs
+++ b/crates/jira-mcp/src/error.rs
@@ -32,11 +32,34 @@ impl AppError {
         Self::new(ErrorCode::INTERNAL_ERROR, "jira_api_error", detail, data)
     }
 
+    /// Like `jira_api_error`, but with an explicit RPC code so a caller-side
+    /// rejection (4xx) is reported as `INVALID_PARAMS` rather than masquerading
+    /// as an internal server error.
+    fn jira_api_error_with_code(
+        rpc_code: ErrorCode,
+        detail: impl Into<String>,
+        data: Option<Value>,
+    ) -> Self {
+        Self::new(rpc_code, "jira_api_error", detail, data)
+    }
+
+    /// Map an HTTP status to the JSON-RPC error code: 5xx is genuinely
+    /// server-side (`INTERNAL_ERROR`), everything else is the caller's input
+    /// to fix (`INVALID_PARAMS`).
+    fn rpc_code_for_status(status: u16) -> ErrorCode {
+        if status >= 500 {
+            ErrorCode::INTERNAL_ERROR
+        } else {
+            ErrorCode::INVALID_PARAMS
+        }
+    }
+
     /// Build a `jira_api_error`, lifting Jira's structured `errors` map and
     /// `errorMessages` array out of the raw response body into the error `data`
     /// when present. Falls back to the raw body as `detail` for non-JSON or
     /// non-standard responses (best-effort — never panics on a weird body).
     fn from_jira_api(status: u16, body: String) -> Self {
+        let rpc_code = Self::rpc_code_for_status(status);
         if let Ok(Value::Object(parsed)) = serde_json::from_str::<Value>(&body) {
             let errors = parsed.get("errors").cloned();
             let error_messages = parsed.get("errorMessages").cloned();
@@ -66,10 +89,10 @@ impl AppError {
                 } else {
                     "Jira rejected the request".to_string()
                 };
-                return Self::jira_api_error(detail, Some(Value::Object(data)));
+                return Self::jira_api_error_with_code(rpc_code, detail, Some(Value::Object(data)));
             }
         }
-        Self::jira_api_error(body, Some(json!({ "status": status })))
+        Self::jira_api_error_with_code(rpc_code, body, Some(json!({ "status": status })))
     }
 
     /// True when this error carries a non-empty Jira field-validation `errors` map.
@@ -225,5 +248,31 @@ mod tests {
 
         assert!(!err.is_field_validation());
         assert_eq!(err.detail, "<html>boom</html>");
+    }
+
+    #[test]
+    fn client_errors_map_to_invalid_params() {
+        let body = r#"{"errorMessages":[],"errors":{"summary":"required"}}"#;
+        let err = AppError::from(jira_core::JiraError::Api {
+            status: 400,
+            message: body.to_string(),
+        });
+        assert_eq!(err.rpc_code, ErrorCode::INVALID_PARAMS);
+
+        // Raw (non-standard) 4xx body still uses INVALID_PARAMS.
+        let raw = AppError::from(jira_core::JiraError::Api {
+            status: 409,
+            message: "conflict".to_string(),
+        });
+        assert_eq!(raw.rpc_code, ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn server_errors_stay_internal() {
+        let err = AppError::from(jira_core::JiraError::Api {
+            status: 503,
+            message: "<html>unavailable</html>".to_string(),
+        });
+        assert_eq!(err.rpc_code, ErrorCode::INTERNAL_ERROR);
     }
 }


### PR DESCRIPTION
## Summary

- `jira_issue_create` returned JSON-RPC `-32603` for *every* Jira error, so a client-side 400 (missing required field, bad project/issuetype, invalid custom field) was indistinguishable from a real server crash — the real reason was hidden from clients that surface only the numeric code.
- A separate intermittent bug reported a *successful* create as a failure: when the post-create re-fetch failed (rate limit, transient 5xx, or read-after-write lag), the whole call errored even though the issue existed — inviting a retry that creates a duplicate.

## Changes

**`crates/jira-mcp/src/error.rs`**
- `from_jira_api` now maps by HTTP status class: 4xx → `INVALID_PARAMS` (-32602), 5xx → `INTERNAL_ERROR` (-32603).
- Stable code stays `jira_api_error`, so `is_field_validation()` and the required-field hint enrichment are unchanged.
- Added tests: 400/409 → `INVALID_PARAMS`, 503 → `INTERNAL_ERROR`.

**`crates/jira-core/src/client.rs`**
- `create_issue_v2` treats the post-create `get_issue` as best-effort: on fetch failure it returns a minimal `Issue` built from the create response (`id`/`key`) plus the request fields, instead of erroring on an issue that was actually created.
- `CreateResponse` now also captures `id` (`#[serde(default)]`, tolerant of bodies without it).
- Added test: POST 201 then GET 500 → `create_issue_v2` returns `Ok` with the created key.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all` (152 passed)
- [x] `cargo build --all`
- [ ] Manual MCP repro: `jira_issue_create` with a missing required field returns `-32602` with `data.errors` naming the field (was bare `-32603`)
- [ ] Manual MCP repro: normal create still returns the created key + full issue
