### PR TITLE
fix(ci): pin npm version in release workflows

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -272,7 +272,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Sync npm package version from VERSION
         run: |

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -311,7 +311,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Sync npm-mcp package version from crates/jira-mcp/VERSION
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -351,7 +351,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Sync npm package version from VERSION
         run: |


### PR DESCRIPTION
## Summary
- 3 open GitHub code-scanning alerts (Scorecard `PinnedDependenciesID`, error severity) caused by `npm install -g npm@latest` in the release workflows
- Pin npm to an exact version instead of `@latest` to satisfy the pinned-dependencies check

## Changes
- `.github/workflows/release-tag.yml`: pin `npm@latest` to `npm@12.0.2`
- `.github/workflows/release-tag-mcp.yml`: pin `npm@latest` to `npm@12.0.2`
- `.github/workflows/release-recover.yml`: pin `npm@latest` to `npm@12.0.2`

## Test plan
- [x] Confirmed no remaining unpinned `npm@latest` in `.github/workflows/`
- [x] Verified diff is a single-line change per file
- [ ] Confirm code-scanning alerts close after merge