### PR TITLE
docs(jira-mcp): improve custom field guidance for issue creation

### DIFF
--- a/crates/jira-mcp/src/app/request.rs
+++ b/crates/jira-mcp/src/app/request.rs
@@ -10,6 +10,15 @@ use crate::{
     models::{BatchCreateOp, BatchUpdateOp, IssueCreateArgs, IssueUpdateArgs},
 };
 
+/// Map custom field inputs to FieldValue for serialization.
+///
+/// Wraps each value as `FieldValue::Raw` to preserve the original JSON type,
+/// which allows array fields (e.g., Labels, MultiSelect) to work correctly.
+/// The JSON shape must match Jira's expectations for the field type:
+/// - Array field (e.g., Labels): `["value1", "value2"]`
+/// - Select field: `{ "value": "option" }`
+/// - User field: `{ "emailAddress": "user@example.com" }`
+/// - Text/Number: scalar value
 pub(super) fn map_custom_fields(
     custom_fields: Option<std::collections::BTreeMap<String, Value>>,
 ) -> HashMap<String, FieldValue> {

--- a/crates/jira-mcp/src/server.rs
+++ b/crates/jira-mcp/src/server.rs
@@ -498,7 +498,7 @@ save_path must be an absolute path inside $HOME unless force_path=true."
 
     #[tool(
         name = "jira_issue_create",
-        description = "Create a Jira issue. Put normal text in 'description' as Markdown (auto-converted to ADF); only use 'description_adf' for pre-built ADF."
+        description = "Create a Jira issue. Put normal text in 'description' as Markdown (auto-converted to ADF); only use 'description_adf' for pre-built ADF. For required custom fields, use 'custom_fields' parameter (BTreeMap field_id→value): e.g., {\"customfield_10553\": [\"label1\", \"label2\"]} for array fields like Labels."
     )]
     pub async fn jira_issue_create(
         &self,


### PR DESCRIPTION
- Document custom_fields parameter support in jira_issue_create tool description
- Add example for array custom fields like Labels (OSS)
- Improve map_custom_fields doc with field type examples
- Clarifies how to pass required custom fields (e.g., customfield_10553) during issue creation

This resolves issues where projects require custom array fields for issue creation (like project JOSS requiring Labels OSS), enabling users to successfully create issues by passing custom fields via the custom_fields parameter.

## Description

<!-- What does this PR do? Why? Link related issues with "Fixes #123" if applicable. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / chore
- [ ] Breaking change (bumps major version)

## Checklist

- [ ] `cargo fmt --all` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] `cargo audit` passes (no new CVEs introduced)
- [ ] Crate changes include added or updated tests, or this PR explains why not
- [ ] For bug fixes in `crates/`, I added or updated a regression test when feasible
- [ ] No new dependency added without justification in PR description
- [ ] New dependencies use permissive licenses (MIT / Apache-2.0 / BSD)

## Security checklist (required for all PRs)

- [x] No secrets, tokens, or credentials added to source code
- [ ] No new `unsafe` blocks without explanation
- [ ] No outbound network calls added outside of `jira-core/src/client.rs`
- [ ] No changes to `.github/workflows/` without explaining why in this PR
- [ ] If release or installer surfaces changed, docs/install notes were updated to match
- [ ] Dependencies sourced only from crates.io (no `git = "..."` deps without justification)

## Merge behavior

- [x] Safe to auto-merge once required checks and approvals pass (add `automerge` label)
- [ ] Needs manual merge because of rollout, migration, release timing, or other risk

## Notes for reviewer

<!-- Anything the reviewer should pay special attention to? -->
