### PR TITLE
ci: switch npm and crates.io publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -171,6 +171,7 @@ jobs:
     environment: production
     permissions:
       contents: read
+      id-token: write # for crates.io Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -178,13 +179,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish jira-core (skip if already published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           VERSION=$(grep '^version' crates/jira-core/Cargo.toml | head -1 | sed 's/^version = "\([^"]*\)".*/\1/')
           if curl -sf "https://index.crates.io/ji/ra/jira-core" | grep -q "\"vers\":\"${VERSION}\""; then
             echo "✓ jira-core v${VERSION} already on crates.io — skipping publish"
           else
-            cargo publish -p jira-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            cargo publish -p jira-core
           fi
       - name: Wait for jira-core in crates.io sparse index
         run: |
@@ -197,12 +203,14 @@ jobs:
           done
           exit 1
       - name: Publish jira-commands (skip if already published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           VERSION=$(grep '^version' crates/jira/Cargo.toml | head -1 | sed 's/^version = "\([^"]*\)".*/\1/')
           if curl -sf "https://index.crates.io/ji/ra/jira-commands" | grep -q "\"vers\":\"${VERSION}\""; then
             echo "✓ jira-commands v${VERSION} already on crates.io — skipping publish"
           else
-            cargo publish -p jira-commands --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            cargo publish -p jira-commands
           fi
 
   create-release:
@@ -251,6 +259,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write # for npm Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -261,6 +270,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for Trusted Publishing support
+        run: npm install -g npm@latest
 
       - name: Sync npm package version from VERSION
         run: |
@@ -290,14 +302,12 @@ jobs:
           test "$NPM_VERSION" = "$VERSION"
 
       - name: Publish @mulham28/jirac (skip if already published)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./packaging/npm/package.json').version")
           if npm view @mulham28/jirac@"$VERSION" version >/dev/null 2>&1; then
             echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
-            npm publish ./packaging/npm --access public
+            npm publish ./packaging/npm --access public --provenance
           fi
 
 

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -200,6 +200,7 @@ jobs:
     environment: production
     permissions:
       contents: read
+      id-token: write # for crates.io Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -207,6 +208,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
+
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       # jira-mcp depends on jira-core. The version of jira-core in this commit
       # must already be on crates.io (published by the jira-commands lane).
@@ -222,13 +227,15 @@ jobs:
           echo "✓ jira-core v${CORE_VERSION} present"
 
       - name: Publish jira-mcp (skip if already published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           VERSION=$(grep '^version' crates/jira-mcp/Cargo.toml | head -1 | sed 's/^version = "\([^"]*\)".*/\1/')
           if curl -sf "https://index.crates.io/ji/ra/jira-mcp" | grep -q "\"vers\":\"${VERSION}\""; then
             echo "✓ jira-mcp v${VERSION} already on crates.io — skipping publish"
           else
             echo "Publishing jira-mcp v${VERSION}..."
-            cargo publish -p jira-mcp --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            cargo publish -p jira-mcp
           fi
 
   create-release:
@@ -291,6 +298,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write # for npm Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -301,6 +309,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for Trusted Publishing support
+        run: npm install -g npm@latest
 
       - name: Sync npm-mcp package version from crates/jira-mcp/VERSION
         run: |
@@ -335,14 +346,12 @@ jobs:
           test "$NPM_MCP_VERSION" = "$VERSION"
 
       - name: Publish @mulham28/jirac-mcp (skip if already published)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./packaging/npm-mcp/package.json').version")
           if npm view @mulham28/jirac-mcp@"$VERSION" version >/dev/null 2>&1; then
             echo "✓ @mulham28/jirac-mcp npm v$VERSION already published, skipping"
           else
-            npm publish ./packaging/npm-mcp --access public
+            npm publish ./packaging/npm-mcp --access public --provenance
           fi
 
   publish-github-packages:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -214,6 +214,7 @@ jobs:
     environment: production
     permissions:
       contents: read
+      id-token: write # for crates.io Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -222,18 +223,24 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       # Idempotent: safe to re-run after partial-success (e.g. if a later step
       # fails and we re-trigger the workflow, we don't want to error on "already
       # published"). Check the crates.io sparse index — the authoritative source
       # cargo itself uses to resolve dependencies.
       - name: Publish jira-core (skip if already published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           VERSION=$(grep '^version' crates/jira-core/Cargo.toml | head -1 | sed 's/^version = "\([^"]*\)".*/\1/')
           if curl -sf "https://index.crates.io/ji/ra/jira-core" | grep -q "\"vers\":\"${VERSION}\""; then
             echo "✓ jira-core v${VERSION} already on crates.io — skipping publish"
           else
             echo "Publishing jira-core v${VERSION}..."
-            cargo publish -p jira-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            cargo publish -p jira-core
           fi
 
       # Use the sparse index (index.crates.io) — authoritative and updates
@@ -257,13 +264,15 @@ jobs:
           exit 1
 
       - name: Publish jira-commands (skip if already published)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           VERSION=$(grep '^version' crates/jira/Cargo.toml | head -1 | sed 's/^version = "\([^"]*\)".*/\1/')
           if curl -sf "https://index.crates.io/ji/ra/jira-commands" | grep -q "\"vers\":\"${VERSION}\""; then
             echo "✓ jira-commands v${VERSION} already on crates.io — skipping publish"
           else
             echo "Publishing jira-commands v${VERSION}..."
-            cargo publish -p jira-commands --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            cargo publish -p jira-commands
           fi
 
   # ── 3. Create GitHub Release ──────────────────────────────────────────────
@@ -329,6 +338,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write # for npm Trusted Publishing
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -339,6 +349,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for Trusted Publishing support
+        run: npm install -g npm@latest
 
       - name: Sync npm package version from VERSION
         run: |
@@ -373,14 +386,12 @@ jobs:
           test "$NPM_VERSION" = "$VERSION"
 
       - name: Publish @mulham28/jirac (skip if already published)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./packaging/npm/package.json').version")
           if npm view @mulham28/jirac@"$VERSION" version >/dev/null 2>&1; then
             echo "✓ @mulham28/jirac npm v$VERSION already published, skipping"
           else
-            npm publish ./packaging/npm --access public
+            npm publish ./packaging/npm --access public --provenance
           fi
 
   publish-github-packages:


### PR DESCRIPTION
## Summary
- Replace long-lived NPM_TOKEN / CARGO_REGISTRY_TOKEN secrets with OIDC trusted publishing
- Add provenance attestation to published npm packages

## Changes
- `release-tag.yml`, `release-tag-mcp.yml`, `release-recover.yml`: add `id-token: write`, authenticate to crates.io via `rust-lang/crates-io-auth-action`, drop `--token`/`NODE_AUTH_TOKEN` in favor of trusted publishing, publish npm packages with `--provenance`
- `publish-npm` jobs: upgrade npm to latest before publish (Node 20's bundled npm predates trusted-publishing support)

## Test plan
- [x] npm trusted publisher configured for `@mulham28/jirac` (release-tag.yml) and `@mulham28/jirac-mcp` (release-tag-mcp.yml)
- [x] crates.io trusted publishing configured for `jira-core`, `jira-commands`, `jira-mcp`
- [ ] Next tagged release on each lane publishes successfully without NPM_TOKEN / CARGO_REGISTRY_TOKEN
- [ ] Remove NPM_TOKEN and CARGO_REGISTRY_TOKEN secrets from repo settings after first successful OIDC publish on each lane