### PR TITLE
chore(packaging): refresh jira-mcp Winget manifests for v2.3.5

### DIFF
--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.4
+PackageVersion: 2.3.5
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-07-24
+ReleaseDate: 2026-08-03
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-x86_64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.4/jirac-mcp-windows-x86_64.zip
-    InstallerSha256: a3975b40a7e94426939f79bad7f85b77321499247213164f084f30d163033632
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.5/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: dc5454532b81525eb147083d1a6f82a7286a9be67bee5ed416af199d60d518b5
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-aarch64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.4/jirac-mcp-windows-aarch64.zip
-    InstallerSha256: 66bd0f1366d12f50b2ed8e30d866d0de6b94a376c0d929504d79ebae3a376112
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.3.5/jirac-mcp-windows-aarch64.zip
+    InstallerSha256: a952819579445150ba0268825826efa650ebef9caaa58e358354f37eda9c4fc7
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
+++ b/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.4
+PackageVersion: 2.3.5
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget-mcp/jirac-mcp.yaml
+++ b/packaging/winget-mcp/jirac-mcp.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.3.4
+PackageVersion: 2.3.5
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for jira-mcp v2.3.5

## Notes

- generated by the jira-mcp release workflow after publishing GitHub release assets
- Winget community submission remains handled by the separate `Winget Submit jira-mcp` workflow