### PR TITLE
chore(packaging): refresh release docs and manifests for v2.8.0

### DIFF
--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.7.0
+PackageVersion: 2.8.0
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-08-01
+ReleaseDate: 2026-08-07
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-windows-x86_64.exe
         PortableCommandAlias: jirac
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.7.0/jirac-windows-x86_64.zip
-    InstallerSha256: 93c959670d2a25125a0ca0389268563894bb136c43ad203b1ce4c67629ee1fee
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.0/jirac-windows-x86_64.zip
+    InstallerSha256: 94e22a503be5d18270e9567a727facfd7751c52ee13434e2db36f028cdb1cec3
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-windows-aarch64.exe
         PortableCommandAlias: jirac
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.7.0/jirac-windows-aarch64.zip
-    InstallerSha256: 1a0d81256c861d417d1b920050bd44cb2b3bb03dca1ef524499fb07d444b3f51
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.0/jirac-windows-aarch64.zip
+    InstallerSha256: 2ea68217a1f44eafa0c36aab87fb1a83d7c816e969a22d170c77354c74b4c34a
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.7.0
+PackageVersion: 2.8.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.7.0
+PackageVersion: 2.8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh root README.md and INSTALL.md for the released version
- refresh contributor avatars in the README footer
- refresh in-repo Winget source manifests for v2.8.0

## Notes

- generated by the release workflow after publishing GitHub release assets
- Winget community submission remains a separate follow-up workflow