### PR TITLE
fix(jira-mcp): trigger patch release for custom field guidance

### DIFF
--- a/crates/jira-mcp/README.md
+++ b/crates/jira-mcp/README.md
@@ -115,3 +115,9 @@ Notes:
 ## More docs
 
 See the root README and `INSTALL.md` for client-specific install notes, helper target details, and workspace-level context.
+
+
+## Release notes
+
+This package is released from the `crates/jira-mcp` lane. User-facing fixes in MCP docs, request handling, or package metadata should use a releasable Conventional Commit type such as `fix(jira-mcp): ...` when they need a patch release.
+


### PR DESCRIPTION
## Summary
- Add a real MCP-lane file change with a releasable `fix(jira-mcp)` commit so release-please can create the patch release PR for the custom-field guidance fix from #445.
- Document the release convention to avoid repeating the docs-only/no-bump issue.

## Testing
- Not run (documentation-only release-trigger change).
