### PR TITLE
chore(packaging): refresh release docs and manifests for v2.8.3

### DIFF
--- a/packaging/winget/jirac.installer.yaml
+++ b/packaging/winget/jirac.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.8.0
+PackageVersion: 2.8.3
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-08-07
+ReleaseDate: 2026-08-13
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-windows-x86_64.exe
         PortableCommandAlias: jirac
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.0/jirac-windows-x86_64.zip
-    InstallerSha256: 94e22a503be5d18270e9567a727facfd7751c52ee13434e2db36f028cdb1cec3
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.3/jirac-windows-x86_64.zip
+    InstallerSha256: 5a7b8e88593133fb6ddb639bae364881f8ee1767711cd20927a8b3e60e7e0201
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-windows-aarch64.exe
         PortableCommandAlias: jirac
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.0/jirac-windows-aarch64.zip
-    InstallerSha256: 2ea68217a1f44eafa0c36aab87fb1a83d7c816e969a22d170c77354c74b4c34a
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/v2.8.3/jirac-windows-aarch64.zip
+    InstallerSha256: 0d40469724d9b553a77a10aba03f88d7a649d509a090bdf8265640e93baefd6a
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget/jirac.locale.en-US.yaml
+++ b/packaging/winget/jirac.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.8.0
+PackageVersion: 2.8.3
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget/jirac.yaml
+++ b/packaging/winget/jirac.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac
-PackageVersion: 2.8.0
+PackageVersion: 2.8.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh root README.md and INSTALL.md for the released version
- refresh contributor avatars in the README footer
- refresh in-repo Winget source manifests for v2.8.3

## Notes

- generated by the release workflow after publishing GitHub release assets
- Winget community submission remains a separate follow-up workflow