### PR TITLE
feat(mcp): add jirac mcp install support for Kilo Code CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,21 @@ Claude may:
 
 ---
 
+## Common commands
+
+```bash
+cargo build --all                                  # build workspace
+cargo test --all                                   # run all tests
+cargo test -p jira-core auth::                     # run tests matching a path in one crate
+cargo test --all test_name                         # run a single test by name across workspace
+cargo run -p jira -- issue view KEY-123             # run the CLI binary
+cargo run -p jira-mcp                               # run the MCP server binary
+cargo fmt --all                                     # format
+cargo clippy --all-targets --all-features -- -D warnings  # lint
+```
+
+---
+
 ## Project overview
 
 Rust CLI for Atlassian Jira (`jirac` binary). Focus: full custom field via dynamic introspection, attachment upload, Jira REST API v3, interactive TUI (ratatui), single binary.
@@ -63,7 +78,7 @@ plugin/
 ### Crate responsibilities
 
 - **`jira-core`** — public API: `JiraClient`, model types (split under `model/`), ADF parser, auth (Cloud + Data Center multi-profile), `FieldCache` for custom-field resolution, error types. Library dependency.
-- **`jira/`** — clap commands (`cli/{api,auth,issue,mcp,plan}.rs`), modular TUI (ratatui + crossterm, 10 submodules under `tui/`), interactive prompts (inquire), datetime helpers. Binary: `jirac`. `mcp` subcommand: `jirac mcp doctor` + `jirac mcp install --client <target>` to register `jirac-mcp` into supported clients (claude-code, claude-desktop, cursor, gemini-cli, codex, vscode, copilot-cli, opencode, generic-json, antigravity, antigravity-cli).
+- **`jira/`** — clap commands (`cli/{api,auth,issue,mcp,plan}.rs`), modular TUI (ratatui + crossterm, 10 submodules under `tui/`), interactive prompts (inquire), datetime helpers. Binary: `jirac`. `mcp` subcommand: `jirac mcp doctor` + `jirac mcp install --client <target>` to register `jirac-mcp` into supported clients (claude-code, claude-desktop, cursor, gemini-cli, codex, vscode, copilot-cli, opencode, generic-json, antigravity, antigravity-cli, kilocode).
 - **`jira-mcp/`** — MCP server via `rmcp`, split into `app.rs` (wiring) + `server.rs` (impl) + `models.rs` (I/O types). Exposes `jira-core` as MCP tools for LLM clients. Binary: `jirac-mcp`.
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jira-commands"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "jira-core"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -219,6 +219,7 @@ jirac mcp install --client opencode
 jirac mcp install --client generic-json
 jirac mcp install --client antigravity
 jirac mcp install --client antigravity-cli
+jirac mcp install --client kilocode
 ```
 
 Supported targets now:
@@ -233,6 +234,7 @@ Supported targets now:
 - `generic-json` (prints a portable JSON snippet instead of writing a file)
 - `antigravity` (`~/.gemini/antigravity/mcp_config.json`, user-level JSON with `mcpServers`)
 - `antigravity-cli` (`~/.gemini/config/mcp_config.json`, user-level JSON with `mcpServers`)
+- `kilocode` (`~/.config/kilo/kilo.json`, Kilo Code CLI global config with `mcp`)
 
 Helpful flags:
 - `--print` prints the JSON snippet or delegated client command first
@@ -256,4 +258,5 @@ Local verification notes:
 - Codex stores MCP entries under `~/.codex/config.toml`; this helper delegates to the Codex CLI directly
 - Antigravity user scope writes `~/.gemini/antigravity/mcp_config.json` (top-level `mcpServers`); override with `ANTIGRAVITY_CONFIG`
 - Antigravity CLI user scope writes `~/.gemini/config/mcp_config.json` (`mcpServers`); override with `ANTIGRAVITY_CLI_CONFIG`
+- Kilo Code CLI user scope writes `~/.config/kilo/kilo.json` (top-level `mcp`, `{"type": "local", "command": [...], "enabled": true}` entries); override with `KILOCODE_CONFIG`. See [Kilo Code CLI MCP docs](https://kilo.ai/docs/automate/mcp/using-in-cli).
 - For local-binary clients, `jirac mcp install` requires `jirac-mcp` on PATH. Install it with `cargo install jira-mcp`, download a release binary, or pass `--command /path/to/jirac-mcp`.

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ export JIRA_TOKEN=your_api_token
 
 Run `jirac mcp install` with no arguments for an interactive picker that first verifies the prerequisites (jirac-mcp binary on PATH, Jira auth configured) and then writes the right config file for the client you pick. Pass `--client <target>` to skip the picker for scripts, or `jirac mcp doctor` to check prerequisites without writing anything.
 
-Supported helpers include Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, VS Code (GitHub Copilot), GitHub Copilot CLI, OpenCode, generic JSON snippets, Antigravity, and antigravity-cli.
+Supported helpers include Claude Code, Claude Desktop, Cursor, Gemini CLI, Codex, VS Code (GitHub Copilot), GitHub Copilot CLI, OpenCode, generic JSON snippets, Antigravity, antigravity-cli, and Kilo Code CLI.
 
 See [INSTALL.md](INSTALL.md) for the supported target matrix, client-specific notes, and recommended install flow.
 

--- a/crates/jira/src/cli/mcp.rs
+++ b/crates/jira/src/cli/mcp.rs
@@ -54,6 +54,8 @@ pub enum McpClient {
     Antigravity,
     #[value(name = "antigravity-cli")]
     AntigravityCli,
+    #[value(name = "kilocode")]
+    KiloCode,
 }
 
 impl std::fmt::Display for McpClient {
@@ -81,6 +83,7 @@ impl std::fmt::Display for McpClient {
             McpClient::AntigravityCli => {
                 "antigravity-cli    (writes ~/.gemini/config/mcp_config.json)"
             }
+            McpClient::KiloCode => "kilocode           (writes ~/.config/kilo/kilo.json)",
             McpClient::GenericJson => "generic-json       (print snippet only, no file changes)",
         };
         f.write_str(label)
@@ -178,6 +181,7 @@ fn run_interactive_prereqs_and_pick(server_command: &str) -> Result<McpClient> {
             McpClient::OpenCode,
             McpClient::Antigravity,
             McpClient::AntigravityCli,
+            McpClient::KiloCode,
             McpClient::GenericJson,
         ],
     )
@@ -307,6 +311,7 @@ fn doctor(client: Option<McpClient>, command: &str) -> Result<()> {
             McpClient::GenericJson,
             McpClient::Antigravity,
             McpClient::AntigravityCli,
+            McpClient::KiloCode,
         ],
     };
 
@@ -442,7 +447,7 @@ enum ClientDescriptor {
 
 fn server_spec(client: &McpClient, name: &str, command: &str, transport: &str) -> ServerSpec {
     match client {
-        McpClient::OpenCode => {
+        McpClient::OpenCode | McpClient::KiloCode => {
             let file_entry = json!({
                 "type": "local",
                 "command": [command, "serve", "--transport", transport],
@@ -542,6 +547,11 @@ fn install_target(client: &McpClient) -> Result<InstallTarget> {
             ),
             "mcpServers",
         ),
+        McpClient::KiloCode => (
+            "kilocode",
+            config_path_from_env_or_default("KILOCODE_CONFIG", kilocode_settings_path(&home)),
+            "mcp",
+        ),
     };
 
     Ok(InstallTarget {
@@ -627,6 +637,14 @@ fn describe_client(client: &McpClient) -> ClientDescriptor {
                 .unwrap_or_else(|_| PathBuf::from("~/.gemini/config/mcp_config.json")),
             note: "Writes user-level config at ~/.gemini/config/mcp_config.json (mcpServers).",
             top_level_key: "mcpServers",
+        },
+        McpClient::KiloCode => ClientDescriptor::FileTarget {
+            label: "kilocode",
+            path: install_target(client)
+                .map(|t| t.path)
+                .unwrap_or_else(|_| PathBuf::from("~/.config/kilo/kilo.json")),
+            note: "Writes Kilo Code CLI global config at ~/.config/kilo/kilo.json (mcp).",
+            top_level_key: "mcp",
         },
     }
 }
@@ -816,6 +834,13 @@ fn opencode_settings_path(home: &Path) -> PathBuf {
             .unwrap_or_else(|| home.join(".config"))
             .join("opencode/opencode.jsonc")
     }
+}
+
+fn kilocode_settings_path(home: &Path) -> PathBuf {
+    env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".config"))
+        .join("kilo/kilo.json")
 }
 
 fn resolve_command_for_client(client: &McpClient, command: &str, dry_run: bool) -> Result<String> {
@@ -1216,6 +1241,24 @@ mod tests {
         assert!(rendered.contains("\"mcpServers\""));
         assert!(rendered.contains("\"jira\""));
         assert!(rendered.contains("\"jirac-mcp\""));
+    }
+
+    #[test]
+    fn kilocode_install_target_uses_mcp_key() {
+        let target = install_target(&McpClient::KiloCode).unwrap();
+        assert_eq!(target.label, "kilocode");
+        assert_eq!(target.top_level_key, "mcp");
+        assert!(target.path.ends_with(".config/kilo/kilo.json"));
+    }
+
+    #[test]
+    fn kilocode_snippet_uses_local_command_array() {
+        let snippet =
+            server_spec(&McpClient::KiloCode, "jira", "/tmp/jirac-mcp", "stdio").json_snippet;
+        let rendered = serde_json::to_string_pretty(&snippet).unwrap();
+        assert!(rendered.contains("\"mcp\""));
+        assert!(rendered.contains("\"type\": \"local\""));
+        assert!(rendered.contains("/tmp/jirac-mcp"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `kilocode` as a new `jirac mcp install --client` target for Kilo Code CLI
- Writes MCP server entries to `~/.config/kilo/kilo.json` under the top-level `mcp` key, matching Kilo's documented `{"type": "local", "command": [...], "enabled": true}` shape (same wiring as the existing OpenCode target)
- Updates README.md / INSTALL.md / CLAUDE.md with the new client

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all`
- [x] Added unit tests for install target path/key and JSON snippet shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)