### PR TITLE
fix(ci): pin npm to 11.19.0 for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release-recover.yml
+++ b/.github/workflows/release-recover.yml
@@ -272,7 +272,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@10.9.9
+        run: npm install -g npm@11.19.0
 
       - name: Sync npm package version from VERSION
         run: |

--- a/.github/workflows/release-tag-mcp.yml
+++ b/.github/workflows/release-tag-mcp.yml
@@ -311,7 +311,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@10.9.9
+        run: npm install -g npm@11.19.0
 
       - name: Sync npm-mcp package version from crates/jira-mcp/VERSION
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -351,7 +351,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for Trusted Publishing support
-        run: npm install -g npm@10.9.9
+        run: npm install -g npm@11.19.0
 
       - name: Sync npm package version from VERSION
         run: |


### PR DESCRIPTION
## Summary
- npm 10.9.9 (from #468) doesn't implement npm Trusted Publishing — the publish step ran unauthenticated and failed with `E404 Not Found - PUT .../@mulham28%2fjirac` on release v2.8.2
- npm Trusted Publishing (OIDC) requires npm >=11.5.1, while npm@12.x (from #465) requires node >=22 and these workflows run on node 20
- npm 11.19.0 is the latest 11.x release and satisfies both: OIDC trusted publishing support + node `^20.17.0` compatibility

## Changes
- `.github/workflows/release-tag.yml`: `npm@10.9.9` → `npm@11.19.0`
- `.github/workflows/release-tag-mcp.yml`: `npm@10.9.9` → `npm@11.19.0`
- `.github/workflows/release-recover.yml`: `npm@10.9.9` → `npm@11.19.0`

## Test plan
- [x] Confirmed `npm view npm@11.19.0 engines` → `node: '^20.17.0 || >=22.9.0'`, matches runner's node v20.20.2
- [ ] After merge, re-run the failed "Publish npm package" job to publish the missing v2.8.2 release to npmjs.org