### PR TITLE
chore(packaging): refresh jira-mcp Winget manifests for v2.5.0

### DIFF
--- a/packaging/winget-mcp/jirac-mcp.installer.yaml
+++ b/packaging/winget-mcp/jirac-mcp.installer.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.4.0
+PackageVersion: 2.5.0
 InstallerType: zip
 NestedInstallerType: portable
-ReleaseDate: 2026-08-07
+ReleaseDate: 2026-09-07
 Installers:
   - Architecture: x64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-x86_64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.4.0/jirac-mcp-windows-x86_64.zip
-    InstallerSha256: 183c8f379d50e1dd39819686d8ef36331639b352546ca4ce5cdecd4512fa8ec4
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.5.0/jirac-mcp-windows-x86_64.zip
+    InstallerSha256: 6de17adaf7e5b4510bfae88a98860368fe4e398a42e36b8649ea25134779565c
   - Architecture: arm64
     NestedInstallerFiles:
       - RelativeFilePath: jirac-mcp-windows-aarch64.exe
         PortableCommandAlias: jirac-mcp
-    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.4.0/jirac-mcp-windows-aarch64.zip
-    InstallerSha256: 675c47f95fec9b94c928744db8cba5238706269920db400f11bf101c16de3c6a
+    InstallerUrl: https://github.com/mulhamna/jira-commands/releases/download/jira-mcp-v2.5.0/jirac-mcp-windows-aarch64.zip
+    InstallerSha256: cf11d108c45280d31c254d561e304e959e81670f18626c9323fbeb777e5947a4
 ManifestType: installer
 ManifestVersion: 1.9.0

--- a/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
+++ b/packaging/winget-mcp/jirac-mcp.locale.en-US.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.4.0
+PackageVersion: 2.5.0
 PackageLocale: en-US
 Publisher: mulhamna
 PublisherUrl: https://github.com/mulhamna

--- a/packaging/winget-mcp/jirac-mcp.yaml
+++ b/packaging/winget-mcp/jirac-mcp.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 PackageIdentifier: mulhamna.jirac-mcp
-PackageVersion: 2.4.0
+PackageVersion: 2.5.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- refresh in-repo Winget source manifests for jira-mcp v2.5.0

## Notes

- generated by the jira-mcp release workflow after publishing GitHub release assets
- Winget community submission remains handled by the separate `Winget Submit jira-mcp` workflow