### PR TITLE
fix(auth): skip confirmation prompt on login token entry

### DIFF
--- a/crates/jira/src/cli/auth.rs
+++ b/crates/jira/src/cli/auth.rs
@@ -258,6 +258,7 @@ async fn login(args: LoginArgs) -> Result<()> {
         None => {
             crate::cli::interactive::require_interactive("API token/secret", "--token")?;
             Password::new(&secret_prompt)
+                .without_confirmation()
                 .with_display_mode(PasswordDisplayMode::Masked)
                 .prompt()
                 .context("Failed to read secret")?


### PR DESCRIPTION
## Summary
- `jirac auth login` appeared to hang after the token was typed: inquire's `Password` prompt asks for a masked confirmation by default, so a second unlabeled masked prompt was easy to read as "no response".

## Changes
- `crates/jira/src/cli/auth.rs`: add `.without_confirmation()` to the token/secret prompt.

## Test plan
- [x] Reproduced the extra `Confirmation:` prompt over a pty before the fix
- [x] Re-ran login over a pty after the fix — flow ends at `✓ Profile ... saved`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
