### PR TITLE
fix(ci): use npm 10.9.9 compatible with node 20 runners

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -272,7 +272,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@10.9.9
 
       - name: Sync npm package version from VERSION
         run: |

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -311,7 +311,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@10.9.9
 
       - name: Sync npm-mcp package version from crates/jira-mcp/VERSION
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -351,7 +351,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@10.9.9
 
       - name: Sync npm package version from VERSION
         run: |


### PR DESCRIPTION
## Summary
- npm@12.0.2 (pinned in #465) requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, but the release workflows run on node 20
- This broke the "Publish npm package" job on the v2.8.1 release with `EBADENGINE` — crates.io and GitHub Packages published fine, only the npmjs.org publish failed
- Pin to npm 10.9.9 (latest 10.x, supports node `^18.17.0 || >=20.5.0`) instead

## Changes
- `.github/workflows/release-tag.yml`: `npm@12.0.2` → `npm@10.9.9`
- `.github/workflows/release-tag-mcp.yml`: `npm@12.0.2` → `npm@10.9.9`
- `.github/workflows/release-recover.yml`: `npm@12.0.2` → `npm@10.9.9`

## Test plan
- [x] Confirmed npm 10.9.9 engine requirement supports node 20 (`npm view npm@10.9.9 engines`)
- [ ] After merge, re-run the failed "Publish npm package" job for tag `v2.8.1` to publish the missing npmjs.org release