### PR TITLE
feat(auth): show Jira account ID in status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ TASK.md
 # Local scratch and staging
 /tmp/
 tmp/
+.forgeguard/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "jira-mcp"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -2,9 +2,12 @@ use crate::help_text;
 use anyhow::{Context, Result};
 use clap::{Subcommand, ValueEnum};
 use inquire::{Password, PasswordDisplayMode, Select, Text};
-use jira_core::config::{
-    config_file_path, default_profile_name, JiraAuthType, JiraConfig, JiraDeployment,
-    JiraProfilesFile,
+use jira_core::{
+    config::{
+        config_file_path, default_profile_name, JiraAuthType, JiraConfig, JiraDeployment,
+        JiraProfilesFile,
+    },
+    JiraClient,
 };
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -418,6 +421,10 @@ async fn status(profile: Option<String>) -> Result<()> {
             "  Secret:         ✓ stored in {}",
             config_file_path().display()
         );
+        match JiraClient::new(config.clone()).get_myself().await {
+            Ok(account_id) => println!("  Jira ID:        {account_id}"),
+            Err(err) => println!("  Jira ID:        unavailable ({err})"),
+        }
     } else {
         println!("  Secret:         ✗ not found — run `jirac auth login`");
     }


### PR DESCRIPTION
## Summary

  - Make `jirac auth status` show the authenticated Jira account ID.
  - Keep the status command useful even when the `/myself` lookup is unavailable.
  - Include local housekeeping for ForgeGuard artifacts.

  ## Changes

  - Fetch the current Jira `accountId` from `/myself` when a stored secret is present.
  - Print `Jira ID` in the auth status output on success.
  - Print `Jira ID: unavailable (...)` on lookup failure instead of failing the whole
  status command.
  - Sync `Cargo.lock` with the current workspace crate versions.
  - Ignore local `.forgeguard/` artifacts.

  ## Test plan

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo check -p jira-commands`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all`
  - [x] `cargo build --all`
  - [x] `git diff --check`