### PR TITLE
feat: configurable issue limit and issue export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ TASK.md
 /tmp/
 tmp/
 .forgeguard/
+.codex/
+.cursor/
+.agents/

--- a/crates/jira-core/src/client.rs
+++ b/crates/jira-core/src/client.rs
@@ -2059,6 +2059,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         })
     }
 
@@ -2090,6 +2091,7 @@ mod tests {
             deployment: JiraDeployment::DataCenter,
             auth_type: JiraAuthType::DataCenterPat,
             api_version: 2,
+            default_issue_limit: None,
         });
 
         let info = client.get_server_info().await.expect("server info");
@@ -2159,6 +2161,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         });
 
         let info = client.get_server_info().await.expect("server info");
@@ -2195,6 +2198,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         });
 
         let fields = client
@@ -2246,6 +2250,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         });
 
         let fields = client
@@ -3329,6 +3334,7 @@ mod tests {
             deployment: JiraDeployment::DataCenter,
             auth_type: JiraAuthType::DataCenterPat,
             api_version: 2,
+            default_issue_limit: None,
         });
 
         let issue = client
@@ -3380,6 +3386,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         });
 
         // Test list
@@ -3448,6 +3455,7 @@ mod tests {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: 3,
+            default_issue_limit: None,
         });
 
         let issue = client.get_issue("TEST-1").await.expect("get issue");

--- a/crates/jira-core/src/config.rs
+++ b/crates/jira-core/src/config.rs
@@ -59,6 +59,10 @@ pub struct JiraConfig {
     pub auth_type: JiraAuthType,
     #[serde(default = "default_api_version")]
     pub api_version: u8,
+    /// Optional cap on the default number of issues returned by list-like
+    /// commands when no explicit `--limit` is given. `None` means "fetch all".
+    #[serde(default)]
+    pub default_issue_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,6 +79,10 @@ pub struct JiraProfileConfig {
     pub auth_type: JiraAuthType,
     #[serde(default = "default_api_version")]
     pub api_version: u8,
+    /// Optional cap on the default number of issues returned by list-like
+    /// commands when no explicit `--limit` is given. `None` means "fetch all".
+    #[serde(default)]
+    pub default_issue_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -109,6 +117,7 @@ impl Default for JiraConfig {
             deployment: JiraDeployment::Cloud,
             auth_type: JiraAuthType::CloudApiToken,
             api_version: default_api_version(),
+            default_issue_limit: None,
         }
     }
 }
@@ -132,6 +141,7 @@ impl From<JiraProfileConfig> for JiraConfig {
             deployment: value.deployment,
             auth_type: value.auth_type,
             api_version,
+            default_issue_limit: value.default_issue_limit,
         }
     }
 }
@@ -177,6 +187,7 @@ impl JiraConfig {
             deployment: self.deployment,
             auth_type: self.auth_type,
             api_version,
+            default_issue_limit: self.default_issue_limit,
         }
     }
 
@@ -277,6 +288,11 @@ impl JiraConfig {
                 self.api_version = value;
             }
         }
+        // Reset-to-default semantics: `JIRA_ISSUE_LIMIT` overrides the file
+        // value. `JIRA_ISSUE_LIMIT=0` is treated as "unset" (fetch all).
+        if let Ok(issue_limit) = env::var("JIRA_ISSUE_LIMIT") {
+            self.default_issue_limit = issue_limit.trim().parse::<u32>().ok().filter(|n| *n > 0);
+        }
     }
 }
 
@@ -327,6 +343,7 @@ impl JiraProfilesFile {
                 deployment: JiraDeployment::Cloud,
                 auth_type: JiraAuthType::CloudApiToken,
                 api_version: default_api_version(),
+                default_issue_limit: None,
             },
         );
 
@@ -544,6 +561,7 @@ timeout_secs = 55
                         deployment: JiraDeployment::Cloud,
                         auth_type: JiraAuthType::CloudApiToken,
                         api_version: 3,
+                        default_issue_limit: None,
                     },
                 ),
                 (
@@ -557,6 +575,7 @@ timeout_secs = 55
                         deployment: JiraDeployment::DataCenter,
                         auth_type: JiraAuthType::DataCenterPat,
                         api_version: 2,
+                        default_issue_limit: None,
                     },
                 ),
             ]),

--- a/crates/jira-core/tests/config_auth_priority.rs
+++ b/crates/jira-core/tests/config_auth_priority.rs
@@ -12,6 +12,7 @@ fn cloud_config_requires_user_identity_but_data_center_pat_does_not() {
         deployment: JiraDeployment::Cloud,
         auth_type: JiraAuthType::CloudApiToken,
         api_version: 3,
+        default_issue_limit: None,
     };
     let data_center = JiraConfig {
         profile_name: Some("dc".into()),
@@ -23,6 +24,7 @@ fn cloud_config_requires_user_identity_but_data_center_pat_does_not() {
         deployment: JiraDeployment::DataCenter,
         auth_type: JiraAuthType::DataCenterPat,
         api_version: 2,
+        default_issue_limit: None,
     };
 
     assert!(cloud.requires_user_identity());

--- a/crates/jira-mcp/src/app/issue.rs
+++ b/crates/jira-mcp/src/app/issue.rs
@@ -32,10 +32,7 @@ use super::{
 impl JiraApp {
     pub async fn issue_list(&self, args: IssueListArgs) -> AppResult<Value> {
         let client = self.build_client()?;
-        let limit = args.limit.unwrap_or(25);
-        if !(1..=100).contains(&limit) {
-            return Err(AppError::validation("limit must be between 1 and 100"));
-        }
+        let limit = self.resolve_limit(args.limit, 25)?;
 
         let jql = if let Some(jql) = args.jql {
             jql
@@ -56,10 +53,7 @@ impl JiraApp {
     }
 
     pub async fn issue_standup(&self, args: IssueStandupArgs) -> AppResult<Value> {
-        let limit = args.limit.unwrap_or(50);
-        if !(1..=100).contains(&limit) {
-            return Err(AppError::validation("limit must be between 1 and 100"));
-        }
+        let limit = self.resolve_limit(args.limit, 50)?;
 
         let since = args.since.unwrap_or_else(|| "2d".to_string());
         let cutoff = Utc::now() - parse_relative_window(&since)?;
@@ -117,10 +111,7 @@ impl JiraApp {
 
     pub async fn issue_sprint_summary(&self, args: SprintSummaryArgs) -> AppResult<Value> {
         let client = self.build_client()?;
-        let limit = args.limit.unwrap_or(100);
-        if !(1..=100).contains(&limit) {
-            return Err(AppError::validation("limit must be between 1 and 100"));
-        }
+        let limit = self.resolve_limit(args.limit, 100)?;
 
         let sprint_label = args
             .sprint
@@ -192,10 +183,7 @@ impl JiraApp {
     }
 
     pub async fn issue_notifications(&self, args: IssueNotificationsArgs) -> AppResult<Value> {
-        let limit = args.limit.unwrap_or(50);
-        if !(1..=100).contains(&limit) {
-            return Err(AppError::validation("limit must be between 1 and 100"));
-        }
+        let limit = self.resolve_limit(args.limit, 50)?;
 
         let since = args.since.unwrap_or_else(|| "7d".to_string());
         let client = self.build_client()?;

--- a/crates/jira-mcp/src/app/shared.rs
+++ b/crates/jira-mcp/src/app/shared.rs
@@ -34,6 +34,22 @@ impl JiraApp {
 
         Ok(JiraClient::new(config))
     }
+
+    /// Resolve the effective limit for a list-like call.
+    ///
+    /// Priority: explicit tool arg > `default_issue_limit` from config >
+    /// `fallback`. The value is clamped to the Jira API upper bound (5000)
+    /// and a minimum of 1.
+    pub(crate) fn resolve_limit(&self, arg: Option<u32>, fallback: u32) -> AppResult<u32> {
+        const MAX: u32 = 5_000;
+        let value = arg
+            .or_else(|| self.load_config().ok().and_then(|c| c.default_issue_limit))
+            .unwrap_or(fallback);
+        if value == 0 {
+            return Err(AppError::validation("limit must be at least 1"));
+        }
+        Ok(value.clamp(1, MAX))
+    }
 }
 
 pub(super) fn require_confirm(confirm: Option<bool>) -> AppResult<()> {

--- a/crates/jira-mcp/src/app/tests.rs
+++ b/crates/jira-mcp/src/app/tests.rs
@@ -149,15 +149,15 @@ async fn standup_rejects_invalid_since_window() {
 
 #[tokio::test]
 #[serial]
-async fn notifications_reject_invalid_limit_before_auth() {
+async fn notifications_reject_zero_limit_before_auth() {
     let err = JiraApp
         .issue_notifications(IssueNotificationsArgs {
             project_key: None,
             since: None,
-            limit: Some(101),
+            limit: Some(0),
         })
         .await
-        .expect_err("invalid limit should fail");
+        .expect_err("zero limit should fail");
 
     assert_eq!(err.to_mcp().message, "validation_error");
 }

--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -235,6 +235,7 @@ async fn login(args: LoginArgs) -> Result<()> {
         deployment,
         auth_type,
         api_version: 0,
+        default_issue_limit: None,
     };
 
     if config.requires_user_identity() {

--- a/crates/jira/src/cli/config.rs
+++ b/crates/jira/src/cli/config.rs
@@ -1,0 +1,100 @@
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use jira_core::config::{config_file_path, JiraConfig, JiraProfilesFile};
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigCommand {
+    /// Set a configuration value for the active profile
+    ///
+    /// Currently supports `default_issue_limit`, the default cap (in number of
+    /// issues) applied by list-like commands when no explicit `--limit` is
+    /// given. Set to `0` to clear (fetch everything).
+    Set {
+        /// Configuration key (e.g. default_issue_limit)
+        key: String,
+        /// Configuration value (e.g. 100)
+        value: String,
+    },
+    /// Remove a configuration value for the active profile,
+    /// restoring the built-in default (fetch everything)
+    Unset {
+        /// Configuration key (e.g. default_issue_limit)
+        key: String,
+    },
+    /// Show the active profile's effective configuration
+    Show,
+}
+
+pub async fn handle(cmd: ConfigCommand) -> Result<()> {
+    match cmd {
+        ConfigCommand::Set { key, value } => set_value(&key, &value),
+        ConfigCommand::Unset { key } => unset_value(&key),
+        ConfigCommand::Show => show(),
+    }
+}
+
+fn set_value(key: &str, value: &str) -> Result<()> {
+    match key {
+        "default_issue_limit" => {
+            let parsed = value.trim().parse::<u32>().map_err(|_| {
+                anyhow::anyhow!("`default_issue_limit` must be a non-negative integer")
+            })?;
+            let mut config = JiraConfig::load().unwrap_or_default();
+            config.default_issue_limit = if parsed == 0 { None } else { Some(parsed) };
+            config.save().context("Failed to save config")?;
+            match config.default_issue_limit {
+                Some(n) => println!("✓ default_issue_limit = {n}"),
+                None => println!("✓ default_issue_limit cleared (will fetch all issues)"),
+            }
+            println!("  Saved to {}", config_file_path().display());
+        }
+        other => {
+            anyhow::bail!("unsupported config key `{other}`. Supported: default_issue_limit")
+        }
+    }
+    Ok(())
+}
+
+fn unset_value(key: &str) -> Result<()> {
+    match key {
+        "default_issue_limit" => {
+            let mut config = JiraConfig::load().unwrap_or_default();
+            config.default_issue_limit = None;
+            config.save().context("Failed to save config")?;
+            println!("✓ default_issue_limit removed (will fetch all issues)");
+        }
+        other => anyhow::bail!("unsupported config key `{other}`. Supported: default_issue_limit"),
+    }
+    Ok(())
+}
+
+fn show() -> Result<()> {
+    let config = JiraConfig::load().unwrap_or_default();
+    let profile = config
+        .profile_name
+        .clone()
+        .unwrap_or_else(|| "default".to_string());
+    println!("Profile:        {profile}");
+    println!(
+        "Base URL:       {}",
+        if config.base_url.is_empty() {
+            "(not set)"
+        } else {
+            &config.base_url
+        }
+    );
+    println!(
+        "Project:        {}",
+        config.project.clone().unwrap_or_else(|| "(not set)".into())
+    );
+    println!(
+        "default_issue_limit: {}",
+        config
+            .default_issue_limit
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "unset (fetch all)".into())
+    );
+
+    let _ = JiraProfilesFile::load(); // validate load path
+    Ok(())
+}

--- a/crates/jira/src/cli/issue.rs
+++ b/crates/jira/src/cli/issue.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::cli::interactive::require_interactive;
 use crate::cli::progress::{progress_bar, spinner_new};
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use inquire::{Confirm, MultiSelect, Select, Text};
 use jira_core::{
     model::{
@@ -22,6 +22,35 @@ use jira_core::{
 use serde_json;
 use serde_json::Value;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormat {
+    Json,
+    Csv,
+}
+
+/// Resolved request bounds for a list-like operation.
+#[derive(Debug, Clone, Copy, Default)]
+struct LimitOptions {
+    /// Explicit `--limit` (overrides configured default).
+    limit: Option<u32>,
+    /// `--all` forces fetching every matching issue.
+    all: bool,
+    /// Configured `default_issue_limit`, used when no explicit limit is given.
+    configured: Option<u32>,
+}
+
+impl LimitOptions {
+    /// Effective cap: `--all` → `None` (fetch everything), otherwise the
+    /// explicit `--limit`, the configured default, or `None` (fetch all).
+    fn effective(self) -> Option<u32> {
+        if self.all {
+            None
+        } else {
+            self.limit.or(self.configured)
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum IssueCommand {
     /// List issues — by project, JQL, or your assigned issues
@@ -29,10 +58,15 @@ pub enum IssueCommand {
     /// Without flags, shows issues assigned to you (assignee = currentUser()).
     /// Use --project for a project overview, or --jql for full control.
     ///
+    /// By default the result count follows, in priority order: the explicit
+    /// `--limit`, then the configured `default_issue_limit`, then "all".
+    /// "All" fetches every matching issue via pagination unless capped.
+    ///
     /// Examples:
     ///   jirac issue list                              # your assigned issues
     ///   jirac issue list -p PROJ                      # all issues in project
     ///   jirac issue list -p PROJ -l 50                # up to 50 results
+    ///   jirac issue list --all -p PROJ                # every issue (paged)
     ///   jirac issue list --jql 'status = "In Progress" AND project = PROJ'
     ///   jirac issue list --jql 'sprint = openSprints() AND assignee = me'
     List {
@@ -42,12 +76,47 @@ pub enum IssueCommand {
         /// Raw JQL query — overrides --project when both are provided
         #[arg(long, value_name = "JQL")]
         jql: Option<String>,
-        /// Maximum number of issues to return (default: 25, max: 100)
-        #[arg(short, long, default_value = "25", value_name = "N")]
-        limit: u32,
+        /// Maximum number of issues to return. Overrides the configured
+        /// default_issue_limit when both are present.
+        #[arg(short, long, value_name = "N")]
+        limit: Option<u32>,
+        /// Fetch every matching issue, ignoring --limit and configured limits.
+        #[arg(long)]
+        all: bool,
         /// Output results as JSON array
         #[arg(long)]
         json: bool,
+    },
+
+    /// Export matching issues to a file in JSON or CSV format
+    ///
+    /// Intended for large, machine-readable result sets (scripts, reporting,
+    /// pipelines). By default fetches every matching issue via pagination;
+    /// use --limit to cap the result.
+    ///
+    /// Examples:
+    ///   jirac issue export -p PROJ --format json                 # all issues, JSON
+    ///   jirac issue export -p PROJ --format csv -o issues.csv    # all issues, CSV
+    ///   jirac issue export -p PROJ --limit 500 --format json -o out.json
+    Export {
+        /// Project key (e.g. PROJ). Overrides default project from config.
+        #[arg(short, long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Raw JQL query — overrides --project when both are provided
+        #[arg(long, value_name = "JQL")]
+        jql: Option<String>,
+        /// Fetch every matching issue (ignores --limit and configured limits)
+        #[arg(long)]
+        all: bool,
+        /// Maximum number of issues to export. Omitting it exports everything.
+        #[arg(short = 'l', long, value_name = "N")]
+        limit: Option<u32>,
+        /// Output format
+        #[arg(long, value_enum, default_value = "json")]
+        format: ExportFormat,
+        /// Output file path. Defaults to stdout when omitted.
+        #[arg(short = 'o', long, value_name = "PATH")]
+        output: Option<PathBuf>,
     },
 
     /// Generate a daily standup summary from your assigned issues
@@ -1192,14 +1261,51 @@ pub async fn handle(
     cmd: IssueCommand,
     client: JiraClient,
     default_project: Option<String>,
+    default_issue_limit: Option<u32>,
 ) -> Result<()> {
     match cmd {
         IssueCommand::List {
             project,
             jql,
             limit,
+            all,
             json,
-        } => list_issues(client, project.or(default_project), jql, limit, json).await,
+        } => {
+            list_issues(
+                client,
+                project.or(default_project),
+                jql,
+                LimitOptions {
+                    limit,
+                    all,
+                    configured: default_issue_limit,
+                },
+                json,
+            )
+            .await
+        }
+        IssueCommand::Export {
+            project,
+            jql,
+            all,
+            limit,
+            format,
+            output,
+        } => {
+            export_issues(
+                client,
+                project.or(default_project),
+                jql,
+                LimitOptions {
+                    limit,
+                    all,
+                    configured: default_issue_limit,
+                },
+                format,
+                output,
+            )
+            .await
+        }
         IssueCommand::Standup {
             project,
             jql,
@@ -1510,7 +1616,7 @@ async fn list_issues(
     client: JiraClient,
     project: Option<String>,
     jql: Option<String>,
-    limit: u32,
+    bounds: LimitOptions,
     json: bool,
 ) -> Result<()> {
     let jql_query = if let Some(jql) = jql {
@@ -1521,19 +1627,29 @@ async fn list_issues(
         "assignee = currentUser() ORDER BY updated DESC".to_string()
     };
 
+    // Resolve the effective request limit (priority: --all > --limit >
+    // config.default_issue_limit > "all"). `None` means unfetched/unbounded.
+    let effective_limit = bounds.effective();
+
+    if effective_limit.is_none() && !bounds.all {
+        // No explicit cap anywhere: we are about to fetch every issue. Give a
+        // gentle, stderr-only hint (keeps --json output clean) on how to cap.
+        eprintln!("ℹ️  No default issue limit set — fetching all issues (this may be slow).");
+        eprintln!(
+            "   Tip: set a cap with `jirac config set default_issue_limit <N>` or pass --limit."
+        );
+    }
+
     let spinner = spinner_new("Fetching issues...");
-    let result = client
-        .search_issues(&jql_query, None, Some(limit))
-        .await
-        .context("Failed to search issues")?;
+    let result = fetch_issues(&client, &jql_query, effective_limit).await?;
     spinner.finish_and_clear();
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&result.issues)?);
+        println!("{}", serde_json::to_string_pretty(&result)?);
         return Ok(());
     }
 
-    if result.issues.is_empty() {
+    if result.is_empty() {
         println!("No issues found.");
         return Ok(());
     }
@@ -1544,7 +1660,7 @@ async fn list_issues(
     );
     println!("{}", "─".repeat(82));
 
-    for issue in &result.issues {
+    for issue in &result {
         let summary = if issue.summary.len() > 38 {
             format!("{}…", &issue.summary[..37])
         } else {
@@ -1559,11 +1675,119 @@ async fn list_issues(
         );
     }
 
-    if let Some(total) = result.total {
-        println!("\nShowing {} of {} issues", result.issues.len(), total);
+    println!("\nShowing {} issues", result.len());
+
+    Ok(())
+}
+
+/// Jira Cloud's per-request `maxResults` upper bound.
+const JIRA_MAX_RESULTS: u32 = 5_000;
+
+/// Fetch issues honoring an optional cap. `None` fetches every matching issue
+/// via cursor-based pagination; `Some(n)` issues a single bounded request
+/// (clamped to [`JIRA_MAX_RESULTS`] to avoid a raw Jira API 400).
+async fn fetch_issues(client: &JiraClient, jql: &str, limit: Option<u32>) -> Result<Vec<Issue>> {
+    match limit {
+        Some(n) => {
+            let raw = n;
+            let n = raw.min(JIRA_MAX_RESULTS);
+            if raw > JIRA_MAX_RESULTS {
+                eprintln!(
+                    "ℹ️  Requested limit {raw} exceeds Jira's {JIRA_MAX_RESULTS} per-request cap; using {JIRA_MAX_RESULTS}."
+                );
+            }
+
+            let result = client
+                .search_issues(jql, None, Some(n))
+                .await
+                .context("Failed to search issues")?;
+            Ok(result.issues)
+        }
+        None => client
+            .get_all_issues(jql)
+            .await
+            .context("Failed to fetch all issues"),
+    }
+}
+
+async fn export_issues(
+    client: JiraClient,
+    project: Option<String>,
+    jql: Option<String>,
+    bounds: LimitOptions,
+    format: ExportFormat,
+    output: Option<std::path::PathBuf>,
+) -> Result<()> {
+    let jql_query = if let Some(jql) = jql {
+        jql
+    } else if let Some(proj) = &project {
+        format!("project = {proj} ORDER BY updated DESC")
+    } else {
+        "assignee = currentUser() ORDER BY updated DESC".to_string()
+    };
+
+    // Priority: --all > --limit > config.default_issue_limit > (fetch all).
+    let effective_limit = bounds.effective();
+
+    let spinner = spinner_new("Exporting issues...");
+    let issues = fetch_issues(&client, &jql_query, effective_limit).await?;
+    spinner.finish_and_clear();
+
+    let rendered: String = match format {
+        ExportFormat::Json => serde_json::to_string_pretty(&issues)?,
+        ExportFormat::Csv => render_issues_csv(&issues),
+    };
+
+    match output {
+        Some(path) => {
+            std::fs::write(&path, rendered)
+                .with_context(|| format!("Failed to write export to {}", path.display()))?;
+            println!(
+                "✓ Exported {} issues ({format:?}) to {}",
+                issues.len(),
+                path.display()
+            );
+        }
+        None => println!("{rendered}"),
     }
 
     Ok(())
+}
+
+/// Render issues as a simple CSV (header + one row per issue). Values are
+/// escaped for commas, quotes, and newlines.
+fn render_issues_csv(issues: &[Issue]) -> String {
+    let mut out = String::new();
+    out.push_str("id,key,project,type,status,summary,assignee,reporter,priority,created,updated\n");
+
+    for issue in issues {
+        let row = [
+            &issue.id,
+            &issue.key,
+            &issue.project_key,
+            &issue.issue_type,
+            &issue.status,
+            &issue.summary,
+            issue.assignee.as_deref().unwrap_or(""),
+            issue.reporter.as_deref().unwrap_or(""),
+            issue.priority.as_deref().unwrap_or(""),
+            &issue.created,
+            &issue.updated,
+        ];
+        let escaped: Vec<String> = row.iter().map(|cell| csv_escape(cell)).collect();
+        out.push_str(&escaped.join(","));
+        out.push('\n');
+    }
+
+    out
+}
+
+fn csv_escape(cell: &str) -> String {
+    if cell.contains(',') || cell.contains('"') || cell.contains('\n') {
+        format!("\"{}\"", cell.replace('"', "\"\""))
+    } else {
+        cell.to_string()
+    }
 }
 
 async fn notifications(

--- a/crates/jira/src/cli/mod.rs
+++ b/crates/jira/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod board;
+pub mod config;
 pub mod interactive;
 pub mod issue;
 pub mod mcp;

--- a/crates/jira/src/main.rs
+++ b/crates/jira/src/main.rs
@@ -70,6 +70,11 @@ enum Commands {
         #[command(subcommand)]
         command: cli::board::BoardCommand,
     },
+    /// View or change local configuration (e.g. default_issue_limit)
+    Config {
+        #[command(subcommand)]
+        command: cli::config::ConfigCommand,
+    },
 }
 
 #[tokio::main]
@@ -121,7 +126,8 @@ async fn main() -> Result<()> {
         Commands::Issue { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             let config = JiraConfig::load().unwrap_or_default();
-            cli::issue::handle(*command, client, config.project).await?;
+            cli::issue::handle(*command, client, config.project, config.default_issue_limit)
+                .await?;
         }
         Commands::Tui { project } => {
             if cli::interactive::is_non_interactive() {
@@ -150,6 +156,9 @@ async fn main() -> Result<()> {
         Commands::Board { command } => {
             let client = build_client().context("Failed to initialize Jira client")?;
             cli::board::handle(command, client).await?;
+        }
+        Commands::Config { command } => {
+            cli::config::handle(command).await?;
         }
     }
 


### PR DESCRIPTION
## Summary
- Removes the arbitrary 100-issue cap on `jirac issue list` and the MCP list tools, making result limits configurable instead of hard-coded.
- Fixes the raw Jira 400 that surfaced when `--limit` exceeded the API cap (discussion #450).
- Adds `jirac config set default_issue_limit` and a dedicated `jirac issue export` for large, machine-readable result sets.

## Changes
- **core**: add optional `default_issue_limit` to `JiraConfig`/`JiraProfileConfig` (+ `JIRA_ISSUE_LIMIT` env override). `None` = fetch all.
- **cli (issue list)**: resolve limit by priority `--all > --limit > default_issue_limit > fetch all`; add `--all`; clamp over-limit values to 5000 with a stderr notice instead of a raw 400.
- **cli (new)**: `jirac config set/unset/show default_issue_limit` and `jirac issue export` (json/csv, `--all`/`--limit`, optional `-o` path).
- **mcp**: replace the hard-coded `1..=100` validation with `resolve_limit()` that honors config and clamps to 5000 across list/standup/sprint-summary/notifications.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `jirac issue list --limit 6000 --json` — clamps to 5000 with a stderr notice; JSON stays parseable
- [x] `jirac issue export --limit 2 --format json` — valid JSON array
- [x] `jirac issue export --limit 2 --format csv` — header + rows, values escaped
- [x] `jirac issue export --limit 3 --format csv -o out.csv` — writes file with confirmation line
- [x] `jirac config set default_issue_limit 100` → `jirac config show` reports `100`, then `unset` restores default (config left unchanged)
- [ ] `jirac issue list` with no limit/config (unbounded) — intentionally not run in a shared environment to avoid pulling every issue; covered by unit-level logic

Related: #450